### PR TITLE
Updating various game names

### DIFF
--- a/DATs/RetroAchievements (No Subfolders)/RA - 3DO Interactive Multiplayer.dat
+++ b/DATs/RetroAchievements (No Subfolders)/RA - 3DO Interactive Multiplayer.dat
@@ -15,10 +15,10 @@
 		<clrmamepro forcepacking="unzip"/>
 		<romvault forcepacking="unzip"/>
 	</header>
-	<machine name="Wreckman (World) (v1.0.0) (retroloveletter) (Aftermarket)">
+	<machine name="Wreckman (World) (v1.0.0) (Aftermarket) (retroloveletter)">
 		<category>Homebrew</category>
-		<description>Wreckman (World) (v1.0.0) (retroloveletter) (Aftermarket)</description>
-		<disk name="Wreckman (World) (v1.0.0) (retroloveletter) (Aftermarket).chd" sha1="3f0b20fa82db7cd8778b386b3c1485aa8b535e23"/>
+		<description>Wreckman (World) (v1.0.0) (Aftermarket) (retroloveletter)</description>
+		<disk name="Wreckman (World) (v1.0.0) (Aftermarket) (retroloveletter).chd" sha1="3f0b20fa82db7cd8778b386b3c1485aa8b535e23"/>
 		<url>https://retroachievements.org/game/24160/hashes</url>
 		<hash>33031a9305cab3eb38af9f163fafe307</hash>
 	</machine>

--- a/DATs/RetroAchievements (No Subfolders)/RA - 3DO Interactive Multiplayer.dat
+++ b/DATs/RetroAchievements (No Subfolders)/RA - 3DO Interactive Multiplayer.dat
@@ -5,8 +5,8 @@
 		<name>RA - 3DO Interactive Multiplayer</name>
 		<description>3DO Interactive Multiplayer</description>
 		<category>No Subfolders</category>
-		<version>20260227</version>
-		<date>27 February 2026</date>
+		<version>20260417</version>
+		<date>17 April 2026</date>
 		<author>AzgoRAth, NeoRetroGamer (Contributor), Jumphil (Contributor)</author>
 		<homepage>https://retroachievements.org</homepage>
 		<url>https://retroachievements.org/system/43/games</url>

--- a/DATs/RetroAchievements (No Subfolders)/RA - Atari 2600.dat
+++ b/DATs/RetroAchievements (No Subfolders)/RA - Atari 2600.dat
@@ -5,13 +5,13 @@
 		<name>RA - Atari 2600</name>
 		<description>Atari 2600</description>
 		<category>No Subfolders</category>
-		<version>20260405</version>
-		<date>5 April 2026</date>
+		<version>20260428</version>
+		<date>28 April 2026</date>
 		<author>AzgoRAth, NeoRetroGamer (Contributor), Jumphil (Contributor)</author>
 		<homepage>https://retroachievements.org</homepage>
 		<url>https://retroachievements.org/system/25/games</url>
-		<titlecount>188</titlecount>
-		<hashcount>201</hashcount>
+		<titlecount>198</titlecount>
+		<hashcount>212</hashcount>
 	</header>
 	<game name="Pepsi Invaders - Coke Wins (NTSC) (Prototype)">
 		<category>Demo</category>
@@ -163,7 +163,7 @@
 		<hash>787a2faebadc670a887a0e2483b8f034</hash>
 	</game>
 	
-    <game name="Halo 2600 (World) (Aftermarket) (Unl)">
+	<game name="Halo 2600 (World) (Aftermarket) (Unl)">
     	<category>Homebrew</category>
 		<description>Halo 2600 (World) (Aftermarket) (Unl)</description>
     	<release name="Halo 2600 (World) (Aftermarket) (Unl)" region="World"/>
@@ -1257,6 +1257,15 @@
 		<rom name="Mario Bros. (USA).a26" size="8192" crc="8fbf7e90" md5="e908611d99890733be31733a979c62d8" sha1="49425ff154b92ca048abb4ce5e8d485c24935035"/>
 		<url>https://retroachievements.org/game/11465/hashes</url>
 		<hash>e908611d99890733be31733a979c62d8</hash>
+	</game>
+	
+	<game name="Masters of the Universe - The Power of He-Man (USA)">
+		<category>Retail</category>
+		<description>Masters of the Universe - The Power of He-Man (USA)</description>
+		<release name="Masters of the Universe - The Power of He-Man (USA)" region="USA"/>
+		<rom name="Masters of the Universe - The Power of He-Man (USA).a26" size="16384" crc="0603e177" md5="3b76242691730b2dd22ec0ceab351bc6" sha1="6db8fa65755db86438ada3d90f4c39cc288dcf84"/>
+		<url>https://retroachievements.org/game/25343/hashes</url>
+		<hash>3b76242691730b2dd22ec0ceab351bc6</hash>
 	</game>
 	
 	<game name="Math Gran Prix (USA)">

--- a/DATs/RetroAchievements (No Subfolders)/RA - Atari 2600.dat
+++ b/DATs/RetroAchievements (No Subfolders)/RA - Atari 2600.dat
@@ -5,37 +5,37 @@
 		<name>RA - Atari 2600</name>
 		<description>Atari 2600</description>
 		<category>No Subfolders</category>
-		<version>20260227</version>
-		<date>27 February 2026</date>
+		<version>20260405</version>
+		<date>5 April 2026</date>
 		<author>AzgoRAth, NeoRetroGamer (Contributor), Jumphil (Contributor)</author>
 		<homepage>https://retroachievements.org</homepage>
 		<url>https://retroachievements.org/system/25/games</url>
 		<titlecount>188</titlecount>
 		<hashcount>201</hashcount>
 	</header>
-	<game name="Pepsi Invaders - Coke Wins (NTSC) (Demo)">
+	<game name="Pepsi Invaders - Coke Wins (NTSC) (Prototype)">
 		<category>Demo</category>
-		<description>Pepsi Invaders - Coke Wins (NTSC) (Demo)</description>
-		<release name="Pepsi Invaders - Coke Wins (NTSC) (Demo)" region="USA"/>
-		<rom name="Pepsi Invaders - Coke Wins (NTSC) (Demo).a26" size="4096" crc="7ac99b5c" md5="212d0b200ed8b45d8795ad899734d7d7" sha1="c5317035e73f60e959c123d89600c81b7c45701f"/>
+		<description>Pepsi Invaders - Coke Wins (NTSC) (Prototype)</description>
+		<release name="Pepsi Invaders - Coke Wins (NTSC) (Prototype)" region="USA"/>
+		<rom name="Pepsi Invaders - Coke Wins (NTSC) (Prototype).a26" size="4096" crc="7ac99b5c" md5="212d0b200ed8b45d8795ad899734d7d7" sha1="c5317035e73f60e959c123d89600c81b7c45701f"/>
 		<url>https://retroachievements.org/game/11697/hashes</url>
 		<hash>212d0b200ed8b45d8795ad899734d7d7</hash>
 	</game>
 	
-	<game name="Venetian Blinds (USA) (Demo)">
+	<game name="Venetian Blinds Demo (USA) (Demo)">
 		<category>Demo</category>
-		<description>Venetian Blinds (USA) (Demo)</description>
-		<release name="Venetian Blinds (USA) (Demo)" region="USA"/>
-		<rom name="Venetian Blinds (USA) (Demo).a26" size="2048" crc="1f0d3562" md5="d08fccfbebaa531c4a4fa7359393a0a9" sha1="81f485b545445080e009adf0f2e93dd4f16b92ce"/>
+		<description>Venetian Blinds Demo (USA) (Demo)</description>
+		<release name="Venetian Blinds Demo (USA) (Demo)" region="USA"/>
+		<rom name="Venetian Blinds Demo (USA) (Demo).a26" size="2048" crc="1f0d3562" md5="d08fccfbebaa531c4a4fa7359393a0a9" sha1="81f485b545445080e009adf0f2e93dd4f16b92ce"/>
 		<url>https://retroachievements.org/game/11715/hashes</url>
 		<hash>d08fccfbebaa531c4a4fa7359393a0a9</hash>
 	</game>
 	
-	<game name="Mega Man (NTSC) (David Galloway) (Demo) (Aftermarket)">
+	<game name="Mega Man (NTSC) (Demo) (Aftermarket) (David Galloway)">
 		<category>Homebrew</category>
-		<description>Mega Man (NTSC) (David Galloway) (Demo) (Aftermarket)</description>
-		<release name="Mega Man (NTSC) (David Galloway) (Demo) (Aftermarket)" region="USA"/>
-		<rom name="Mega Man (NTSC) (David Galloway) (Demo) (Aftermarket).a26" size="32768" crc="9158b4ed" md5="c74ddb744209a92382616e2fa38d1378" sha1="c2fd4bf592d2c1948d4cba02da7980f1df8751f4"/>
+		<description>Mega Man (NTSC) (Demo) (Aftermarket) (David Galloway)</description>
+		<release name="Mega Man (NTSC) (Demo) (Aftermarket) (David Galloway)" region="USA"/>
+		<rom name="Mega Man (NTSC) (Demo) (Aftermarket) (David Galloway).a26" size="32768" crc="9158b4ed" md5="c74ddb744209a92382616e2fa38d1378" sha1="c2fd4bf592d2c1948d4cba02da7980f1df8751f4"/>
 		<url>https://retroachievements.org/game/17048/hashes</url>
 		<hash>c74ddb744209a92382616e2fa38d1378</hash>
 	</game>
@@ -49,37 +49,37 @@
 		<hash>76b970b1497e9ec92ee9209895f4d682</hash>
 	</game>
 	
-	<game name="Touhou (USA) (Demo) (Aftermarket)">
+	<game name="Touhou (NTSC) (Demo) (Aftermarket) (Unl)">
 		<category>Homebrew</category>
-		<description>Touhou (USA) (Demo) (Aftermarket)</description>
-		<release name="Touhou (USA) (Demo) (Aftermarket)" region="USA"/>
-		<rom name="Touhou (USA) (Demo) (Aftermarket).a26" size="4096" crc="0c0a6fbc" md5="494af1350a71d7de6661dac265dbbd82" sha1="39cd9520a140ff9f58098dd9ac2cfcae294f30b4"/>
+		<description>Touhou (NTSC) (Demo) (Aftermarket) (Unl)</description>
+		<release name="Touhou (NTSC) (Demo) (Aftermarket) (Unl)" region="USA"/>
+		<rom name="Touhou (NTSC) (Demo) (Aftermarket) (Unl).a26" size="4096" crc="0c0a6fbc" md5="494af1350a71d7de6661dac265dbbd82" sha1="39cd9520a140ff9f58098dd9ac2cfcae294f30b4"/>
 		<url>https://retroachievements.org/game/29062/hashes</url>
 		<hash>494af1350a71d7de6661dac265dbbd82</hash>
 	</game>
 	
-	<game name="Alien Force (NTSC) (Nova32) (Aftermarket)">
+	<game name="Alien Force (NTSC) (Aftermarket) (Nova32)">
 		<category>Homebrew</category>
-		<description>Alien Force (NTSC) (Nova32) (Aftermarket)</description>
-		<release name="Alien Force (NTSC) (Nova32) (Aftermarket)" region="USA"/>
-		<rom name="Alien Force (NTSC) (Nova32) (Aftermarket).a26" size="8192" crc="7c5ceba6" md5="e204a6b63a8e6e1400fde46bbd054722" sha1="9b9ed3cc635203a6f917032ed741e2c1fdcc1af3"/>
+		<description>Alien Force (NTSC) (Aftermarket) (Nova32)</description>
+		<release name="Alien Force (NTSC) (Aftermarket) (Nova32)" region="USA"/>
+		<rom name="Alien Force (NTSC) (Aftermarket) (Nova32).a26" size="8192" crc="7c5ceba6" md5="e204a6b63a8e6e1400fde46bbd054722" sha1="9b9ed3cc635203a6f917032ed741e2c1fdcc1af3"/>
 		<url>https://retroachievements.org/game/26007/hashes</url>
 		<hash>e204a6b63a8e6e1400fde46bbd054722</hash>
 	</game>
 	
-	<game name="Amoeba Jump (World) (v1.3) (PAL) (Aftermarket)" cloneof="Amoeba Jump (World) (v1.3) (NTSC) (Aftermarket)">
+	<game name="Amoeba Jump (World) (v1.3) (PAL) (Aftermarket) (Unl)" cloneof="Amoeba Jump (World) (v1.3) (NTSC) (Aftermarket) (Unl)">
 		<category>Homebrew</category>
-		<description>Amoeba Jump (World) (v1.3) (PAL) (Aftermarket)</description>
-		<release name="Amoeba Jump (World) (v1.3) (PAL) (Aftermarket)" region="Europe"/>
-		<rom name="Amoeba Jump (World) (v1.3) (PAL) (Aftermarket).a26" size="4096" crc="77112941" md5="0c72cc3a6658c1abd4b735ef55fa72e4" sha1="b04b1181950e2bb898ea23ff11de93c9b56fdc65"/>
+		<description>Amoeba Jump (World) (v1.3) (PAL) (Aftermarket) (Unl)</description>
+		<release name="Amoeba Jump (World) (v1.3) (PAL) (Aftermarket) (Unl)" region="Europe"/>
+		<rom name="Amoeba Jump (World) (v1.3) (PAL) (Aftermarket) (Unl).a26" size="4096" crc="77112941" md5="0c72cc3a6658c1abd4b735ef55fa72e4" sha1="b04b1181950e2bb898ea23ff11de93c9b56fdc65"/>
 		<url>https://retroachievements.org/game/13457/hashes</url>
 		<hash>0c72cc3a6658c1abd4b735ef55fa72e4</hash>
 	</game>
-	<game name="Amoeba Jump (World) (v1.3) (NTSC) (Aftermarket)">
+	<game name="Amoeba Jump (World) (v1.3) (NTSC) (Aftermarket) (Unl)">
 		<category>Homebrew</category>
-		<description>Amoeba Jump (World) (v1.3) (NTSC) (Aftermarket)</description>
-		<release name="Amoeba Jump (World) (v1.3) (NTSC) (Aftermarket)" region="USA"/>
-		<rom name="Amoeba Jump (World) (v1.3) (NTSC) (Aftermarket).a26" size="4096" crc="e4349cef" md5="539f3c42c4e15f450ed93cb96ce93af5" sha1="dccbfb28358ca8339920b584cf64465905ce1354"/>
+		<description>Amoeba Jump (World) (v1.3) (NTSC) (Aftermarket) (Unl)</description>
+		<release name="Amoeba Jump (World) (v1.3) (NTSC) (Aftermarket) (Unl)" region="USA"/>
+		<rom name="Amoeba Jump (World) (v1.3) (NTSC) (Aftermarket) (Unl).a26" size="4096" crc="e4349cef" md5="539f3c42c4e15f450ed93cb96ce93af5" sha1="dccbfb28358ca8339920b584cf64465905ce1354"/>
 		<url>https://retroachievements.org/game/13457/hashes</url>
 		<hash>539f3c42c4e15f450ed93cb96ce93af5</hash>
 	</game>
@@ -93,11 +93,11 @@
 		<hash>597af15cc043c11f60f1e5cc6f091380</hash>
 	</game>
 	
-	<game name="Birds and Beans (NTSC) (v2.2) (Bluswimmer) (Aftermarket)">
+	<game name="Birds and Beans (NTSC) (v2.2) (Aftermarket) (Bluswimmer)">
 		<category>Homebrew</category>
-		<description>Birds and Beans (NTSC) (v2.2) (Bluswimmer) (Aftermarket)</description>
-		<release name="Birds and Beans (NTSC) (v2.2) (Bluswimmer) (Aftermarket)" region="USA"/>
-		<rom name="Birds and Beans (NTSC) (v2.2) (Bluswimmer) (Aftermarket).a26" size="4096" crc="9cdedf59" md5="41e0953e9e8810ce67bc7995b37bbf8b" sha1="d5565849199b206466c6f65f66489ed60a53faa8"/>
+		<description>Birds and Beans (NTSC) (v2.2) (Aftermarket) (Bluswimmer)</description>
+		<release name="Birds and Beans (NTSC) (v2.2) (Aftermarket) (Bluswimmer)" region="USA"/>
+		<rom name="Birds and Beans (NTSC) (v2.2) (Aftermarket) (Bluswimmer).a26" size="4096" crc="9cdedf59" md5="41e0953e9e8810ce67bc7995b37bbf8b" sha1="d5565849199b206466c6f65f66489ed60a53faa8"/>
 		<url>https://retroachievements.org/game/26027/hashes</url>
 		<hash>41e0953e9e8810ce67bc7995b37bbf8b</hash>
 	</game>
@@ -111,126 +111,126 @@
 		<hash>e60ddaf73ee51ecba7dd22219faede50</hash>
 	</game>
 	
-	<game name="Dark Mage (NTSC) (Greg Troutman) (Aftermarket)">
+	<game name="Dark Mage (NTSC) (Aftermarket) (Greg Troutman)">
 		<category>Homebrew</category>
-		<description>Dark Mage (NTSC) (Greg Troutman) (Aftermarket)</description>
-		<release name="Dark Mage (NTSC) (Greg Troutman) (Aftermarket)" region="USA"/>
-		<rom name="Dark Mage (NTSC) (Greg Troutman) (Aftermarket).a26" size="8192" crc="2b38b9de" md5="6333ef5b5cbb77acd47f558c8b7a95d3" sha1="c5af53c4b64c3db552d4717b8583d6fe8d3e7952"/>
+		<description>Dark Mage (NTSC) (Aftermarket) (Greg Troutman)</description>
+		<release name="Dark Mage (NTSC) (Aftermarket) (Greg Troutman)" region="USA"/>
+		<rom name="Dark Mage (NTSC) (Aftermarket) (Greg Troutman).a26" size="8192" crc="2b38b9de" md5="6333ef5b5cbb77acd47f558c8b7a95d3" sha1="c5af53c4b64c3db552d4717b8583d6fe8d3e7952"/>
 		<url>https://retroachievements.org/game/13321/hashes</url>
 		<hash>6333ef5b5cbb77acd47f558c8b7a95d3</hash>
 	</game>
 	
-	<game name="Fix-It Felix Sr. (Europe) (PAL60) (Aftermarket)" cloneof="Fix-It Felix Sr. (USA) (Aftermarket)">
+	<game name="Fix-It Felix Sr. (Europe) (PAL 60) (Aftermarket) (Unl)" cloneof="Fix-It Felix Sr. (NTSC) (Aftermarket) (Unl)">
 		<category>Homebrew</category>
-		<description>Fix-It Felix Sr. (Europe) (PAL60) (Aftermarket)</description>
-		<release name="Fix-It Felix Sr. (Europe) (PAL60) (Aftermarket)" region="Europe"/>
-		<rom name="Fix-It Felix Sr. (Europe) (PAL60) (Aftermarket).a26" size="4096" crc="b0677067" md5="c7490861ebf74ff1722362aaa146029f" sha1="5a258bdfdf1c72c7b74d1a90f7fb8f7a4d3f7cc7"/>
+		<description>Fix-It Felix Sr. (Europe) (PAL 60) (Aftermarket) (Unl)</description>
+		<release name="Fix-It Felix Sr. (Europe) (PAL 60) (Aftermarket) (Unl)" region="Europe"/>
+		<rom name="Fix-It Felix Sr. (Europe) (PAL 60) (Aftermarket) (Unl).a26" size="4096" crc="b0677067" md5="c7490861ebf74ff1722362aaa146029f" sha1="5a258bdfdf1c72c7b74d1a90f7fb8f7a4d3f7cc7"/>
 		<url>https://retroachievements.org/game/14710/hashes</url>
 		<hash>c7490861ebf74ff1722362aaa146029f</hash>
 	</game>
-	<game name="Fix-It Felix Sr. (USA) (Aftermarket)">
+	<game name="Fix-It Felix Sr. (NTSC) (Aftermarket) (Unl)">
 		<category>Homebrew</category>
-		<description>Fix-It Felix Sr. (USA) (Aftermarket)</description>
-		<release name="Fix-It Felix Sr. (USA) (Aftermarket)" region="USA"/>
-		<rom name="Fix-It Felix Sr. (USA) (Aftermarket).a26" size="4096" crc="4f066bc9" md5="db112399ab6d6402cc2b34f18ef449da" sha1="296d9c1ef7b214b863516822c7a38009559f3a2a"/>
+		<description>Fix-It Felix Sr. (NTSC) (Aftermarket) (Unl)</description>
+		<release name="Fix-It Felix Sr. (NTSC) (Aftermarket) (Unl)" region="USA"/>
+		<rom name="Fix-It Felix Sr. (NTSC) (Aftermarket) (Unl).a26" size="4096" crc="4f066bc9" md5="db112399ab6d6402cc2b34f18ef449da" sha1="296d9c1ef7b214b863516822c7a38009559f3a2a"/>
 		<url>https://retroachievements.org/game/14710/hashes</url>
 		<hash>db112399ab6d6402cc2b34f18ef449da</hash>
 	</game>
 	
-	<game name="Flappy (USA) (RC2) (Aftermarket)">
+	<game name="Flappy (NTSC) (RC2) (Aftermarket) (Unl)">
 		<category>Homebrew</category>
-		<description>Flappy (USA) (RC2) (Aftermarket)</description>
-		<release name="Flappy (USA) (RC2) (Aftermarket)" region="USA"/>
-		<rom name="Flappy (USA) (RC2) (Aftermarket).a26" size="4096" crc="1a7ec0c2" md5="2d33a44e82f88d05f6c50577218c0cae" sha1="14e043587ac67ed5792b4937ddf0e045adeb653a"/>
+		<description>Flappy (NTSC) (RC2) (Aftermarket) (Unl)</description>
+		<release name="Flappy (NTSC) (RC2) (Aftermarket) (Unl)" region="USA"/>
+		<rom name="Flappy (NTSC) (RC2) (Aftermarket) (Unl).a26" size="4096" crc="1a7ec0c2" md5="2d33a44e82f88d05f6c50577218c0cae" sha1="14e043587ac67ed5792b4937ddf0e045adeb653a"/>
 		<url>https://retroachievements.org/game/12795/hashes</url>
 		<hash>2d33a44e82f88d05f6c50577218c0cae</hash>
 	</game>
 	
-	<game name="Go Fish! (World) (PAL) (Aftermarket)" cloneof="Go Fish! (World) (NTSC) (Aftermarket)">
+	<game name="Go Fish! (World) (PAL) (Aftermarket) (Unl)" cloneof="Go Fish! (World) (NTSC) (Aftermarket) (Unl)">
     	<category>Homebrew</category>
-		<description>Go Fish! (World) (PAL) (Aftermarket)</description>
-		<release name="Go Fish! (World) (PAL) (Aftermarket)" region="Europe"/>
-    	<rom name="Go Fish! (World) (PAL) (Aftermarket).a26" size="8192" crc="9a08fc7c" md5="1b64dbaba6bbc1d428e59f088e8018e7" sha1="f286f2e862ca8361c67d815afd9d4e7b27094557"/>
+		<description>Go Fish! (World) (PAL) (Aftermarket) (Unl)</description>
+		<release name="Go Fish! (World) (PAL) (Aftermarket) (Unl)" region="Europe"/>
+    	<rom name="Go Fish! (World) (PAL) (Aftermarket) (Unl).a26" size="8192" crc="9a08fc7c" md5="1b64dbaba6bbc1d428e59f088e8018e7" sha1="f286f2e862ca8361c67d815afd9d4e7b27094557"/>
     	<url>https://retroachievements.org/game/13140/hashes</url>
 		<hash>1b64dbaba6bbc1d428e59f088e8018e7</hash>
 	</game>
-	<game name="Go Fish! (World) (NTSC) (Aftermarket)">
+	<game name="Go Fish! (World) (NTSC) (Aftermarket) (Unl)">
     	<category>Homebrew</category>
-		<description>Go Fish! (World) (NTSC) (Aftermarket)</description>
-    	<release name="Go Fish! (World) (NTSC) (Aftermarket)" region="USA"/>
-    	<rom name="Go Fish! (World) (NTSC) (Aftermarket).a26" size="8192" crc="b99fc2bf" md5="787a2faebadc670a887a0e2483b8f034" sha1="c8094b18ea8d7dd0e1824a5fff2c26dd5f99a520"/>
+		<description>Go Fish! (World) (NTSC) (Aftermarket) (Unl)</description>
+    	<release name="Go Fish! (World) (NTSC) (Aftermarket) (Unl)" region="USA"/>
+    	<rom name="Go Fish! (World) (NTSC) (Aftermarket) (Unl).a26" size="8192" crc="b99fc2bf" md5="787a2faebadc670a887a0e2483b8f034" sha1="c8094b18ea8d7dd0e1824a5fff2c26dd5f99a520"/>
     	<url>https://retroachievements.org/game/13140/hashes</url>
 		<hash>787a2faebadc670a887a0e2483b8f034</hash>
 	</game>
 	
-    <game name="Halo 2600 (World) (Aftermarket)">
+    <game name="Halo 2600 (World) (Aftermarket) (Unl)">
     	<category>Homebrew</category>
-		<description>Halo 2600 (World) (Aftermarket)</description>
-    	<release name="Halo 2600 (World) (Aftermarket)" region="World"/>
-    	<rom name="Halo 2600 (World) (Aftermarket).a26" size="4096" crc="3978a823" md5="4afa7f377eae1cafb4265c68f73f2718" sha1="2a9647e27ab27e6cf82b3bf122edf212fa34ae86"/>
+		<description>Halo 2600 (World) (Aftermarket) (Unl)</description>
+    	<release name="Halo 2600 (World) (Aftermarket) (Unl)" region="World"/>
+    	<rom name="Halo 2600 (World) (Aftermarket) (Unl).a26" size="4096" crc="3978a823" md5="4afa7f377eae1cafb4265c68f73f2718" sha1="2a9647e27ab27e6cf82b3bf122edf212fa34ae86"/>
     	<url>https://retroachievements.org/game/11776/hashes</url>
 		<hash>4afa7f377eae1cafb4265c68f73f2718</hash>
 	</game>
 	
-	<game name="INV+ (World) (Aftermarket)">
+	<game name="INV+ (World) (Aftermarket) (Unl)">
     	<category>Homebrew</category>
-		<description>INV+ (World) (Aftermarket)</description>
-    	<release name="INV+ (World) (Aftermarket)" region="World"/>
-   		<rom name="INV+ (World) (Aftermarket).a26" size="4096" crc="8ebde037" md5="9ea8ed9dec03082973244a080941e58a" sha1="74dc0247a9c9e4ecec1c173e01274e2391643a60"/>
+		<description>INV+ (World) (Aftermarket) (Unl)</description>
+    	<release name="INV+ (World) (Aftermarket) (Unl)" region="World"/>
+   		<rom name="INV+ (World) (Aftermarket) (Unl).a26" size="4096" crc="8ebde037" md5="9ea8ed9dec03082973244a080941e58a" sha1="74dc0247a9c9e4ecec1c173e01274e2391643a60"/>
    		<url>https://retroachievements.org/game/13154/hashes</url>
 		<hash>9ea8ed9dec03082973244a080941e58a</hash>
 	</game>
 	
-	<game name="Katamari (NTSC) (v1.3) (Rabbit2600) (Aftermarket)">
+	<game name="Katamari (NTSC) (v1.3) (Aftermarket) (Rabbit2600)">
     	<category>Homebrew</category>
-		<description>Katamari (NTSC) (v1.3) (Rabbit2600) (Aftermarket)</description>
-    	<release name="Katamari (NTSC) (v1.3) (Rabbit2600) (Aftermarket)" region="USA"/>
-   		<rom name="Katamari (NTSC) (v1.3) (Rabbit2600) (Aftermarket).a26" size="8192" crc="20f6c442" md5="b467c468a17b82372244893d767f55e2" sha1="0097c3a56b3d92b3192182d2b47937c7579c528d"/>
+		<description>Katamari (NTSC) (v1.3) (Aftermarket) (Rabbit2600)</description>
+    	<release name="Katamari (NTSC) (v1.3) (Aftermarket) (Rabbit2600)" region="USA"/>
+   		<rom name="Katamari (NTSC) (v1.3) (Aftermarket) (Rabbit2600).a26" size="8192" crc="20f6c442" md5="b467c468a17b82372244893d767f55e2" sha1="0097c3a56b3d92b3192182d2b47937c7579c528d"/>
    		<url>https://retroachievements.org/game/26087/hashes</url>
 		<hash>b467c468a17b82372244893d767f55e2</hash>
 	</game>
 	
-	<game name="Kelly Kangaroo (USA) (v0.6) (Aftermarket)">
+	<game name="Kelly Kangaroo (NTSC) (v0.6) (Aftermarket) (Unl)">
     	<category>Homebrew</category>
-		<description>Kelly Kangaroo (USA) (v0.6) (Aftermarket)</description>
-    	<release name="Kelly Kangaroo (USA) (v0.6) (Aftermarket)" region="USA"/>
-   		<rom name="Kelly Kangaroo (USA) (v0.6) (Aftermarket).a26" size="32768" crc="fcb219c6" md5="c411ec2fed53fa14c1fde93a8a975345" sha1="7ebb5e591f0d9b4349d16ee8da50a8fab7c9c30f"/>
+		<description>Kelly Kangaroo (NTSC) (v0.6) (Aftermarket) (Unl)</description>
+    	<release name="Kelly Kangaroo (NTSC) (v0.6) (Aftermarket) (Unl)" region="USA"/>
+   		<rom name="Kelly Kangaroo (NTSC) (v0.6) (Aftermarket) (Unl).a26" size="32768" crc="fcb219c6" md5="c411ec2fed53fa14c1fde93a8a975345" sha1="7ebb5e591f0d9b4349d16ee8da50a8fab7c9c30f"/>
    		<url>https://retroachievements.org/game/33061/hashes</url>
 		<hash>c411ec2fed53fa14c1fde93a8a975345</hash>
 	</game>
 	
-	 <game name="Oystron (World) (Aftermarket)">
+	 <game name="Oystron (World) (Aftermarket) (Unl)">
    		<category>Homebrew</category>
-		<description>Oystron (World) (Aftermarket)</description>
-   		<release name="Oystron (World) (Aftermarket)" region="World"/>
-   		<rom name="Oystron (World) (Aftermarket).a26" size="4096" crc="8155dccf" md5="91f0a708eeb93c133e9672ad2c8e0429" sha1="412e8a2438379878ee4de5c6bf4e5a9ee2707c8b"/>
+		<description>Oystron (World) (Aftermarket) (Unl)</description>
+   		<release name="Oystron (World) (Aftermarket) (Unl)" region="World"/>
+   		<rom name="Oystron (World) (Aftermarket) (Unl).a26" size="4096" crc="8155dccf" md5="91f0a708eeb93c133e9672ad2c8e0429" sha1="412e8a2438379878ee4de5c6bf4e5a9ee2707c8b"/>
    		<url>https://retroachievements.org/game/14693/hashes</url>
 		<hash>91f0a708eeb93c133e9672ad2c8e0429</hash>
 	</game>
 	
-	<game name="Pac-Man 4K (NTSC) (v2008-05-24) (Dennis Debro) (Aftermarket)">
+	<game name="Pac-Man 4K (NTSC) (v2008-05-24) (Aftermarket) (Dennis Debro)">
 		<category>Homebrew</category>
-		<description>Pac-Man 4K (NTSC) (v2008-05-24) (Dennis Debro) (Aftermarket)</description>
-		<release name="Pac-Man 4K (NTSC) (v2008-05-24) (Dennis Debro) (Aftermarket)" region="USA"/>
-		<rom name="Pac-Man 4K (NTSC) (v2008-05-24) (Dennis Debro) (Aftermarket).a26" size="4096" crc="4db1f88a" md5="6e88da2b704916eb04a998fed9e23a3e" sha1="f6b59b338f205e2e1e593592d04512d40d8a9bdf"/>
+		<description>Pac-Man 4K (NTSC) (v2008-05-24) (Aftermarket) (Dennis Debro)</description>
+		<release name="Pac-Man 4K (NTSC) (v2008-05-24) (Aftermarket) (Dennis Debro)" region="USA"/>
+		<rom name="Pac-Man 4K (NTSC) (v2008-05-24) (Aftermarket) (Dennis Debro).a26" size="4096" crc="4db1f88a" md5="6e88da2b704916eb04a998fed9e23a3e" sha1="f6b59b338f205e2e1e593592d04512d40d8a9bdf"/>
 		<url>https://retroachievements.org/game/13151/hashes</url>
 		<hash>6e88da2b704916eb04a998fed9e23a3e</hash>
 	</game>
 	
-	<game name="Princess Rescue (NTSC) (v2013-07-31) (Chris Spry) (Aftermarket)">
+	<game name="Princess Rescue (NTSC) (v2013-07-31) (Chris Spry)">
 		<category>Homebrew</category>
-		<description>Princess Rescue (NTSC) (v2013-07-31) (Chris Spry) (Aftermarket)</description>
-		<release name="Princess Rescue (NTSC) (v2013-07-31) (Chris Spry) (Aftermarket)" region="USA"/>
+		<description>Princess Rescue (NTSC) (v2013-07-31) (Chris Spry)</description>
+		<release name="Princess Rescue (NTSC) (v2013-07-31) (Chris Spry)" region="USA"/>
 		<rom name="Princess Rescue (NTSC) (v2013-07-31) (Chris Spry).a26" size="32768" crc="560dac0c" md5="104468e44898b8e9fa4a1500fde8d4cb" sha1="58aa6bba1d0d26c1287135fc9237b684a984b6be"/>
 		<url>https://retroachievements.org/game/11695/hashes</url>
 		<hash>104468e44898b8e9fa4a1500fde8d4cb</hash>
 	</game>
 	
-	<game name="Punch Out (NTSC) (Demake) (MathanGames) (Aftermarket)">
+	<game name="Punch Out (Demake) (NTSC) (Aftermarket) (MathanGames)">
 		<category>Homebrew</category>
-		<description>Punch Out (NTSC) (Demake) (MathanGames) (Aftermarket)</description>
-		<release name="Punch Out (NTSC) (Demake) (MathanGames) (Aftermarket)" region="USA"/>
-		<rom name="Punch Out (NTSC) (Demake) (MathanGames) (Aftermarket).a26" size="32768" crc="780db785" md5="ea6a1cdd1b14eac02759ea6372cfc1f5" sha1="b9d93a04b7fe83ef6782c1145819de24cc4c0f0f"/>
+		<description>Punch Out (Demake) (NTSC) (Aftermarket) (MathanGames)</description>
+		<release name="Punch Out (Demake) (NTSC) (Aftermarket) (MathanGames)" region="USA"/>
+		<rom name="Punch Out (Demake) (NTSC) (Aftermarket) (MathanGames).a26" size="32768" crc="780db785" md5="ea6a1cdd1b14eac02759ea6372cfc1f5" sha1="b9d93a04b7fe83ef6782c1145819de24cc4c0f0f"/>
 		<url>https://retroachievements.org/game/25021/hashes</url>
 		<hash>ea6a1cdd1b14eac02759ea6372cfc1f5</hash>
 	</game>
@@ -252,168 +252,168 @@
 		<hash>e2bd71a61584da41ac7c55b90deab543</hash>
 	</game>
 	
-	<game name="Rock Shot (NTSC) (Vivian Video) (Aftermarket)">
+	<game name="Rock Shot (NTSC) (Aftermarket) (Vivian Video)">
 		<category>Homebrew</category>
-		<description>Rock Shot (NTSC) (Vivian Video) (Aftermarket)</description>
-		<release name="Rock Shot (NTSC) (Vivian Video) (Aftermarket)" region="USA"/>
-		<rom name="Rock Shot (NTSC) (Vivian Video) (Aftermarket).a26" size="4096" crc="654c7274" md5="d92c1ebe55807fab5921d960130d6925" sha1="25c1338cc954bf903136258cf162f5a584f97b89"/>
+		<description>Rock Shot (NTSC) (Aftermarket) (Vivian Video)</description>
+		<release name="Rock Shot (NTSC) (Aftermarket) (Vivian Video)" region="USA"/>
+		<rom name="Rock Shot (NTSC) (Aftermarket) (Vivian Video).a26" size="4096" crc="654c7274" md5="d92c1ebe55807fab5921d960130d6925" sha1="25c1338cc954bf903136258cf162f5a584f97b89"/>
 		<url>https://retroachievements.org/game/36536/hashes</url>
 		<hash>d92c1ebe55807fab5921d960130d6925</hash>
 	</game>
 	
-	<game name="Sheep It Up! (World) (PAL) (Aftermarket)" cloneof="Sheep It Up! (World) (NTSC) (Aftermarket)">
+	<game name="Sheep It Up! - PAL (World) (Aftermarket) (Unl)" cloneof="Sheep It Up! - NTSC (World) (Aftermarket) (Unl)">
    		<category>Homebrew</category>
-		<description>Sheep It Up! (World) (PAL) (Aftermarket)</description>
-		<release name="Sheep It Up! (World) (PAL) (Aftermarket)" region="Europe"/>
-   		<rom name="Sheep It Up! (World) (PAL) (Aftermarket).a26" size="4096" crc="13de1052" md5="1f6267db16ffeb90ba48890d5f84ac9e" sha1="b2d070404738c771e7c5bd3139858f7f8822d423"/>
+		<description>Sheep It Up! - PAL (World) (Aftermarket) (Unl)</description>
+		<release name="Sheep It Up! - PAL (World) (Aftermarket) (Unl)" region="Europe"/>
+   		<rom name="Sheep It Up! - PAL (World) (Aftermarket) (Unl).a26" size="4096" crc="13de1052" md5="1f6267db16ffeb90ba48890d5f84ac9e" sha1="b2d070404738c771e7c5bd3139858f7f8822d423"/>
     	<url>https://retroachievements.org/game/13456/hashes</url>
 		<hash>1f6267db16ffeb90ba48890d5f84ac9e</hash>
 	</game>
-	<game name="Sheep It Up! (World) (NTSC) (Aftermarket)">
+	<game name="Sheep It Up! - NTSC (World) (Aftermarket) (Unl)">
     	<category>Homebrew</category>
-		<description>Sheep It Up! (World) (NTSC) (Aftermarket)</description>
-    	<release name="Sheep It Up! (World) (NTSC) (Aftermarket)" region="USA"/>
-   		<rom name="Sheep It Up! (World) (NTSC) (Aftermarket).a26" size="4096" crc="5be003ad" md5="8debebc61916692e2d66f2edf4bed29c" sha1="d22009a4c4e92e0533bf4379d743f80f53064fde"/>
+		<description>Sheep It Up! - NTSC (World) (Aftermarket) (Unl)</description>
+    	<release name="Sheep It Up! - NTSC (World) (Aftermarket) (Unl)" region="USA"/>
+   		<rom name="Sheep It Up! - NTSC (World) (Aftermarket) (Unl).a26" size="4096" crc="5be003ad" md5="8debebc61916692e2d66f2edf4bed29c" sha1="d22009a4c4e92e0533bf4379d743f80f53064fde"/>
    		<url>https://retroachievements.org/game/13456/hashes</url>
 		<hash>8debebc61916692e2d66f2edf4bed29c</hash>
 	</game>
-	<game name="Sheep It Up! (World) (SECAM) (Aftermarket)" cloneof="Sheep It Up! (World) (NTSC) (Aftermarket)">
+	<game name="Sheep It Up! - SECAM (World) (Aftermarket) (Unl)" cloneof="Sheep It Up! - NTSC (World) (Aftermarket) (Unl)">
    		<category>Homebrew</category>
-		<description>Sheep It Up! (World) (SECAM) (Aftermarket)</description>
-		<release name="Sheep It Up! (World) (SECAM) (Aftermarket)" region="World"/>
-   		<rom name="Sheep It Up! (World) (SECAM) (Aftermarket).a26" size="4096" crc="f915ad29" md5="da3f54e89b54b0a2391d0513ab8c9861" sha1="566249fc4b955fe7baab05e4818724d3387674b3"/>
+		<description>Sheep It Up! - SECAM (World) (Aftermarket) (Unl)</description>
+		<release name="Sheep It Up! - SECAM (World) (Aftermarket) (Unl)" region="World"/>
+   		<rom name="Sheep It Up! - SECAM (World) (Aftermarket) (Unl).a26" size="4096" crc="f915ad29" md5="da3f54e89b54b0a2391d0513ab8c9861" sha1="566249fc4b955fe7baab05e4818724d3387674b3"/>
    		<url>https://retroachievements.org/game/13456/hashes</url>
 		<hash>da3f54e89b54b0a2391d0513ab8c9861</hash>
 	</game>
 	
-	<game name="Skeleton+ (NTSC) (Eric Ball) (Aftermarket)">
+	<game name="Skeleton+ (NTSC) (Aftermarket) (Eric Ball)">
 		<category>Homebrew</category>
-		<description>Skeleton+ (NTSC) (Eric Ball) (Aftermarket)</description>
-		<release name="Skeleton+ (NTSC) (Eric Ball) (Aftermarket)" region="USA"/>
-		<rom name="Skeleton+ (NTSC) (Eric Ball) (Aftermarket).a26" size="4096" crc="69666409" md5="eafe8b40313a65792e88ff9f2fe2655c" sha1="71e757f92788794632e48a8104e715cb9eb6b217"/>
+		<description>Skeleton+ (NTSC) (Aftermarket) (Eric Ball)</description>
+		<release name="Skeleton+ (NTSC) (Aftermarket) (Eric Ball)" region="USA"/>
+		<rom name="Skeleton+ (NTSC) (Aftermarket) (Eric Ball).a26" size="4096" crc="69666409" md5="eafe8b40313a65792e88ff9f2fe2655c" sha1="71e757f92788794632e48a8104e715cb9eb6b217"/>
 		<url>https://retroachievements.org/game/13382/hashes</url>
 		<hash>eafe8b40313a65792e88ff9f2fe2655c</hash>
 	</game>
 	
-	<game name="Slide Boy in Maze Land (USA) (Final) (Aftermarket)">
+	<game name="Slide Boy in Maze Land (NTSC) (Final) (Aftermarket) (Unl)">
 		<category>Homebrew</category>
-		<description>Slide Boy in Maze Land (USA) (Final) (Aftermarket)</description>
-		<release name="Slide Boy in Maze Land (USA) (Final) (Aftermarket)" region="USA"/>
-		<rom name="Slide Boy in Maze Land (USA) (Final) (Aftermarket).a26" size="32768" crc="1a7388ca" md5="024e97dabc0b083c31ea52a83cca4e01" sha1="744882a4a5a9122e902e5dca743e5b2e42abee32"/>
+		<description>Slide Boy in Maze Land (NTSC) (Final) (Aftermarket) (Unl)</description>
+		<release name="Slide Boy in Maze Land (NTSC) (Final) (Aftermarket) (Unl)" region="USA"/>
+		<rom name="Slide Boy in Maze Land (NTSC) (Final) (Aftermarket) (Unl).a26" size="32768" crc="1a7388ca" md5="024e97dabc0b083c31ea52a83cca4e01" sha1="744882a4a5a9122e902e5dca743e5b2e42abee32"/>
 		<url>https://retroachievements.org/game/26387/hashes</url>
 		<hash>024e97dabc0b083c31ea52a83cca4e01</hash>
 	</game>
 	
-	<game name="Snake (Rick Skrbina) (USA) (Aftermarket)">
+	<game name="Snake (Rick Skrbina) (NTSC) (Aftermarket) (Unl)">
 		<category>Homebrew</category>
-		<description>Snake (Rick Skrbina) (USA) (Aftermarket)</description>
-		<release name="Snake (Rick Skrbina) (USA) (Aftermarket)" region="USA"/>
-		<rom name="Snake (Rick Skrbina) (USA) (Aftermarket).a26" size="4096" crc="5c0b7e5f" md5="bd81069d0945f26d7ff753767208c305" sha1="5c41c48869aa4b64111a24011589be33e7f73ade"/>
+		<description>Snake (Rick Skrbina) (NTSC) (Aftermarket) (Unl)</description>
+		<release name="Snake (Rick Skrbina) (NTSC) (Aftermarket) (Unl)" region="USA"/>
+		<rom name="Snake (Rick Skrbina) (NTSC) (Aftermarket) (Unl).a26" size="4096" crc="5c0b7e5f" md5="bd81069d0945f26d7ff753767208c305" sha1="5c41c48869aa4b64111a24011589be33e7f73ade"/>
 		<url>https://retroachievements.org/game/14725/hashes</url>
 		<hash>bd81069d0945f26d7ff753767208c305</hash>
 	</game>
 	
-	<game name="Spies in the Night (NTSC) (Jared Gray West) (Aftermarket)">
+	<game name="Spies in the Night (NTSC) (Aftermarket) (Jared Gray West)">
 		<category>Homebrew</category>
-		<description>Spies in the Night (NTSC) (Jared Gray West) (Aftermarket)</description>
-		<release name="Spies in the Night (NTSC) (Jared Gray West) (Aftermarket)" region="USA"/>
-		<rom name="Spies in the Night (NTSC) (Jared Gray West) (Aftermarket).a26" size="8192" crc="6209531c" md5="aecdc8da1d67ad5fd520582750e19938" sha1="934b652be776f37b597e94675b9609fd9b711960"/>
+		<description>Spies in the Night (NTSC) (Aftermarket) (Jared Gray West)</description>
+		<release name="Spies in the Night (NTSC) (Aftermarket) (Jared Gray West)" region="USA"/>
+		<rom name="Spies in the Night (NTSC) (Aftermarket) (Jared Gray West).a26" size="8192" crc="6209531c" md5="aecdc8da1d67ad5fd520582750e19938" sha1="934b652be776f37b597e94675b9609fd9b711960"/>
 		<url>https://retroachievements.org/game/22548/hashes</url>
 		<hash>aecdc8da1d67ad5fd520582750e19938</hash>
 	</game>
 	
-	<game name="Tetris26 (NTSC) (Colin Hughes) (Aftermarket)">
+	<game name="Tetris26 (NTSC) (Aftermarket) (Colin Hughes)">
 		<category>Homebrew</category>
-		<description>Tetris26 (NTSC) (Colin Hughes) (Aftermarket)</description>
-		<release name="Tetris26 (NTSC) (Colin Hughes) (Aftermarket)" region="USA"/>
-		<rom name="Tetris26 (NTSC) (Colin Hughes) (Aftermarket).a26" size="2048" crc="ebe8d2a9" md5="0279a63d922163da5a4fde76397f3fe0" sha1="c512f2f770d0e8fad29c0ab9e56fd875bc8d1b55"/>
+		<description>Tetris26 (NTSC) (Aftermarket) (Colin Hughes)</description>
+		<release name="Tetris26 (NTSC) (Aftermarket) (Colin Hughes)" region="USA"/>
+		<rom name="Tetris26 (NTSC) (Aftermarket) (Colin Hughes).a26" size="2048" crc="ebe8d2a9" md5="0279a63d922163da5a4fde76397f3fe0" sha1="c512f2f770d0e8fad29c0ab9e56fd875bc8d1b55"/>
 		<url>https://retroachievements.org/game/13141/hashes</url>
 		<hash>0279a63d922163da5a4fde76397f3fe0</hash>
 	</game>
 	
-	<game name="Angry Video Game Nerd K.O. Boxing (World) (NTSC) (Aftermarket)">
+	<game name="Angry Video Game Nerd K.O. Boxing (World) (NTSC) (Aftermarket) (Unl)">
 		<category>Homebrew</category>
-		<description>Angry Video Game Nerd K.O. Boxing (World) (NTSC) (Aftermarket)</description>
-		<release name="Angry Video Game Nerd K.O. Boxing (World) (NTSC) (Aftermarket)" region="USA"/>
-		<rom name="Angry Video Game Nerd K.O. Boxing (World) (NTSC) (Aftermarket).a26" size="32768" crc="53f02c00" md5="6a7e6fc102bf7459f89419c548a79e2c" sha1="bbcac5c5b2384ab6aa83574e6b9486c4b60822d4"/>
+		<description>Angry Video Game Nerd K.O. Boxing (World) (NTSC) (Aftermarket) (Unl)</description>
+		<release name="Angry Video Game Nerd K.O. Boxing (World) (NTSC) (Aftermarket) (Unl)" region="USA"/>
+		<rom name="Angry Video Game Nerd K.O. Boxing (World) (NTSC) (Aftermarket) (Unl).a26" size="32768" crc="53f02c00" md5="6a7e6fc102bf7459f89419c548a79e2c" sha1="bbcac5c5b2384ab6aa83574e6b9486c4b60822d4"/>
 		<url>https://retroachievements.org/game/14686/hashes</url>
 		<hash>6a7e6fc102bf7459f89419c548a79e2c</hash>
 	</game>
 	
-	<game name="Video Simon (NTSC) (Mark De Smet) (Aftermarket)">
+	<game name="Video Simon (NTSC) (Aftermarket) (Mark De Smet)">
 		<category>Homebrew</category>
-		<description>Video Simon (NTSC) (Mark De Smet) (Aftermarket)</description>
-		<release name="Video Simon (NTSC) (Mark De Smet) (Aftermarket)" region="USA"/>
-		<rom name="Video Simon (NTSC) (Mark De Smet) (Aftermarket).a26" size="4096" crc="c3a4bd27" md5="16f494f20af5dc803bc35939ef924020" sha1="a345a5696f1d63a879e7bb7e3a74c825e97ef7c3"/>
+		<description>Video Simon (NTSC) (Aftermarket) (Mark De Smet)</description>
+		<release name="Video Simon (NTSC) (Aftermarket) (Mark De Smet)" region="USA"/>
+		<rom name="Video Simon (NTSC) (Aftermarket) (Mark De Smet).a26" size="4096" crc="c3a4bd27" md5="16f494f20af5dc803bc35939ef924020" sha1="a345a5696f1d63a879e7bb7e3a74c825e97ef7c3"/>
 		<url>https://retroachievements.org/game/13152/hashes</url>
 		<hash>16f494f20af5dc803bc35939ef924020</hash>
 	</game>
 	
-	<game name="Wall Jump Ninja (World) (2015-01-15) (PAL 60Hz) (Aftermarket)" cloneof="Wall Jump Ninja (World) (2015-01-15) (NTSC) (Aftermarket)">
+	<game name="Wall Jump Ninja (World) (2015-01-15) (PAL 60Hz) (Aftermarket) (Unl)" cloneof="Wall Jump Ninja (World) (2015-01-15) (NTSC) (Aftermarket) (Unl)">
 		<category>Homebrew</category>
-		<description>Wall Jump Ninja (World) (2015-01-15) (PAL 60Hz) (Aftermarket)</description>
-		<release name="Wall Jump Ninja (World) (2015-01-15) (PAL 60Hz) (Aftermarket)" region="Europe"/>
-		<rom name="Wall Jump Ninja (World) (2015-01-15) (PAL 60Hz) (Aftermarket).a26" size="4096" crc="b491c2b6" md5="2489359c38551a1d96cbaa4e52d8bb30" sha1="bd3e8686a09175f51a0fcb51115d9b91b0e6b852"/>
+		<description>Wall Jump Ninja (World) (2015-01-15) (PAL 60Hz) (Aftermarket) (Unl)</description>
+		<release name="Wall Jump Ninja (World) (2015-01-15) (PAL 60Hz) (Aftermarket) (Unl)" region="Europe"/>
+		<rom name="Wall Jump Ninja (World) (2015-01-15) (PAL 60Hz) (Aftermarket) (Unl).a26" size="4096" crc="b491c2b6" md5="2489359c38551a1d96cbaa4e52d8bb30" sha1="bd3e8686a09175f51a0fcb51115d9b91b0e6b852"/>
 		<url>https://retroachievements.org/game/11536/hashes</url>
 		<hash>2489359c38551a1d96cbaa4e52d8bb30</hash>
 	</game>
-	<game name="Wall Jump Ninja (World) (2015-01-15) (NTSC) (Aftermarket)">
+	<game name="Wall Jump Ninja (World) (2015-01-15) (NTSC) (Aftermarket) (Unl)">
 		<category>Homebrew</category>
-		<description>Wall Jump Ninja (World) (2015-01-15) (NTSC) (Aftermarket)</description>
-		<release name="Wall Jump Ninja (World) (2015-01-15) (NTSC) (Aftermarket)" region="USA"/>
-		<rom name="Wall Jump Ninja (World) (2015-01-15) (NTSC) (Aftermarket).a26" size="4096" crc="353215e0" md5="3c56c0c5f6f97850ed0aa7bcc2a4e30e" sha1="a06fb0c60fff651b0be270e926f220706e86a5b4"/>
+		<description>Wall Jump Ninja (World) (2015-01-15) (NTSC) (Aftermarket) (Unl)</description>
+		<release name="Wall Jump Ninja (World) (2015-01-15) (NTSC) (Aftermarket) (Unl)" region="USA"/>
+		<rom name="Wall Jump Ninja (World) (2015-01-15) (NTSC) (Aftermarket) (Unl).a26" size="4096" crc="353215e0" md5="3c56c0c5f6f97850ed0aa7bcc2a4e30e" sha1="a06fb0c60fff651b0be270e926f220706e86a5b4"/>
 		<url>https://retroachievements.org/game/11536/hashes</url>
 		<hash>3c56c0c5f6f97850ed0aa7bcc2a4e30e</hash>
 	</game>
 	
-	<game name="Wall-E (USA) (v20130624) (Aftermarket)">
+	<game name="Wall-E (NTSC) (v20130624) (Aftermarket) (Unl)">
 		<category>Homebrew</category>
-		<description>Wall-E (USA) (v20130624) (Aftermarket)</description>
-		<release name="Wall-E (USA) (v20130624) (Aftermarket)" region="USA"/>
-		<rom name="Wall-E (USA) (v20130624) (Aftermarket).a26" size="4096" crc="5d278aa5" md5="8c304722f73b9c91d3b68db6eaad690d" sha1="8d02cae15084a804e45bb012cd0681f87ffa2d3b"/>
+		<description>Wall-E (NTSC) (v20130624) (Aftermarket) (Unl)</description>
+		<release name="Wall-E (NTSC) (v20130624) (Aftermarket) (Unl)" region="USA"/>
+		<rom name="Wall-E (NTSC) (v20130624) (Aftermarket) (Unl).a26" size="4096" crc="5d278aa5" md5="8c304722f73b9c91d3b68db6eaad690d" sha1="8d02cae15084a804e45bb012cd0681f87ffa2d3b"/>
 		<url>https://retroachievements.org/game/26911/hashes</url>
 		<hash>8c304722f73b9c91d3b68db6eaad690d</hash>
 	</game>
 	
-	<game name="Wipeout 2600 (USA) (Aftermarket)">
+	<game name="Wipeout 2600 (NTSC) (Aftermarket) (Unl)">
 		<category>Homebrew</category>
-		<description>Wipeout 2600 (USA) (Aftermarket)</description>
-		<release name="Wipeout 2600 (USA) (Aftermarket)" region="USA"/>
-		<rom name="Wipeout 2600 (USA) (Aftermarket).a26" size="4096" crc="613a1389" md5="7088177126d7257472986b65690ce88a" sha1="dbc0e0032c4573a19790fbc551346362adff97b6"/>
+		<description>Wipeout 2600 (NTSC) (Aftermarket) (Unl)</description>
+		<release name="Wipeout 2600 (NTSC) (Aftermarket) (Unl)" region="USA"/>
+		<rom name="Wipeout 2600 (NTSC) (Aftermarket) (Unl).a26" size="4096" crc="613a1389" md5="7088177126d7257472986b65690ce88a" sha1="dbc0e0032c4573a19790fbc551346362adff97b6"/>
 		<url>https://retroachievements.org/game/26910/hashes</url>
 		<hash>7088177126d7257472986b65690ce88a</hash>
 	</game>
-	<game name="Wipeout 2600 (USA) (Faster Missiles) (Aftermarket)" cloneof="Wipeout 2600 (USA) (Aftermarket)">
+	<game name="Wipeout 2600 (NTSC) (Faster Missiles) (Aftermarket) (Unl)" cloneof="Wipeout 2600 (NTSC) (Aftermarket) (Unl)">
 		<category>Homebrew</category>
-		<description>Wipeout 2600 (USA) (Faster Missiles) (Aftermarket)</description>
-		<rom name="Wipeout 2600 (USA) (Faster Missiles) (Aftermarket).a26" size="4096" crc="b12c3419" md5="f3bb1153e493d740bf41d4e75131001b" sha1="8f3d7abeac8d4b339c6d1b145cdd09e93041bb91"/>
+		<description>Wipeout 2600 (NTSC) (Faster Missiles) (Aftermarket) (Unl)</description>
+		<rom name="Wipeout 2600 (NTSC) (Faster Missiles) (Aftermarket) (Unl).a26" size="4096" crc="b12c3419" md5="f3bb1153e493d740bf41d4e75131001b" sha1="8f3d7abeac8d4b339c6d1b145cdd09e93041bb91"/>
 		<url>https://retroachievements.org/game/26910/hashes</url>
 		<hash>f3bb1153e493d740bf41d4e75131001b</hash>
 	</game>
 	
-	<game name="Xanthiom (NTSC) (v6.0) (MathanGames) (Aftermarket)">
+	<game name="Xanthiom (NTSC) (v6.0) (Aftermarket) (MathanGames)">
 		<category>Homebrew</category>
-		<description>Xanthiom (NTSC) (v6.0) (MathanGames) (Aftermarket)</description>
-		<release name="Xanthiom (NTSC) (v6.0) (MathanGames) (Aftermarket)" region="USA"/>
-		<rom name="Xanthiom (NTSC) (v6.0) (MathanGames) (Aftermarket).a26" size="65536" crc="82738d98" md5="bdda231978da7e14757920094693248a" sha1="bbc0d8e79d4d9a519f68abf2223eeff851c3fec9"/>
+		<description>Xanthiom (NTSC) (v6.0) (Aftermarket) (MathanGames)</description>
+		<release name="Xanthiom (NTSC) (v6.0) (Aftermarket) (MathanGames)" region="USA"/>
+		<rom name="Xanthiom (NTSC) (v6.0) (Aftermarket) (MathanGames).a26" size="65536" crc="82738d98" md5="bdda231978da7e14757920094693248a" sha1="bbc0d8e79d4d9a519f68abf2223eeff851c3fec9"/>
 		<url>https://retroachievements.org/game/25027/hashes</url>
 		<hash>bdda231978da7e14757920094693248a</hash>
 	</game>
 	
-	<game name="Yahtzee (NTSC) (Russell Babylon) (Aftermarket)">
+	<game name="Yahtzee (NTSC) (Aftermarket) (Russell Babylon)">
 		<category>Homebrew</category>
-		<description>Yahtzee (NTSC) (Russell Babylon) (Aftermarket)</description>
-		<release name="Yahtzee (NTSC) (Russell Babylon) (Aftermarket)" region="USA"/>
-		<rom name="Yahtzee (NTSC) (Russell Babylon) (Aftermarket).a26" size="4096" crc="5c93f4d0" md5="d090836f0a4ea8db9ac7abb7d6adf61e" sha1="6a1e0142c6886a6589a58e029e5aec6b72f7d27f"/>
+		<description>Yahtzee (NTSC) (Aftermarket) (Russell Babylon)</description>
+		<release name="Yahtzee (NTSC) (Aftermarket) (Russell Babylon)" region="USA"/>
+		<rom name="Yahtzee (NTSC) (Aftermarket) (Russell Babylon).a26" size="4096" crc="5c93f4d0" md5="d090836f0a4ea8db9ac7abb7d6adf61e" sha1="6a1e0142c6886a6589a58e029e5aec6b72f7d27f"/>
 		<url>https://retroachievements.org/game/13024/hashes</url>
 		<hash>d090836f0a4ea8db9ac7abb7d6adf61e</hash>
 	</game>
 	
-	<game name="Zippy the Porcupine (NTSC) (v2) (Chris Spry) (Aftermarket)">
+	<game name="Zippy the Porcupine (NTSC) (v2) (Aftermarket) (Chris Spry)">
 		<category>Homebrew</category>
-		<description>Zippy the Porcupine (NTSC) (v2) (Chris Spry) (Aftermarket)</description>
-		<release name="Zippy the Porcupine (NTSC) (v2) (Chris Spry) (Aftermarket)" region="USA"/>
-		<rom name="Zippy the Porcupine (NTSC) (v2) (Chris Spry) (Aftermarket).a26" size="65536" crc="d57d3189" md5="457b03cd48ff6d895795ef043c6b0f1e" sha1="cbe88e316b471a6476f284df8634d5b646b4bdc5"/>
+		<description>Zippy the Porcupine (NTSC) (v2) (Aftermarket) (Chris Spry)</description>
+		<release name="Zippy the Porcupine (NTSC) (v2) (Aftermarket) (Chris Spry)" region="USA"/>
+		<rom name="Zippy the Porcupine (NTSC) (v2) (Aftermarket) (Chris Spry).a26" size="65536" crc="d57d3189" md5="457b03cd48ff6d895795ef043c6b0f1e" sha1="cbe88e316b471a6476f284df8634d5b646b4bdc5"/>
 		<url>https://retroachievements.org/game/11803/hashes</url>
 		<hash>457b03cd48ff6d895795ef043c6b0f1e</hash>
 	</game>
@@ -552,11 +552,11 @@
 		<hash>16cb43492987d2f32b423817cdaaf7c4</hash>
 	</game>
 	
-	<game name="Alpha Beam with Ernie (USA) (Joystick Patch) (v2011.01.10)">
+	<game name="Alpha Beam with Ernie (Japan, USA) (En) (Joystick Patch) (v2011.01.10)">
 		<category>Retail</category>
-		<description>Alpha Beam with Ernie (USA) (Joystick Patch) (v2011.01.10)</description>
-		<release name="Alpha Beam with Ernie (USA) (Joystick Patch) (v2011.01.10)" region="USA"/>
-		<rom name="Alpha Beam with Ernie (USA) (Joystick Patch) (v2011.01.10).a26" size="8192" crc="bbeeb804" md5="a5d82e469a499a41cfb6e459eba89ad0" sha1="e8519ca4397a4adeb6332017d9a5de63df045362"/>
+		<description>Alpha Beam with Ernie (Japan, USA) (En) (Joystick Patch) (v2011.01.10)</description>
+		<release name="Alpha Beam with Ernie (Japan, USA) (En) (Joystick Patch) (v2011.01.10)" region="USA"/>
+		<rom name="Alpha Beam with Ernie (Japan, USA) (En) (Joystick Patch) (v2011.01.10).a26" size="8192" crc="bbeeb804" md5="a5d82e469a499a41cfb6e459eba89ad0" sha1="e8519ca4397a4adeb6332017d9a5de63df045362"/>
 		<url>https://retroachievements.org/game/13207/hashes</url>
 		<hash>a5d82e469a499a41cfb6e459eba89ad0</hash>
 	</game>
@@ -672,11 +672,11 @@
 		<hash>136f75c4dd02c29283752b7e5799f978</hash>
 	</game>
 	
-	<game name="Big Bird's Egg Catch (USA) (Joystick Patch)">
+	<game name="Big Bird's Egg Catch (Japan, USA) (En) (Joystick Patch)">
 		<category>Retail</category>
-		<description>Big Bird's Egg Catch (USA) (Joystick Patch)</description>
-		<release name="Big Bird's Egg Catch (USA) (Joystick Patch)" region="USA"/>
-		<rom name="Big Bird's Egg Catch (USA) (Joystick Patch).a26" size="8192" crc="4c343277" md5="d22a401f0b20808196f538cc43786459" sha1="418db57875e69a7dc5e535d71a7953bf74c30798"/>
+		<description>Big Bird's Egg Catch (Japan, USA) (En) (Joystick Patch)</description>
+		<release name="Big Bird's Egg Catch (Japan, USA) (En) (Joystick Patch)" region="USA"/>
+		<rom name="Big Bird's Egg Catch (Japan, USA) (En) (Joystick Patch).a26" size="8192" crc="4c343277" md5="d22a401f0b20808196f538cc43786459" sha1="418db57875e69a7dc5e535d71a7953bf74c30798"/>
 		<url>https://retroachievements.org/game/14499/hashes</url>
 		<hash>d22a401f0b20808196f538cc43786459</hash>
 	</game>
@@ -1358,11 +1358,11 @@
 		<hash>0164f26f6b38a34208cd4a2d0212afc3</hash>
 	</game>
 	
-	<game name="Mr. Run and Jump (World) (Aftermarket)">
+	<game name="Mr. Run and Jump (World) (Aftermarket) (Unl)">
 		<category>Retail</category>
-		<description>Mr. Run and Jump (World) (Aftermarket)</description>
-		<release name="Mr. Run and Jump (World) (Aftermarket)" region="World"/>
-		<rom name="Mr. Run and Jump (World) (Aftermarket).a26" size="16384" crc="9cdb0360" md5="a18c31f680d1adeb541e89508b7a5e3b" sha1="5363ff31b2719ab8114c6d5ac226deb0fb3c1d1f"/>
+		<description>Mr. Run and Jump (World) (Aftermarket) (Unl)</description>
+		<release name="Mr. Run and Jump (World) (Aftermarket) (Unl)" region="World"/>
+		<rom name="Mr. Run and Jump (World) (Aftermarket) (Unl).a26" size="16384" crc="9cdb0360" md5="a18c31f680d1adeb541e89508b7a5e3b" sha1="5363ff31b2719ab8114c6d5ac226deb0fb3c1d1f"/>
 		<url>https://retroachievements.org/game/30131/hashes</url>
 		<hash>a18c31f680d1adeb541e89508b7a5e3b</hash>
 	</game>
@@ -1493,11 +1493,11 @@
 		<hash>f724d3dd2471ed4cf5f191dbb724b69f</hash>
 	</game>
 	
-	<game name="RealSports Volleyball (USA)">
+	<game name="RealSports Volleyball (USA, Europe) (En,Fr,De,Es,It)">
 		<category>Retail</category>
-		<description>RealSports Volleyball (USA)</description>
-		<release name="RealSports Volleyball (USA)" region="USA"/>
-		<rom name="RealSports Volleyball (USA).a26" size="4096" crc="54fc9eb2" md5="aed0b7bd64cc384f85fdea33e28daf3b" sha1="2025e1d868595fad36e5d9e7384ffd24c206208d"/>
+		<description>RealSports Volleyball (USA, Europe) (En,Fr,De,Es,It)</description>
+		<release name="RealSports Volleyball (USA, Europe) (En,Fr,De,Es,It)" region="USA"/>
+		<rom name="RealSports Volleyball (USA, Europe) (En,Fr,De,Es,It).a26" size="4096" crc="54fc9eb2" md5="aed0b7bd64cc384f85fdea33e28daf3b" sha1="2025e1d868595fad36e5d9e7384ffd24c206208d"/>
 		<url>https://retroachievements.org/game/16350/hashes</url>
 		<hash>aed0b7bd64cc384f85fdea33e28daf3b</hash>
 	</game>

--- a/DATs/RetroAchievements (No Subfolders)/RA - Atari 7800.dat
+++ b/DATs/RetroAchievements (No Subfolders)/RA - Atari 7800.dat
@@ -5,98 +5,98 @@
 		<name>RA - Atari 7800</name>
 		<description>Atari 7800</description>
 		<category>No Subfolders</category>
-		<version>20260227</version>
-		<date>27 February 2026</date>
+		<version>20260405</version>
+		<date>5 April 2026</date>
 		<author>AzgoRAth, NeoRetroGamer (Contributor), Jumphil (Contributor)</author>
 		<homepage>https://retroachievements.org</homepage>
 		<url>https://retroachievements.org/system/51/games</url>
 		<titlecount>39</titlecount>
 		<hashcount>40</hashcount>
 	</header>
-	<game name="2048 (World) (Aftermarket)">
+	<game name="2048 (World) (Aftermarket) (Unl)">
 		<category>Homebrew</category>
-		<description>2048 (World) (Aftermarket)</description>
-		<release name="2048 (World) (Aftermarket)" region="World"/>
-		<rom name="2048 (World) (Aftermarket).a78" size="49280" crc="118ea84d" md5="a43ae0a26441ff804a9fbaf094a3533d" sha1="99ed61f87bad6e119c1ef69099e4c348b3bbf143"/>
+		<description>2048 (World) (Aftermarket) (Unl)</description>
+		<release name="2048 (World) (Aftermarket) (Unl)" region="World"/>
+		<rom name="2048 (World) (Aftermarket) (Unl).a78" size="49280" crc="118ea84d" md5="a43ae0a26441ff804a9fbaf094a3533d" sha1="99ed61f87bad6e119c1ef69099e4c348b3bbf143"/>
 		<url>https://retroachievements.org/game/24465/hashes</url>
 		<hash>6f157f421c7ed5d952b393122d37915e</hash>
 	</game>
 	
-	<game name="Bentley Bear's Crystal Quest (World) (NTSC) (Aftermarket)">
+	<game name="Bentley Bear's Crystal Quest (World) (NTSC) (Aftermarket) (Unl)">
 		<category>Homebrew</category>
-		<description>Bentley Bear's Crystal Quest (World) (NTSC) (Aftermarket)</description>
-		<release name="Bentley Bear's Crystal Quest (World) (NTSC) (Aftermarket)" region="USA"/>
-		<rom name="Bentley Bear's Crystal Quest (World) (NTSC) (Aftermarket).a78" size="147456" crc="d44622b3" md5="34483432b92f565f4ced82a141119164" sha1="4a850d4b97bea621e9b6df142afeec8b398d6d6c"/>
+		<description>Bentley Bear's Crystal Quest (World) (NTSC) (Aftermarket) (Unl)</description>
+		<release name="Bentley Bear's Crystal Quest (World) (NTSC) (Aftermarket) (Unl)" region="USA"/>
+		<rom name="Bentley Bear's Crystal Quest (World) (NTSC) (Aftermarket) (Unl).a78" size="147456" crc="d44622b3" md5="34483432b92f565f4ced82a141119164" sha1="4a850d4b97bea621e9b6df142afeec8b398d6d6c"/>
 		<url>https://retroachievements.org/game/31170/hashes</url>
 		<hash>34483432b92f565f4ced82a141119164</hash>
 	</game>
 	
-	<game name="DeathMerchant (World) (v1.30) (Digital) (Aftermarket)">
+	<game name="DeathMerchant (World) (v1.30) (Digital) (Aftermarket) (Unl)">
 		<category>Homebrew</category>
-		<description>DeathMerchant (World) (v1.30) (Digital) (Aftermarket)</description>
-		<release name="DeathMerchant (World) (v1.30) (Digital) (Aftermarket)" region="World"/>
-		<rom name="DeathMerchant (World) (v1.30) (Digital) (Aftermarket).a78" size="49280" crc="57adcd6b" md5="596297af60645bf3db97e4c78a21f526" sha1="e01c232f1c51ad1a7f15b0ec5ecc1a47271bc232"/>
+		<description>DeathMerchant (World) (v1.30) (Digital) (Aftermarket) (Unl)</description>
+		<release name="DeathMerchant (World) (v1.30) (Digital) (Aftermarket) (Unl)" region="World"/>
+		<rom name="DeathMerchant (World) (v1.30) (Digital) (Aftermarket) (Unl).a78" size="49280" crc="57adcd6b" md5="596297af60645bf3db97e4c78a21f526" sha1="e01c232f1c51ad1a7f15b0ec5ecc1a47271bc232"/>
 		<url>https://retroachievements.org/game/28950/hashes</url>
 		<hash>fab7b59dd580dce0b28be3e74a7b8433</hash>
 	</game>
 	
-	<game name="Flappy Bird (USA) (Matthias Lüdtke) (Aftermarket)">
+	<game name="Flappy Bird (USA) (Aftermarket) (Matthias Lüdtke)">
 		<category>Homebrew</category>
-		<description>Flappy Bird (USA) (Matthias Lüdtke) (Aftermarket)</description>
-		<release name="Flappy Bird (USA) (Matthias Lüdtke) (Aftermarket)" region="USA"/>
-		<rom name="Flappy Bird (USA) (Matthias Lüdtke) (Aftermarket).a78" size="32896" crc="59812261" md5="6b3c664b4223085f835ef1a6ca346687" sha1="267776f2da752d5b6420252a9176cf430344454f"/>
+		<description>Flappy Bird (USA) (Aftermarket) (Matthias Lüdtke)</description>
+		<release name="Flappy Bird (USA) (Aftermarket) (Matthias Lüdtke)" region="USA"/>
+		<rom name="Flappy Bird (USA) (Aftermarket) (Matthias Lüdtke).a78" size="32896" crc="59812261" md5="6b3c664b4223085f835ef1a6ca346687" sha1="267776f2da752d5b6420252a9176cf430344454f"/>
 		<url>https://retroachievements.org/game/24485/hashes</url>
 		<hash>bac78b53f4f6b3f68c0f8073f0073179</hash>
 	</game>
 	
-	<game name="Knight Guy in Low-Res World - Castle Days (World) (RC1.1) (Aftermarket)">
+	<game name="Knight Guy in Low-Res World - Castle Days (World) (RC1.1) (Aftermarket) (Unl)">
 		<category>Homebrew</category>
-		<description>Knight Guy in Low-Res World - Castle Days (World) (RC1.1) (Aftermarket)</description>
-		<release name="Knight Guy in Low-Res World - Castle Days (World) (RC1.1) (Aftermarket)" region="World"/>
-		<rom name="Knight Guy in Low-Res World - Castle Days (World) (RC1.1) (Aftermarket).a78" size="147584" crc="539e3dd7" md5="95dfe1404d66dc1dc499c8c06171aec3" sha1="31e9ef48c43b06aa96df459b72b75c73eddc7633"/>
+		<description>Knight Guy in Low-Res World - Castle Days (World) (RC1.1) (Aftermarket) (Unl)</description>
+		<release name="Knight Guy in Low-Res World - Castle Days (World) (RC1.1) (Aftermarket) (Unl)" region="World"/>
+		<rom name="Knight Guy in Low-Res World - Castle Days (World) (RC1.1) (Aftermarket) (Unl).a78" size="147584" crc="539e3dd7" md5="95dfe1404d66dc1dc499c8c06171aec3" sha1="31e9ef48c43b06aa96df459b72b75c73eddc7633"/>
 		<url>https://retroachievements.org/game/29938/hashes</url>
 		<hash>33dbb58f9ee73e9f476b4ebbc8190c88</hash>
 	</game>
 	
-	<game name="Meteor Shower (World) (v1.05) (NTSC) (Aftermarket)" cloneof="Meteor Shower (World) (v1.06) (NTSC) (Aftermarket)">
+	<game name="Meteor Shower (World) (v1.05) (NTSC) (Aftermarket) (Unl)" cloneof="Meteor Shower (World) (v1.06) (NTSC) (Aftermarket) (Unl)">
 		<category>Homebrew</category>
-		<description>Meteor Shower (World) (v1.05) (NTSC) (Aftermarket)</description>
-		<rom name="Meteor Shower (World) (v1.05) (NTSC) (Aftermarket).a78" size="16512" crc="8052ccb3" md5="21d1caaeca24e023fad3df23b452b93a" sha1="50f743e617c4456ea5f2f1d66725e63b9359fd41"/>
+		<description>Meteor Shower (World) (v1.05) (NTSC) (Aftermarket) (Unl)</description>
+		<rom name="Meteor Shower (World) (v1.05) (NTSC) (Aftermarket) (Unl).a78" size="16512" crc="8052ccb3" md5="21d1caaeca24e023fad3df23b452b93a" sha1="50f743e617c4456ea5f2f1d66725e63b9359fd41"/>
 		<url>https://retroachievements.org/game/24518/hashes</url>
 		<hash>c3f6201d6a9388e860328c963a3301cc</hash>
 	</game>
-	<game name="Meteor Shower (World) (v1.06) (NTSC) (Aftermarket)">
+	<game name="Meteor Shower (World) (v1.06) (NTSC) (Aftermarket) (Unl)">
 		<category>Homebrew</category>
-		<description>Meteor Shower (World) (v1.06) (NTSC) (Aftermarket)</description>
-		<release name="Meteor Shower (World) (v1.06) (NTSC) (Aftermarket)" region="USA"/>
-		<rom name="Meteor Shower (World) (v1.06) (NTSC) (Aftermarket).a78" size="16384" crc="aa7fc852" md5="a44241d782ee14b53483487cc8216274" sha1="687ffa98659be34bd04e3602a74ed678463549a6"/>
+		<description>Meteor Shower (World) (v1.06) (NTSC) (Aftermarket) (Unl)</description>
+		<release name="Meteor Shower (World) (v1.06) (NTSC) (Aftermarket) (Unl)" region="USA"/>
+		<rom name="Meteor Shower (World) (v1.06) (NTSC) (Aftermarket) (Unl).a78" size="16384" crc="aa7fc852" md5="a44241d782ee14b53483487cc8216274" sha1="687ffa98659be34bd04e3602a74ed678463549a6"/>
 		<url>https://retroachievements.org/game/24518/hashes</url>
 		<hash>a44241d782ee14b53483487cc8216274</hash>
 	</game>
 	
-	<game name="Rikki &amp; Vikki (World) (Aftermarket)">
+	<game name="Rikki &amp; Vikki (World) (R14) (Aftermarket) (Unl)">
 		<category>Homebrew</category>
-		<description>Rikki &amp; Vikki (World) (Aftermarket)</description>
-		<release name="Rikki &amp; Vikki (World) (Aftermarket)" region="World"/>
-		<rom name="Rikki &amp; Vikki (World) (Aftermarket).a78" size="524288" crc="3ea5d821" md5="b3bc889e9cc498636990c5a4d980e85c" sha1="b26d3125a109fed15e380dc32f2e55d84f350450"/>
+		<description>Rikki &amp; Vikki (World) (R14) (Aftermarket) (Unl)</description>
+		<release name="Rikki &amp; Vikki (World) (R14) (Aftermarket) (Unl)" region="World"/>
+		<rom name="Rikki &amp; Vikki (World) (World) (R14) (Aftermarket) (Unl).a78" size="524288" crc="3ea5d821" md5="b3bc889e9cc498636990c5a4d980e85c" sha1="b26d3125a109fed15e380dc32f2e55d84f350450"/>
 		<url>https://retroachievements.org/game/16547/hashes</url>
 		<hash>b3bc889e9cc498636990c5a4d980e85c</hash>
 	</game>
 	
-	<game name="Super Pac-Man (World) (v1.09) (NTSC) (Aftermarket)">
+	<game name="Super Pac-Man (World) (v1.09) (NTSC) (Aftermarket) (Unl)">
 		<category>Homebrew</category>
-		<description>Super Pac-Man (World) (v1.09) (NTSC) (Aftermarket)</description>
-		<release name="Super Pac-Man (World) (v1.09) (NTSC) (Aftermarket)" region="World"/>
-		<rom name="Super Pac-Man (World) (v1.09) (NTSC) (Aftermarket).a78" size="32768" crc="415a28ad" md5="7ab539bb0e99e1e5a1c89230bde64610" sha1="e1c51fa453b8dc600e5d7f46df1443b99a1507d0"/>
+		<description>Super Pac-Man (World) (v1.09) (NTSC) (Aftermarket) (Unl)</description>
+		<release name="Super Pac-Man (World) (v1.09) (NTSC) (Aftermarket) (Unl)" region="World"/>
+		<rom name="Super Pac-Man (World) (v1.09) (NTSC) (Aftermarket) (Unl).a78" size="32768" crc="415a28ad" md5="7ab539bb0e99e1e5a1c89230bde64610" sha1="e1c51fa453b8dc600e5d7f46df1443b99a1507d0"/>
 		<url>https://retroachievements.org/game/31174/hashes</url>
 		<hash>7ab539bb0e99e1e5a1c89230bde64610</hash>
 	</game>
 	
-	<game name="TiME Salvo (USA) (Mike Saarna) (Aftermarket)">
+	<game name="TiME Salvo (USA) (Aftermarket) (Mike Saarna)">
 		<category>Homebrew</category>
-		<description>TiME Salvo (USA) (Mike Saarna) (Aftermarket)</description>
-		<release name="TiME Salvo (USA) (Mike Saarna) (Aftermarket)" region="USA"/>
-		<rom name="TiME Salvo (USA) (Mike Saarna) (Aftermarket).a78" size="49280" crc="99908716" md5="668c10974001dc1b02466bdaaa6c7d2b" sha1="83d24c64ca9def70012c4b3fb50c949ac4ce0560"/>
+		<description>TiME Salvo (USA) (Aftermarket) (Mike Saarna)</description>
+		<release name="TiME Salvo (USA) (Aftermarket) (Mike Saarna)" region="USA"/>
+		<rom name="TiME Salvo (USA) (Aftermarket) (Mike Saarna).a78" size="49280" crc="99908716" md5="668c10974001dc1b02466bdaaa6c7d2b" sha1="83d24c64ca9def70012c4b3fb50c949ac4ce0560"/>
 		<url>https://retroachievements.org/game/16574/hashes</url>
 		<hash>a60e4b608505d1fb201703b266f754a7</hash>
 	</game>
@@ -110,11 +110,11 @@
 		<hash>54af86a45014f0e436bdc5fc6dd03389</hash>
 	</game>
 	
-	<game name="Wordle (World) (v1.07) (Aftermarket)">
+	<game name="Wordle (World) (v1.07) (Aftermarket) (Unl)">
 		<category>Homebrew</category>
-		<description>Wordle (World) (v1.07) (Aftermarket)</description>
-		<release name="Wordle (World) (v1.07) (Aftermarket)" region="World"/>
-		<rom name="Wordle (World) (v1.07) (Aftermarket).a78" size="131200" crc="718e07c5" md5="f71ec2b94f34b9290b70079550be460c" sha1="5d1bfb4f747ac621be1cd85a5663778c15928baf"/>
+		<description>Wordle (World) (v1.07) (Aftermarket) (Unl)</description>
+		<release name="Wordle (World) (v1.07) (Aftermarket) (Unl)" region="World"/>
+		<rom name="Wordle (World) (v1.07) (Aftermarket) (Unl).a78" size="131200" crc="718e07c5" md5="f71ec2b94f34b9290b70079550be460c" sha1="5d1bfb4f747ac621be1cd85a5663778c15928baf"/>
 		<url>https://retroachievements.org/game/24466/hashes</url>
 		<hash>71ce8910b0efd5d0014a9695cce3b7ad</hash>
 	</game>

--- a/DATs/RetroAchievements (No Subfolders)/RA - Atari 7800.dat
+++ b/DATs/RetroAchievements (No Subfolders)/RA - Atari 7800.dat
@@ -58,6 +58,15 @@
 		<hash>33dbb58f9ee73e9f476b4ebbc8190c88</hash>
 	</game>
 	
+	<game name="Lift (World) (v20240711) (Aftermarket) (Inufuto)">
+		<category>Homebrew</category>
+		<description>Lift (World) (v20240711) (Aftermarket) (Inufuto)</description>
+		<release name="Lift (World) (v20240711) (Aftermarket) (Inufuto)" region="World"/>
+		<rom name="Lift (World) (v20240711) (Aftermarket) (Inufuto).a78" size="16512" crc="f7c9c471" md5="61d1c414c835ea9db7daca739043fa64" sha1="6344f9d52010ca54caf00ea9cc5f97c93b4ba107"/>
+		<url>https://retroachievements.org/game/38104/hashes</url>
+		<hash>6765d3723f4256d680d374327f9aa42c</hash>
+	</game>
+	
 	<game name="Meteor Shower (World) (v1.05) (NTSC) (Aftermarket) (Unl)" cloneof="Meteor Shower (World) (v1.06) (NTSC) (Aftermarket) (Unl)">
 		<category>Homebrew</category>
 		<description>Meteor Shower (World) (v1.05) (NTSC) (Aftermarket) (Unl)</description>
@@ -287,6 +296,15 @@
 		<rom name="Kung-Fu Master (USA).a78" size="32768" crc="297899bb" md5="f57d0af323d4e173fb49ed447f0563d7" sha1="8824bffdf4f30a8191e581752a75259a663092ca"/>
 		<url>https://retroachievements.org/game/16945/hashes</url>
 		<hash>f57d0af323d4e173fb49ed447f0563d7</hash>
+	</game>
+	
+	<game name="Mario Bros. (USA)">
+		<category>Retail</category>
+		<description>Mario Bros. (USA)</description>
+		<release name="Mario Bros. (USA)" region="USA"/>
+		<rom name="Mario Bros. (USA).a78" size="49152" crc="8021a13b" md5="431ca060201ee1f9eb49d44962874049" sha1="12e04b67094af622641c536379c69ecad2ee98ed"/>
+		<url>https://retroachievements.org/game/13366/hashes</url>
+		<hash>431ca060201ee1f9eb49d44962874049</hash>
 	</game>
 	
 	<game name="Mean 18 Ultimate Golf (USA)">

--- a/DATs/RetroAchievements (No Subfolders)/RA - Atari Jaguar CD.dat
+++ b/DATs/RetroAchievements (No Subfolders)/RA - Atari Jaguar CD.dat
@@ -5,8 +5,8 @@
 		<name>RA - Atari Jaguar CD</name>
 		<description>Atari Jaguar CD</description>
 		<category>No Subfolders</category>
-		<version>20251225</version>
-		<date>25 December 2025</date>
+		<version>20260417</version>
+		<date>17 April 2026</date>
 		<author>AzgoRAth, NeoRetroGamer (Contributor), Jumphil (Contributor)</author>
 		<homepage>https://retroachievements.org</homepage>
 		<url>https://retroachievements.org/system/77/games</url>

--- a/DATs/RetroAchievements (No Subfolders)/RA - Atari Jaguar CD.dat
+++ b/DATs/RetroAchievements (No Subfolders)/RA - Atari Jaguar CD.dat
@@ -15,72 +15,72 @@
 		<clrmamepro forcepacking="unzip"/>
 		<romvault forcepacking="unzip"/>
 	</header>
-	<game name="Home Run Derby (World) (v2.0) (MGNS8M) (Demo) (Aftermarket)">
+	<game name="Home Run Derby (World) (v2.0) (Aftermarket) (Unl) (MGNS8M)">
 		<category>Homebrew</category>
-		<description>Home Run Derby (World) (v2.0) (MGNS8M) (Demo) (Aftermarket)</description>
-		<release name="Home Run Derby (World) (v2.0) (MGNS8M) (Demo) (Aftermarket)" region="World"/>
-		<rom name="Home Run Derby (World) (v2.0) (MGNS8M) (Demo) (Aftermarket).cdi" size="16334440" crc="37dcea03" md5="82aede01ec23dd9f4a8c9131c439a6c8" sha1="5934c163cde32b46f531413b26c009a4c8dc9e2f"/>
+		<description>Home Run Derby (World) (v2.0) (Aftermarket) (Unl) (MGNS8M)</description>
+		<release name="Home Run Derby (World) (v2.0) (Aftermarket) (Unl) (MGNS8M)" region="World"/>
+		<rom name="Home Run Derby (World) (v2.0) (Aftermarket) (Unl) (MGNS8M).cdi" size="16334440" crc="37dcea03" md5="82aede01ec23dd9f4a8c9131c439a6c8" sha1="5934c163cde32b46f531413b26c009a4c8dc9e2f"/>
 		<url>https://retroachievements.org/game/26665/hashes</url>
 		<hash>bc696313d459a3829c209c81a04e5f6a</hash>
 	</game>
-	<game name="Home Run Derby (World) (v1.0) (MGNS8M) (Demo) (Aftermarket)" cloneof="Home Run Derby (World) (v2.0) (MGNS8M) (Demo) (Aftermarket)">
+	<game name="Home Run Derby (World) (v1.0) (Aftermarket) (Unl) (MGNS8M)" cloneof="Home Run Derby (World) (v2.0) (Aftermarket) (Unl) (MGNS8M)">
 		<category>Homebrew</category>
-		<description>Home Run Derby (World) (v1.0) (MGNS8M) (Demo) (Aftermarket)</description>
-		<rom name="Home Run Derby (World) (v1.0) (MGNS8M) (Demo) (Aftermarket).cdi" size="16334440" crc="5df9cee0" md5="8a202ef9ce960d36232ca00bd8dd0e5e" sha1="50ce7774a4df542b251f850a50f9611e867cf518"/>
+		<description>Home Run Derby (World) (v1.0) (Aftermarket) (Unl) (MGNS8M)</description>
+		<rom name="Home Run Derby (World) (v1.0) (Aftermarket) (Unl) (MGNS8M).cdi" size="16334440" crc="5df9cee0" md5="8a202ef9ce960d36232ca00bd8dd0e5e" sha1="50ce7774a4df542b251f850a50f9611e867cf518"/>
 		<url>https://retroachievements.org/game/26665/hashes</url>
 		<hash>89c1de1195d7f25bda63875201445f25</hash>
 	</game>
 	
-	<game name="Alice's Mom's Rescue (World) (OrionSoft) (Aftermarket)">
+	<game name="Alice's Mom's Rescue (World) (Aftermarket) (Unl) (OrionSoft)">
 		<category>Homebrew</category>
-		<description>Alice's Mom's Rescue (World) (OrionSoft) (Aftermarket)</description>
-		<release name="Alice's Mom's Rescue (World) (OrionSoft) (Aftermarket)" region="World"/>
-		<rom name="Alice's Mom's Rescue (World) (OrionSoft) (Aftermarket).cdi" size="40635552" crc="6129069f" md5="a1c193c1cfd73378835851bf88f0d79a" sha1="5b72dff04d71a85776e50c3b5c4829f7c9835bed"/>
+		<description>Alice's Mom's Rescue (World) (Aftermarket) (Unl) (OrionSoft)</description>
+		<release name="Alice's Mom's Rescue (World) (Aftermarket) (Unl) (OrionSoft)" region="World"/>
+		<rom name="Alice's Mom's Rescue (World) (Aftermarket) (Unl) (OrionSoft).cdi" size="40635552" crc="6129069f" md5="a1c193c1cfd73378835851bf88f0d79a" sha1="5b72dff04d71a85776e50c3b5c4829f7c9835bed"/>
 		<url>https://retroachievements.org/game/22942/hashes</url>
 		<hash>7a3837f8d61c7e60d09e7e3864195c0b</hash>
 	</game>
 	
-	<game name="Downfall (World) (Reboot) (Aftermarket)">
+	<game name="Downfall (World) (Aftermarket) (Unl) (Reboot)">
 		<category>Homebrew</category>
-		<description>Downfall (World) (Reboot) (Aftermarket)</description>
-		<release name="Downfall (World) (Reboot) (Aftermarket)" region="World"/>
-		<rom name="Downfall (World) (Reboot) (Aftermarket).cdi" size="16334440" crc="8bed0f08" md5="51a69397824d347e67ec8f0efc69f6f5" sha1="bb3f3205853263b9929a28ef19844f9462953acd"/>
+		<description>Downfall (World) (Aftermarket) (Unl) (Reboot)</description>
+		<release name="Downfall (World) (Aftermarket) (Unl) (Reboot)" region="World"/>
+		<rom name="Downfall (World) (Aftermarket) (Unl) (Reboot).cdi" size="16334440" crc="8bed0f08" md5="51a69397824d347e67ec8f0efc69f6f5" sha1="bb3f3205853263b9929a28ef19844f9462953acd"/>
 		<url>https://retroachievements.org/game/24459/hashes</url>
 		<hash>ef4b4b04e5857bb172e5dc804f075ea1</hash>
 	</game>
 	
-	<game name="Elansar (World) (OrionSoft) (Aftermarket)">
+	<game name="Elansar (World) (Aftermarket) (Unl) (OrionSoft)">
 		<category>Homebrew</category>
-		<description>Elansar (World) (OrionSoft) (Aftermarket)</description>
-		<release name="Elansar (World) (OrionSoft) (Aftermarket)" region="World"/>
-		<rom name="Elansar (World) (OrionSoft) (Aftermarket).cdi" size="52705749" crc="7f5723e2" md5="efccb8ad7c1c395e4aecd9e653348173" sha1="47591e96a7ca152d2f851050ebfa0d2e1a81c269"/>
+		<description>Elansar (World) (Aftermarket) (Unl) (OrionSoft)</description>
+		<release name="Elansar (World) (Aftermarket) (Unl) (OrionSoft)" region="World"/>
+		<rom name="Elansar (World) (Aftermarket) (Unl) (OrionSoft).cdi" size="52705749" crc="7f5723e2" md5="efccb8ad7c1c395e4aecd9e653348173" sha1="47591e96a7ca152d2f851050ebfa0d2e1a81c269"/>
 		<url>https://retroachievements.org/game/24515/hashes</url>
 		<hash>87a5b4eecd0b5ebd56a44d924fa54077</hash>
 	</game>
 
-	<game name="Full Circle - Rocketeer (World) (Promo) (Reboot) (Aftermarket)">
+	<game name="Full Circle - Rocketeer (World) (Promo) (Aftermarket) (Unl) (Reboot)">
 		<category>Homebrew</category>
-		<description>Full Circle - Rocketeer (World) (Promo) (Reboot) (Aftermarket)</description>
-		<release name="Full Circle - Rocketeer (World) (Promo) (Reboot) (Aftermarket)" region="World"/>
-		<rom name="Full Circle - Rocketeer (World) (Promo) (Reboot) (Aftermarket).cdi" size="16334440" crc="67b0c629" md5="651f6076fe47024f1e64944ab27b8ff7" sha1="75f0fe79d6662e96fc2b56983f7cbea40e07d2d7"/>
+		<description>Full Circle - Rocketeer (World) (Promo) (Aftermarket) (Unl) (Reboot)</description>
+		<release name="Full Circle - Rocketeer (World) (Promo) (Aftermarket) (Unl) (Reboot)" region="World"/>
+		<rom name="Full Circle - Rocketeer (World) (Promo) (Aftermarket) (Unl) (Reboot).cdi" size="16334440" crc="67b0c629" md5="651f6076fe47024f1e64944ab27b8ff7" sha1="75f0fe79d6662e96fc2b56983f7cbea40e07d2d7"/>
 		<url>https://retroachievements.org/game/24462/hashes</url>
 		<hash>97f5012d44f6332ad2e3c020715787b7</hash>
 	</game>
 
-	<game name="Jagmatch (World) (Sebastian Mihai) (Aftermarket)">
+	<game name="Jagmatch (World) (Aftermarket) (Unl) (Sebastian Mihai)">
 		<category>Homebrew</category>
-		<description>Jagmatch (World) (Sebastian Mihai) (Aftermarket)</description>
-		<release name="Jagmatch (World) (Sebastian Mihai) (Aftermarket)" region="World"/>
-		<rom name="Jagmatch (World) (Sebastian Mihai) (Aftermarket).cdi" size="16334440" crc="ee114035" md5="7f7eb633f7415703b83620af49449bed" sha1="8254706690c7bf411973f3894e0430aff0dde2a5"/>
+		<description>Jagmatch (World) (Aftermarket) (Unl) (Sebastian Mihai)</description>
+		<release name="Jagmatch (World) (Aftermarket) (Unl) (Sebastian Mihai)" region="World"/>
+		<rom name="Jagmatch (World) (Aftermarket) (Unl) (Sebastian Mihai).cdi" size="16334440" crc="ee114035" md5="7f7eb633f7415703b83620af49449bed" sha1="8254706690c7bf411973f3894e0430aff0dde2a5"/>
 		<url>https://retroachievements.org/game/24304/hashes</url>
 		<hash>b406a7402a14c406e26aa21f4e4b8817</hash>
 	</game>
 	
-	<game name="Kobayashi Maru (World) (Promo-Final) (Reboot) (Aftermarket)">
+	<game name="Kobayashi Maru (World) (Promo-Final) (Aftermarket) (Unl) (Reboot)">
 		<category>Homebrew</category>
-		<description>Kobayashi Maru (World) (Promo-Final) (Reboot) (Aftermarket)</description>
-		<release name="Kobayashi Maru (World) (Promo-Final) (Reboot) (Aftermarket)" region="World"/>
-		<rom name="Kobayashi Maru (World) (Promo-Final) (Reboot) (Aftermarket).cdi" size="16334440" crc="efbbe60b" md5="e796fc84fdb4f4b2e5ea94c98a83bd51" sha1="188d60d8ced4440a93bde68990d31853e97a59bb"/>
+		<description>Kobayashi Maru (World) (Promo-Final) (Aftermarket) (Unl) (Reboot)</description>
+		<release name="Kobayashi Maru (World) (Promo-Final) (Aftermarket) (Unl) (Reboot)" region="World"/>
+		<rom name="Kobayashi Maru (World) (Promo-Final) (Aftermarket) (Unl) (Reboot).cdi" size="16334440" crc="efbbe60b" md5="e796fc84fdb4f4b2e5ea94c98a83bd51" sha1="188d60d8ced4440a93bde68990d31853e97a59bb"/>
 		<url>https://retroachievements.org/game/24385/hashes</url>
 		<hash>1afcfa7cc6565e8b774ac2556ce8d8ca</hash>
 	</game>
@@ -99,11 +99,11 @@
 		<hash>D19987D55D2B0AA6D0FF82EF9D859341</hash>
 	</game>
 	
-	<game name="SuperFly DX (World) (v1.1) (Reboot) (Aftermarket)">
+	<game name="SuperFly DX (World) (v1.1) (Aftermarket) (Unl) (Reboot)">
 		<category>Homebrew</category>
-		<description>SuperFly DX (World) (v1.1) (Reboot) (Aftermarket)</description>
-		<release name="SuperFly DX (World) (v1.1) (Reboot) (Aftermarket)" region="World"/>
-		<rom name="SuperFly DX (World) (v1.1) (Reboot) (Aftermarket).cdi" size="16334440" crc="6abbf100" md5="dd749830a6e7447f23a7f1f3a85803d3" sha1="7cf73aa7420bf8837aae735ec777bb2a0a2d8852"/>
+		<description>SuperFly DX (World) (v1.1) (Aftermarket) (Unl) (Reboot)</description>
+		<release name="SuperFly DX (World) (v1.1) (Aftermarket) (Unl) (Reboot)" region="World"/>
+		<rom name="SuperFly DX (World) (v1.1) (Aftermarket) (Unl) (Reboot).cdi" size="16334440" crc="6abbf100" md5="dd749830a6e7447f23a7f1f3a85803d3" sha1="7cf73aa7420bf8837aae735ec777bb2a0a2d8852"/>
 		<url>https://retroachievements.org/game/24088/hashes</url>
 		<hash>b7a6ddb06827fc8cbaa3fee0369e6fda</hash>
 	</game>

--- a/DATs/RetroAchievements (No Subfolders)/RA - Atari Jaguar.dat
+++ b/DATs/RetroAchievements (No Subfolders)/RA - Atari Jaguar.dat
@@ -13,50 +13,50 @@
 		<titlecount>20</titlecount>
 		<hashcount>20</hashcount>
 	</header>
-	<game name="OSMOZYS (World) (Demo) (Aftermarket)">
+	<game name="OSMOZYS (World) (Demo) (Aftermarket) (Unl)">
 		<category>Homebrew</category>
-		<description>OSMOZYS (World) (Demo) (Aftermarket)</description>
-		<rom name="OSMOZYS (World) (Demo) (Aftermarket).j64" size="2097152" crc="3463527f" md5="985bd1236c3c416381240fb537e86536" sha1="d9626311fe481b1bdb22de9b750e122061412a20"/>
+		<description>OSMOZYS (World) (Demo) (Aftermarket) (Unl)</description>
+		<rom name="OSMOZYS (World) (Demo) (Aftermarket) (Unl).j64" size="2097152" crc="3463527f" md5="985bd1236c3c416381240fb537e86536" sha1="d9626311fe481b1bdb22de9b750e122061412a20"/>
 		<url>https://retroachievements.org/game/20427/hashes</url>
 		<hash>985bd1236c3c416381240fb537e86536</hash>
 	</game>
 	
-	<game name="Star Fighter (USA) (Demo) (Gedalya) (Aftermarket)">
+	<game name="Star Fighter (USA) (Demo) (Aftermarket) (Gedalya)">
 		<category>Homebrew</category>
-		<description>Star Fighter (USA) (Demo) (Gedalya) (Aftermarket)</description>
-		<rom name="Star Fighter (USA) (Demo) (Gedalya) (Aftermarket).j64" size="4194304" crc="832bf4ca" md5="a5767fc6c628759a5b6ba99874ff8bc4" sha1="193edcd6f0bf0524f012c60e73e6f7f9ad9a2fc7"/>
+		<description>Star Fighter (USA) (Demo) (Aftermarket) (Gedalya)</description>
+		<rom name="Star Fighter (USA) (Demo) (Aftermarket) (Gedalya).j64" size="4194304" crc="832bf4ca" md5="a5767fc6c628759a5b6ba99874ff8bc4" sha1="193edcd6f0bf0524f012c60e73e6f7f9ad9a2fc7"/>
 		<url>https://retroachievements.org/game/27930/hashes</url>
 		<hash>a5767fc6c628759a5b6ba99874ff8bc4</hash>
 	</game>
 	
-	<game name="Alice's Mom's Rescue (World) (En,Fr,De,Es,It) (Aftermarket)">
+	<game name="Alice's Mom's Rescue (World) (En,Fr,De,Es,It) (Aftermarket) (Unl)">
 		<category>Homebrew</category>
-		<description>Alice's Mom's Rescue (World) (En,Fr,De,Es,It) (Aftermarket)</description>
-		<rom name="Alice's Mom's Rescue (World) (En,Fr,De,Es,It) (Aftermarket).j64" size="4194304" crc="d47bb973" md5="4d18fba4b15fda9e5ed96f4f18427a2d" sha1="e09c3447e61791f514ffddec1cd47d1fcb7f1fa8"/>
+		<description>Alice's Mom's Rescue (World) (En,Fr,De,Es,It) (Aftermarket) (Unl)</description>
+		<rom name="Alice's Mom's Rescue (World) (En,Fr,De,Es,It) (Aftermarket) (Unl).j64" size="4194304" crc="d47bb973" md5="4d18fba4b15fda9e5ed96f4f18427a2d" sha1="e09c3447e61791f514ffddec1cd47d1fcb7f1fa8"/>
 		<url>https://retroachievements.org/game/24630/hashes</url>
 		<hash>4d18fba4b15fda9e5ed96f4f18427a2d</hash>
 	</game>
 	
-	<game name="Black Out! (World) (Aftermarket)">
+	<game name="Black Out! (World) (Aftermarket) (Unl)">
 		<category>Homebrew</category>
-		<description>Black Out! (World) (Aftermarket)</description>
-		<rom name="Black Out! (World) (Aftermarket).j64" size="1963132" crc="2e793832" md5="f3f81e5c5ab19410d683d11d1cbb85f2" sha1="318fc3e305449535ff7a3cffe2445ed47c1e3ac3"/>
+		<description>Black Out! (World) (Aftermarket) (Unl)</description>
+		<rom name="Black Out! (World) (Aftermarket) (Unl).j64" size="1963132" crc="2e793832" md5="f3f81e5c5ab19410d683d11d1cbb85f2" sha1="318fc3e305449535ff7a3cffe2445ed47c1e3ac3"/>
 		<url>https://retroachievements.org/game/20634/hashes</url>
 		<hash>f3f81e5c5ab19410d683d11d1cbb85f2</hash>
 	</game>
 	
-	<game name="Downfall (World) (Aftermarket)">
+	<game name="Downfall (World) (Aftermarket) (Unl)">
 		<category>Homebrew</category>
-		<description>Downfall (World) (Aftermarket)</description>
-		<rom name="Downfall (World) (Aftermarket).j64" size="2097152" crc="acfceabd" md5="4206ec6abeee07b9525fdda9925f3e55" sha1="8939ba84cf27e7c4bc659f6d61c07c5b03ccdc9d"/>
+		<description>Downfall (World) (Aftermarket) (Unl)</description>
+		<rom name="Downfall (World) (Aftermarket) (Unl).j64" size="2097152" crc="acfceabd" md5="4206ec6abeee07b9525fdda9925f3e55" sha1="8939ba84cf27e7c4bc659f6d61c07c5b03ccdc9d"/>
 		<url>https://retroachievements.org/game/22522/hashes</url>
 		<hash>4206ec6abeee07b9525fdda9925f3e55</hash>
 	</game>
 	
-	<game name="Frog Feast (World) (Aftermarket)">
+	<game name="Frog Feast (World) (Aftermarket) (Unl)">
     	<category>Homebrew</category>
-		<description>Frog Feast (World) (Aftermarket)</description>
-    	<rom name="Frog Feast (World) (Aftermarket).j64" size="1048576" crc="6038e95f" md5="54af14494cb3b9d584adcbd2d1a5216e" sha1="5b2295907f6fdadf5f44b1e392dcd6f5471fd095"/>
+		<description>Frog Feast (World) (Aftermarket) (Unl)</description>
+    	<rom name="Frog Feast (World) (Aftermarket) (Unl).j64" size="1048576" crc="6038e95f" md5="54af14494cb3b9d584adcbd2d1a5216e" sha1="5b2295907f6fdadf5f44b1e392dcd6f5471fd095"/>
     	<url>https://retroachievements.org/game/16892/hashes</url>
 		<hash>54af14494cb3b9d584adcbd2d1a5216e</hash>
 	</game>
@@ -173,10 +173,10 @@
 		<hash>5f2115d0bdcae4f3aa8e832f23f4ebdd</hash>
 	</game>
 	
-	<game name="Zero 5 (World) (Aftermarket)">
+	<game name="Zero 5 (World) (Aftermarket) (Unl)">
 		<category>Retail</category>
-		<description>Zero 5 (World) (Aftermarket)</description>
-		<rom name="Zero 5 (World) (Aftermarket).j64" size="2097152" crc="61c7eec0" md5="08b31fae8cbd44ac65d44baf1a0545a2" sha1="b68de2cd49cb70e92f2415837edfa7ab46770a78"/>
+		<description>Zero 5 (World) (Aftermarket) (Unl)</description>
+		<rom name="Zero 5 (World) (Aftermarket) (Unl).j64" size="2097152" crc="61c7eec0" md5="08b31fae8cbd44ac65d44baf1a0545a2" sha1="b68de2cd49cb70e92f2415837edfa7ab46770a78"/>
 		<url>https://retroachievements.org/game/16922/hashes</url>
 		<hash>08b31fae8cbd44ac65d44baf1a0545a2</hash>
 	</game>

--- a/DATs/RetroAchievements (No Subfolders)/RA - Atari Jaguar.dat
+++ b/DATs/RetroAchievements (No Subfolders)/RA - Atari Jaguar.dat
@@ -5,8 +5,8 @@
 		<name>RA - Atari Jaguar</name>
 		<description>Atari Jaguar</description>
 		<category>No Subfolders</category>
-		<version>20251225</version>
-		<date>25 December 2025</date>
+		<version>20260417</version>
+		<date>17 April 2026</date>
 		<author>AzgoRAth, NeoRetroGamer (Contributor), Jumphil (Contributor)</author>
 		<homepage>https://retroachievements.org</homepage>
 		<url>https://retroachievements.org/system/17/games</url>

--- a/DATs/RetroAchievements (No Subfolders)/RA - Atari Lynx.dat
+++ b/DATs/RetroAchievements (No Subfolders)/RA - Atari Lynx.dat
@@ -295,6 +295,16 @@
 		<hash>c9ed2a3bdefd6d5fdf67302d87b5cfb2</hash>
 	</game>
 	
+	<game name="Pac-Land (USA, Europe)">
+		<category>Retail</category>
+		<description>Pac-Land (USA, Europe)</description>
+		<release name="Pac-Land (USA, Europe)" region="Europe"/>
+		<release name="Pac-Land (USA, Europe)" region="USA"/>
+		<rom name="Pac-Land (USA, Europe).lyx" size="131072" crc="aa50dd22" md5="0a14754b351b4f11a1359e252b8eb992" sha1="58b57835703e3145a54e1c0ada38c9218bf4cd3d"/>
+		<url>https://retroachievements.org/game/10600/hashes</url>
+		<hash>0a14754b351b4f11a1359e252b8eb992</hash>
+	</game>
+	
 	<game name="Pinball Jam (USA, Europe)">
 		<category>Retail</category>
 		<description>Pinball Jam (USA, Europe)</description>

--- a/DATs/RetroAchievements (No Subfolders)/RA - Atari Lynx.dat
+++ b/DATs/RetroAchievements (No Subfolders)/RA - Atari Lynx.dat
@@ -5,8 +5,8 @@
 		<name>RA - Atari Lynx</name>
 		<description>Atari Lynx</description>
 		<category>No Subfolders</category>
-		<version>20260208</version>
-		<date>08 February 2026</date>
+		<version>20260417</version>
+		<date>17 April 2026</date>
 		<author>AzgoRAth, NeoRetroGamer (Contributor), Jumphil (Contributor)</author>
 		<homepage>https://retroachievements.org</homepage>
 		<url>https://retroachievements.org/system/13/games</url>

--- a/DATs/RetroAchievements (No Subfolders)/RA - Atari Lynx.dat
+++ b/DATs/RetroAchievements (No Subfolders)/RA - Atari Lynx.dat
@@ -13,81 +13,81 @@
 		<titlecount>39</titlecount>
 		<hashcount>40</hashcount>
 	</header>
-	<game name="CHIP-8 Emulator (World) (Aftermarket)">
+	<game name="CHIP-8 Emulator (World) (Aftermarket) (Unl)">
 		<category>Homebrew</category>
-		<description>CHIP-8 Emulator (World) (Aftermarket)</description>
-		<release name="CHIP-8 Emulator (World) (Aftermarket)" region="World"/>
-		<rom name="CHIP-8 Emulator (World) (Aftermarket).lyx" size="23511" crc="ed70fbcc" md5="3d4c70cba51a5c1f0e2fc3c1acb4be50" sha1="27e4cf003e98bc8a66c3627976b18e33fa820b12"/>
+		<description>CHIP-8 Emulator (World) (Aftermarket) (Unl)</description>
+		<release name="CHIP-8 Emulator (World) (Aftermarket) (Unl)" region="World"/>
+		<rom name="CHIP-8 Emulator (World) (Aftermarket) (Unl).lyx" size="23511" crc="ed70fbcc" md5="3d4c70cba51a5c1f0e2fc3c1acb4be50" sha1="27e4cf003e98bc8a66c3627976b18e33fa820b12"/>
 		<url>https://retroachievements.org/game/25950/hashes</url>
 		<hash>3d4c70cba51a5c1f0e2fc3c1acb4be50</hash>
 	</game>
 	
-	<game name="Flappy Bird (86) (World) (tonma) (Aftermarket)">
+	<game name="Flappy Bird (86) (World) (Aftermarket) (tonma)">
 		<category>Homebrew</category>
-		<description>Flappy Bird (86) (World) (tonma) (Aftermarket)</description>
-		<release name="Flappy Bird (86) (World) (tonma) (Aftermarket)" region="World"/>
-		<rom name="Flappy Bird (86) (World) (tonma) (Aftermarket).lyx" size="32111" crc="c61f1606" md5="85e80cae6da0cbced0d409a48a49c33e" sha1="eae69daddb1a9de53fc45755af135dd25d185c2a"/>
+		<description>Flappy Bird (86) (World) (Aftermarket) (tonma)</description>
+		<release name="Flappy Bird (86) (World) (Aftermarket) (tonma)" region="World"/>
+		<rom name="Flappy Bird (86) (World) (Aftermarket) (tonma).lyx" size="32111" crc="c61f1606" md5="85e80cae6da0cbced0d409a48a49c33e" sha1="eae69daddb1a9de53fc45755af135dd25d185c2a"/>
 		<url>https://retroachievements.org/game/19508/hashes</url>
 		<hash>0173ec92e8e8a0359901f310c5f12bb1</hash>
 	</game>
-	<game name="Flappy Bird (EE) (World) (tonma) (Aftermarket)" cloneof="Flappy Bird (86) (World) (tonma) (Aftermarket)">
+	<game name="Flappy Bird (EE) (World) (Aftermarket) (tonma)" cloneof="Flappy Bird (86) (World) (Aftermarket) (tonma)">
 		<category>Homebrew</category>
-		<description>Flappy Bird (EE) (World) (tonma) (Aftermarket)</description>
-		<rom name="Flappy Bird (EE) (World) (tonma) (Aftermarket).lyx" size="32073" crc="e6787336" md5="84d02bc4f902462f654216007a379fbb" sha1="da3ca5809a475f70a2275ceac43198f98dbe0b79"/>
+		<description>Flappy Bird (EE) (World) (Aftermarket) (tonma)</description>
+		<rom name="Flappy Bird (EE) (World) (Aftermarket) (tonma).lyx" size="32073" crc="e6787336" md5="84d02bc4f902462f654216007a379fbb" sha1="da3ca5809a475f70a2275ceac43198f98dbe0b79"/>
 		<url>https://retroachievements.org/game/19508/hashes</url>
 		<hash>8f05d2ffdadffdbce7a1040a9aa0f8e7</hash>
 	</game>
 	
-	<game name="Critter Championship (World) (Aftermarket)">
+	<game name="Critter Championship (World) (Demo) (Aftermarket) (Unl)">
 		<category>Homebrew</category>
-		<description>Critter Championship (World) (Aftermarket)</description>
-		<release name="Critter Championship (World) (Aftermarket)" region="World"/>
-		<rom name="Critter Championship (World) (Aftermarket).lnx" size="82289" crc="1785665b" md5="e138c8c988b6ed948e33af73eae1764f" sha1="c3399a6ac822ff3de2659de5894df505a08e7a90"/>
+		<description>Critter Championship (World) (Demo) (Aftermarket) (Unl)</description>
+		<release name="Critter Championship (World) (Demo) (Aftermarket) (Unl)" region="World"/>
+		<rom name="Critter Championship (World) (Demo) (Aftermarket) (Unl).lnx" size="82289" crc="1785665b" md5="e138c8c988b6ed948e33af73eae1764f" sha1="c3399a6ac822ff3de2659de5894df505a08e7a90"/>
 		<url>https://retroachievements.org/game/19715/hashes</url>
 		<hash>757852d987db4cc79a1a81eadc9dd821</hash>
 	</game>
 	
-	<game name="Running Knight (World) (LynxJam 2023) (Dr. Ludos) (Aftermarket)">
+	<game name="Running Knight (World) (LynxJam 2023) (Aftermarket) (Unl) (Dr. Ludos)">
 		<category>Homebrew</category>
-		<description>Running Knight (World) (LynxJam 2023) (Dr. Ludos) (Aftermarket)</description>
-		<release name="Running Knight (World) (LynxJam 2023) (Dr. Ludos) (Aftermarket)" region="World"/>
-		<rom name="Running Knight (World) (LynxJam 2023) (Dr. Ludos) (Aftermarket).lnx" size="262208" crc="482719d8" md5="f3663cf094ca1ab6883d6b3c03e7429d" sha1="f826cecb0e2ddc3620d6509b821591aa11d0ec4e"/>
+		<description>Running Knight (World) (LynxJam 2023) (Aftermarket) (Unl) (Dr. Ludos)</description>
+		<release name="Running Knight (World) (LynxJam 2023) (Aftermarket) (Unl) (Dr. Ludos)" region="World"/>
+		<rom name="Running Knight (World) (LynxJam 2023) (Aftermarket) (Unl) (Dr. Ludos).lnx" size="262208" crc="482719d8" md5="f3663cf094ca1ab6883d6b3c03e7429d" sha1="f826cecb0e2ddc3620d6509b821591aa11d0ec4e"/>
 		<url>https://retroachievements.org/game/29053/hashes</url>
 		<hash>24077ab7bf46300ff02aa4ca78a81c2c</hash>
 	</game>
 	
-	<game name="Scooternia (World) (Aftermarket)">
+	<game name="Scooternia (World) (Demo) (Aftermarket) (Unl)">
 		<category>Homebrew</category>
-		<description>Scooternia (World) (Aftermarket)</description>
-		<release name="Scooternia (World) (Aftermarket)" region="World"/>
-		<rom name="Scooternia (World) (Aftermarket).lyx" size="262144" crc="7606dcac" md5="459aaf1e66384ea3534e3ce2149a1718" sha1="93e228f35b5b38f1d5bfac0fbb934ea5fbc98263"/>
+		<description>Scooternia (World) (Demo) (Aftermarket) (Unl)</description>
+		<release name="Scooternia (World) (Demo) (Aftermarket) (Unl)" region="World"/>
+		<rom name="Scooternia (World) (Demo) (Aftermarket) (Unl).lyx" size="262144" crc="7606dcac" md5="459aaf1e66384ea3534e3ce2149a1718" sha1="93e228f35b5b38f1d5bfac0fbb934ea5fbc98263"/>
 		<url>https://retroachievements.org/game/24300/hashes</url>
 		<hash>459aaf1e66384ea3534e3ce2149a1718</hash>
 	</game>
 	
-	<game name="T-Tris (World) (Alt) (Aftermarket)">
+	<game name="T-Tris (World) (Pirate) (Alt)">
 		<category>Homebrew</category>
-		<description>T-Tris (World) (Alt) (Aftermarket)</description>
-		<release name="T-Tris (World) (Alt) (Aftermarket)" region="World"/>
-		<rom name="T-Tris (World) (Alt) (Aftermarket).bll" size="15700" crc="a261fcbc" md5="1b6a8a0b7f80332e9c7dfecaded8683e" sha1="d337d0b38e22f42c92691ad2a80d48125d908b7f"/>
+		<description>T-Tris (World) (Pirate) (Alt)</description>
+		<release name="T-Tris (World) (Pirate) (Alt)" region="World"/>
+		<rom name="T-Tris (World) (Pirate) (Alt).bll" size="15700" crc="a261fcbc" md5="1b6a8a0b7f80332e9c7dfecaded8683e" sha1="d337d0b38e22f42c92691ad2a80d48125d908b7f"/>
 		<url>https://retroachievements.org/game/24898/hashes</url>
 		<hash>1b6a8a0b7f80332e9c7dfecaded8683e</hash>
 	</game>
 	
-	<game name="Timeloop (World) (Aftermarket)">
+	<game name="Timeloop (World) (Aftermarket) (Unl)">
 		<category>Homebrew</category>
-		<description>Timeloop (World) (Aftermarket)</description>
-		<release name="Timeloop (World) (Aftermarket)" region="World"/>
-		<rom name="Timeloop (World) (Aftermarket).lnx" size="262208" crc="5508e5f5" md5="dc0919e6666a61b11a0f904b543a7518" sha1="7c30f02e6a908b1c93e8251e0ed3f96234ebe72f"/>
+		<description>Timeloop (World) (Aftermarket) (Unl)</description>
+		<release name="Timeloop (World) (Aftermarket) (Unl)" region="World"/>
+		<rom name="Timeloop (World) (Aftermarket) (Unl).lnx" size="262208" crc="5508e5f5" md5="dc0919e6666a61b11a0f904b543a7518" sha1="7c30f02e6a908b1c93e8251e0ed3f96234ebe72f"/>
 		<url>https://retroachievements.org/game/27007/hashes</url>
 		<hash>749f3e82357bab232731f0e56f97569c</hash>
 	</game>
 	
-	<game name="Z.A.P. (World) (Aftermarket)">
+	<game name="Z.A.P. (World) (Aftermarket) (Unl)">
 		<category>Homebrew</category>
-		<description>Z.A.P. (World) (Aftermarket)</description>
-		<release name="Z.A.P. (World) (Aftermarket)" region="World"/>
-		<rom name="Z.A.P. (World) (Aftermarket).lnx" size="24873" crc="6b51794e" md5="fb84478cb62f47c0773996515ada47c9" sha1="7cd0c413e12c812fdb6476f7ed661111fe90bec1"/>
+		<description>Z.A.P. (World) (Aftermarket) (Unl)</description>
+		<release name="Z.A.P. (World) (Aftermarket) (Unl)" region="World"/>
+		<rom name="Z.A.P. (World) (Aftermarket) (Unl).lnx" size="24873" crc="6b51794e" md5="fb84478cb62f47c0773996515ada47c9" sha1="7cd0c413e12c812fdb6476f7ed661111fe90bec1"/>
 		<url>https://retroachievements.org/game/19714/hashes</url>
 		<hash>d5079e2e6e1ad9c2b730e47c240a4da0</hash>
 	</game>
@@ -257,11 +257,11 @@
 		<hash>e5e42190918847b8c6056e78316ee91d</hash>
 	</game>
 	
-	<game name="Lexis (World) (Aftermarket)">
+	<game name="Lexis (World) (Aftermarket) (Unl)">
 		<category>Retail</category>
-		<description>Lexis (World) (Aftermarket)</description>
-		<release name="Lexis (World) (Aftermarket)" region="World"/>
-		<rom name="Lexis (World) (Aftermarket).lyx" size="262144" crc="0271b6e9" md5="7ee41edaef283459c9df93366c5da267" sha1="b973cee4a58dbae5ab2d540b38db90aae78ba323"/>
+		<description>Lexis (World) (Aftermarket) (Unl)</description>
+		<release name="Lexis (World) (Aftermarket) (Unl)" region="World"/>
+		<rom name="Lexis (World) (Aftermarket) (Unl).lyx" size="262144" crc="0271b6e9" md5="7ee41edaef283459c9df93366c5da267" sha1="b973cee4a58dbae5ab2d540b38db90aae78ba323"/>
 		<url>https://retroachievements.org/game/10242/hashes</url>
 		<hash>7ee41edaef283459c9df93366c5da267</hash>
 	</game>

--- a/DATs/RetroAchievements (No Subfolders)/RA - Atari Lynx.dat
+++ b/DATs/RetroAchievements (No Subfolders)/RA - Atari Lynx.dat
@@ -5,8 +5,8 @@
 		<name>RA - Atari Lynx</name>
 		<description>Atari Lynx</description>
 		<category>No Subfolders</category>
-		<version>20260417</version>
-		<date>17 April 2026</date>
+		<version>20260424</version>
+		<date>24 April 2026</date>
 		<author>AzgoRAth, NeoRetroGamer (Contributor), Jumphil (Contributor)</author>
 		<homepage>https://retroachievements.org</homepage>
 		<url>https://retroachievements.org/system/13/games</url>

--- a/DATs/RetroAchievements (No Subfolders)/RA - Colecovision.dat
+++ b/DATs/RetroAchievements (No Subfolders)/RA - Colecovision.dat
@@ -5,8 +5,8 @@
 		<name>RA - Colecovision</name>
 		<description>Colecovision</description>
 		<category>No Subfolders</category>
-		<version>20260227</version>
-		<date>27 February 2026</date>
+		<version>20260417</version>
+		<date>17 April 2026</date>
 		<author>AzgoRAth, NeoRetroGamer (Contributor), Jumphil (Contributor)</author>
 		<homepage>https://retroachievements.org</homepage>
 		<url>https://retroachievements.org/system/44/games</url>

--- a/DATs/RetroAchievements (No Subfolders)/RA - Colecovision.dat
+++ b/DATs/RetroAchievements (No Subfolders)/RA - Colecovision.dat
@@ -13,106 +13,106 @@
 		<titlecount>40</titlecount>
 		<hashcount>42</hashcount>
 	</header>
-	<game name="Dragon's Lair (World) (Aftermarket)">
+	<game name="Dragon's Lair (World) (SGM) (Aftermarket) (Team Pixelboy)">
 		<category>Homebrew</category>
-		<description>Dragon's Lair (World) (Aftermarket)</description>
-		<release name="Dragon's Lair (World) (Aftermarket)" region="World"/>
-		<rom name="Dragon's Lair (World) (Aftermarket).col" size="262144" crc="12ceee08" md5="3568ed427a9e33de164b44402103ae64" sha1="e74f80fef5276ee6d58b2ed6ee8ebeec668db324"/>
+		<description>Dragon's Lair (World) (SGM) (Aftermarket) (Team Pixelboy)</description>
+		<release name="Dragon's Lair (World) (SGM) (Aftermarket) (Team Pixelboy)" region="World"/>
+		<rom name="Dragon's Lair (World) (SGM) (Aftermarket) (Team Pixelboy).col" size="262144" crc="12ceee08" md5="3568ed427a9e33de164b44402103ae64" sha1="e74f80fef5276ee6d58b2ed6ee8ebeec668db324"/>
 		<url>https://retroachievements.org/game/33722/hashes</url>
 		<hash>3568ed427a9e33de164b44402103ae64</hash>
 	</game>
 	
-	<game name="Frostbite (World) (Aftermarket)">
+	<game name="Frostbite (World) (Aftermarket) (Unl)">
 		<category>Homebrew</category>
-		<description>Frostbite (World) (Aftermarket)</description>
-		<release name="Frostbite (World) (Aftermarket)" region="World"/>
-		<rom name="Frostbite (World) (Aftermarket).col" size="32768" crc="b3212318" md5="9c3a581843ce1efe220e7e726cadb9ea" sha1="92ed60d081e192053823b62b90a647279b241dd5"/>
+		<description>Frostbite (World) (Aftermarket) (Unl)</description>
+		<release name="Frostbite (World) (Aftermarket) (Unl)" region="World"/>
+		<rom name="Frostbite (World) (Aftermarket) (Unl).col" size="32768" crc="b3212318" md5="9c3a581843ce1efe220e7e726cadb9ea" sha1="92ed60d081e192053823b62b90a647279b241dd5"/>
 		<url>https://retroachievements.org/game/25263/hashes</url>
 		<hash>9c3a581843ce1efe220e7e726cadb9ea</hash>
 	</game>
 	
-	<game name="Ice Muncher (World) (v1.0) (Aftermarket)" cloneof="Ice Muncher (World) (v1.1) (Aftermarket)">
+	<game name="Ice Muncher (World) (v1.0) (Aftermarket) (Unl)" cloneof="Ice Muncher (World) (v1.1) (Aftermarket) (Unl)">
 		<category>Homebrew</category>
-		<description>Ice Muncher (World) (v1.0) (Aftermarket)</description>
-		<rom name="Ice Muncher (World) (v1.0) (Aftermarket).col" size="29615" crc="8cf16f2f" md5="d0c499b2af27b4d717de879f47607625" sha1="e15b10be51112035fe69ed84f260b2bbe192d3b7"/>
+		<description>Ice Muncher (World) (v1.0) (Aftermarket) (Unl)</description>
+		<rom name="Ice Muncher (World) (v1.0) (Aftermarket) (Unl).col" size="29615" crc="8cf16f2f" md5="d0c499b2af27b4d717de879f47607625" sha1="e15b10be51112035fe69ed84f260b2bbe192d3b7"/>
 		<url>https://retroachievements.org/game/25104/hashes</url>
 		<hash>d0c499b2af27b4d717de879f47607625</hash>
 	</game>
-	<game name="Ice Muncher (World) (v1.1) (Aftermarket)">
+	<game name="Ice Muncher (World) (v1.1) (Aftermarket) (Unl)">
 		<category>Homebrew</category>
-		<description>Ice Muncher (World) (v1.1) (Aftermarket)</description>
-		<release name="Ice Muncher (World) (v1.1) (Aftermarket)" region="World"/>
-		<rom name="Ice Muncher (World) (v1.1) (Aftermarket).col" size="29580" crc="9be9516f" md5="47210914b12d9bd06c15d9f5f9e896fe" sha1="e9296cabf5b0054a710e1c54df920131bde36e1b"/>
+		<description>Ice Muncher (World) (v1.1) (Aftermarket) (Unl)</description>
+		<release name="Ice Muncher (World) (v1.1) (Aftermarket) (Unl)" region="World"/>
+		<rom name="Ice Muncher (World) (v1.1) (Aftermarket) (Unl).col" size="29580" crc="9be9516f" md5="47210914b12d9bd06c15d9f5f9e896fe" sha1="e9296cabf5b0054a710e1c54df920131bde36e1b"/>
 		<url>https://retroachievements.org/game/25104/hashes</url>
 		<hash>47210914b12d9bd06c15d9f5f9e896fe</hash>
 	</game>
 	
-	<game name="Minesweeper (World) (Aftermarket)">
+	<game name="Minesweeper (World) (Aftermarket) (Unl)">
 		<category>Homebrew</category>
-		<description>Minesweeper (World) (Aftermarket)</description>
-		<release name="Minesweeper (World) (Aftermarket)" region="World"/>
-		<rom name="Minesweeper (World) (Aftermarket).col" size="13604" crc="5cd9d34a" md5="53021bab905ed4bc85a00ccc0e2bf595" sha1="f8eb14dd0916042028907477997ab9ee44655208"/>
+		<description>Minesweeper (World) (Aftermarket) (Unl)</description>
+		<release name="Minesweeper (World) (Aftermarket) (Unl)" region="World"/>
+		<rom name="Minesweeper (World) (Aftermarket) (Unl).col" size="13604" crc="5cd9d34a" md5="53021bab905ed4bc85a00ccc0e2bf595" sha1="f8eb14dd0916042028907477997ab9ee44655208"/>
 		<url>https://retroachievements.org/game/22414/hashes</url>
 		<hash>53021bab905ed4bc85a00ccc0e2bf595</hash>
 	</game>
 	
-	<game name="Multiverse (World) (Aftermarket)">
+	<game name="Multiverse (World) (Aftermarket) (Unl)">
 		<category>Homebrew</category>
-		<description>Multiverse (World) (Aftermarket)</description>
-		<release name="Multiverse (World) (Aftermarket)" region="World"/>
-		<rom name="Multiverse (World) (Aftermarket).col" size="32768" crc="d45475ac" md5="f8f57b1c5171a771b3987be56ef9f0ff" sha1="86cd2a4011957f417d50c3de8dd52c4c14e8e52a"/>
+		<description>Multiverse (World) (Aftermarket) (Unl)</description>
+		<release name="Multiverse (World) (Aftermarket) (Unl)" region="World"/>
+		<rom name="Multiverse (World) (Aftermarket) (Unl).col" size="32768" crc="d45475ac" md5="f8f57b1c5171a771b3987be56ef9f0ff" sha1="86cd2a4011957f417d50c3de8dd52c4c14e8e52a"/>
 		<url>https://retroachievements.org/game/29939/hashes</url>
 		<hash>f8f57b1c5171a771b3987be56ef9f0ff</hash>
 	</game>
 	
-	<game name="Pac-Man Collection (World) (Aftermarket)">
+	<game name="Pac-Man Collection (World) (Aftermarket) (Unl)">
 		<category>Homebrew</category>
-		<description>Pac-Man Collection (World) (Aftermarket)</description>
-		<release name="Pac-Man Collection (World) (Aftermarket)" region="World"/>
-		<rom name="Pac-Man Collection (World) (Aftermarket).col" size="131072" crc="f3ccacb3" md5="9cebe6571aa12803eadcefd9cde6b1b6" sha1="b88ea5f1b052a224068bcc920c6a18760f263c8f"/>
+		<description>Pac-Man Collection (World) (Aftermarket) (Unl)</description>
+		<release name="Pac-Man Collection (World) (Aftermarket) (Unl)" region="World"/>
+		<rom name="Pac-Man Collection (World) (Aftermarket) (Unl).col" size="131072" crc="f3ccacb3" md5="9cebe6571aa12803eadcefd9cde6b1b6" sha1="b88ea5f1b052a224068bcc920c6a18760f263c8f"/>
 		<url>https://retroachievements.org/game/29868/hashes</url>
 		<hash>9cebe6571aa12803eadcefd9cde6b1b6</hash>
 	</game>
 	
-	<game name="Quest for the Golden Chalice (World) (Aftermarket)">
+	<game name="Quest for the Golden Chalice (World) (Aftermarket) (Unl)">
 		<category>Homebrew</category>
-		<description>Quest for the Golden Chalice (World) (Aftermarket)</description>
-		<release name="Quest for the Golden Chalice (World) (Aftermarket)" region="World"/>
-		<rom name="Quest for the Golden Chalice (World) (Aftermarket).col" size="32768" crc="6da37da8" md5="eabcb4a9a1eac2c6f8a7d002987d9e55" sha1="21398973ba4ebd563ccfb0f3c1c03c6a447f4eea"/>
+		<description>Quest for the Golden Chalice (World) (Aftermarket) (Unl)</description>
+		<release name="Quest for the Golden Chalice (World) (Aftermarket) (Unl)" region="World"/>
+		<rom name="Quest for the Golden Chalice (World) (Aftermarket) (Unl).col" size="32768" crc="6da37da8" md5="eabcb4a9a1eac2c6f8a7d002987d9e55" sha1="21398973ba4ebd563ccfb0f3c1c03c6a447f4eea"/>
 		<url>https://retroachievements.org/game/24468/hashes</url>
 		<hash>eabcb4a9a1eac2c6f8a7d002987d9e55</hash>
 	</game>
 	
-	<game name="Sega Flipper (SG-1000 Conversion) (World) (Aftermarket)">
+	<game name="Sega Flipper (SG-1000 Conversion) (World) (Aftermarket) (Unl)">
 		<category>Homebrew</category>
-		<description>Sega Flipper (SG-1000 Conversion) (World) (Aftermarket)</description>
-		<release name="Sega Flipper (SG-1000 Conversion) (World) (Aftermarket)" region="World"/>
-		<rom name="Sega Flipper (SG-1000 Conversion) (World) (Aftermarket).col" size="16384" crc="e7739f82" md5="e61ca91de0e9591fb16204e8a626923a" sha1="4a6d106f0fe36ed9dbe7823f1c9044e17aeea181"/>
+		<description>Sega Flipper (SG-1000 Conversion) (World) (Aftermarket) (Unl)</description>
+		<release name="Sega Flipper (SG-1000 Conversion) (World) (Aftermarket) (Unl)" region="World"/>
+		<rom name="Sega Flipper (SG-1000 Conversion) (World) (Aftermarket) (Unl).col" size="16384" crc="e7739f82" md5="e61ca91de0e9591fb16204e8a626923a" sha1="4a6d106f0fe36ed9dbe7823f1c9044e17aeea181"/>
 		<url>https://retroachievements.org/game/25957/hashes</url>
 		<hash>e61ca91de0e9591fb16204e8a626923a</hash>
 	</game>
 	
-	<game name="Sudoku (World) (v1.0) (Aftermarket)" cloneof="Sudoku (World) (v2.0) (Aftermarket)">
+	<game name="Sudoku (World) (v1.0) (Aftermarket) (Unl)" cloneof="Sudoku (World) (v2.0) (Aftermarket) (Unl)">
 		<category>Homebrew</category>
-		<description>Sudoku (World) (v1.0) (Aftermarket)</description>
-		<rom name="Sudoku (World) (v1.0) (Aftermarket).col" size="10496" crc="12144312" md5="94476e431aca0f9590964d6797d5dee9" sha1="0124ba683340188c7a9a89122af7a54db07e1edb"/>
+		<description>Sudoku (World) (v1.0) (Aftermarket) (Unl)</description>
+		<rom name="Sudoku (World) (v1.0) (Aftermarket) (Unl).col" size="10496" crc="12144312" md5="94476e431aca0f9590964d6797d5dee9" sha1="0124ba683340188c7a9a89122af7a54db07e1edb"/>
 		<url>https://retroachievements.org/game/14471/hashes</url>
 		<hash>94476e431aca0f9590964d6797d5dee9</hash>
 	</game>
-	<game name="Sudoku (World) (v2.0) (Aftermarket)">
+	<game name="Sudoku (World) (v2.0) (Aftermarket) (Unl)">
 		<category>Homebrew</category>
-		<description>Sudoku (World) (v2.0) (Aftermarket)</description>
-		<release name="Sudoku (World) (v2.0) (Aftermarket)" region="World"/>
-		<rom name="Sudoku (World) (v2.0) (Aftermarket).col" size="10496" crc="2aa3abb2" md5="e34e775b40367815197dc4086aab2f89" sha1="499c9746f0dacab59a3fb23f80169df34cfbb91a"/>
+		<description>Sudoku (World) (v2.0) (Aftermarket) (Unl)</description>
+		<release name="Sudoku (World) (v2.0) (Aftermarket) (Unl)" region="World"/>
+		<rom name="Sudoku (World) (v2.0) (Aftermarket) (Unl).col" size="10496" crc="2aa3abb2" md5="e34e775b40367815197dc4086aab2f89" sha1="499c9746f0dacab59a3fb23f80169df34cfbb91a"/>
 		<url>https://retroachievements.org/game/14471/hashes</url>
 		<hash>e34e775b40367815197dc4086aab2f89</hash>
 	</game>
 	
-	<game name="Where's Derpy (USA) (v1.2) (gameblabla) (Aftermarket)">
+	<game name="Where's Derpy (USA) (v1.2) (Aftermarket) (gameblabla)">
 		<category>Homebrew</category>
-		<description>Where's Derpy (USA) (v1.2) (gameblabla) (Aftermarket)</description>
-		<release name="Where's Derpy (USA) (v1.2) (gameblabla) (Aftermarket)" region="USA"/>
-		<rom name="Where's Derpy (USA) (v1.2) (gameblabla) (Aftermarket).col" size="27740" crc="53059516" md5="291282d0946c56d3763044d73fbff74c" sha1="a595ebac485814cd6e4c40b33dfbcab25d0e9c03"/>
+		<description>Where's Derpy (USA) (v1.2) (Aftermarket) (gameblabla)</description>
+		<release name="Where's Derpy (USA) (v1.2) (Aftermarket) (gameblabla)" region="USA"/>
+		<rom name="Where's Derpy (USA) (v1.2) (Aftermarket) (gameblabla).col" size="27740" crc="53059516" md5="291282d0946c56d3763044d73fbff74c" sha1="a595ebac485814cd6e4c40b33dfbcab25d0e9c03"/>
 		<url>https://retroachievements.org/game/34944/hashes</url>
 		<hash>291282d0946c56d3763044d73fbff74c</hash>
 	</game>

--- a/DATs/RetroAchievements (No Subfolders)/RA - Colecovision.dat
+++ b/DATs/RetroAchievements (No Subfolders)/RA - Colecovision.dat
@@ -5,8 +5,8 @@
 		<name>RA - Colecovision</name>
 		<description>Colecovision</description>
 		<category>No Subfolders</category>
-		<version>20260417</version>
-		<date>17 April 2026</date>
+		<version>20260424</version>
+		<date>24 April 2026</date>
 		<author>AzgoRAth, NeoRetroGamer (Contributor), Jumphil (Contributor)</author>
 		<homepage>https://retroachievements.org</homepage>
 		<url>https://retroachievements.org/system/44/games</url>
@@ -371,6 +371,16 @@
 		<rom name="Popeye (USA).col" size="16384" crc="a095454d" md5="a7773e1265e0089bc8f148527256a20e" sha1="f54f110ba5864bb3418f84e1c2cdc5c856dda771"/>
 		<url>https://retroachievements.org/game/18259/hashes</url>
 		<hash>a7773e1265e0089bc8f148527256a20e</hash>
+	</game>
+	
+	<game name="Rocky - Super Action Boxing (USA, Europe)">
+		<category>Retail</category>
+		<description>Rocky - Super Action Boxing (USA, Europe)</description>
+		<release name="Rocky - Super Action Boxing (USA, Europe)" region="Europe"/>
+		<release name="Rocky - Super Action Boxing (USA, Europe)" region="USA"/>
+		<rom name="Rocky - Super Action Boxing (USA, Europe).col" size="20480" crc="37f144d3" md5="d35fdb81f4a733925b0a33dfb53d9d78" sha1="11def2adb622bbf62bfd2ac14d8151c8f2f772eb"/>
+		<url>https://retroachievements.org/game/32358/hashes</url>
+		<hash>d35fdb81f4a733925b0a33dfb53d9d78</hash>
 	</game>
 	
 	<game name="Spy Hunter (USA)">

--- a/DATs/RetroAchievements (No Subfolders)/RA - Elektor TV Games Computer.dat
+++ b/DATs/RetroAchievements (No Subfolders)/RA - Elektor TV Games Computer.dat
@@ -5,13 +5,13 @@
 		<name>RA - Elektor TV Games Computer</name>
 		<description>Elektor TV Games Computer</description>
 		<category>No Subfolders</category>
-		<version>20251225</version>
-		<date>25 December 2025</date>
+		<version>20260428</version>
+		<date>28 April 2026</date>
 		<author>AzgoRAth, NeoRetroGamer (Contributor), Jumphil (Contributor)</author>
 		<homepage>https://retroachievements.org</homepage>
 		<url>https://retroachievements.org/system/75/games</url>
-		<titlecount>26</titlecount>
-		<hashcount>26</hashcount>
+		<titlecount>29</titlecount>
+		<hashcount>29</hashcount>
 	</header>
 	<game name="Asteroids (Europe) (ESS-011-5)">
 		<category>Retail</category>
@@ -195,6 +195,14 @@
 		<rom name="Rocket Hunting (Europe) (ESS-010-9).tvc" size="5875" crc="76f288a3" md5="ff5f7f6c0bba34a081acb131653ca758" sha1="09ae6cf098e1182d3744f8be2f35cf6f3d385daa"/>
 		<url>https://retroachievements.org/game/24661/hashes</url>
 		<hash>ff5f7f6c0bba34a081acb131653ca758</hash>
+	</game>
+	
+	<game name="Rocket Shooting (Europe) (ESS-006-3)">
+		<category>Retail</category>
+		<description>Rocket Shooting (Europe) (ESS-006-3)</description>
+		<rom name="Rocket Shooting (Europe) (ESS-006-3).tvc" size="1077" crc="f8b41252" md5="472a9af429b440ba09a84ed6bc4630a6" sha1="392dafc12acae84bf2631f924f2519cddc00f556"/>
+		<url>https://retroachievements.org/game/24662/hashes</url>
+		<hash>472a9af429b440ba09a84ed6bc4630a6</hash>
 	</game>
 	
 	<game name="Snakes and Ladders (Europe) (ESS-011-1)">

--- a/DATs/RetroAchievements (No Subfolders)/RA - Emerson Arcadia 2001.dat
+++ b/DATs/RetroAchievements (No Subfolders)/RA - Emerson Arcadia 2001.dat
@@ -5,28 +5,28 @@
 		<name>RA - Emerson Arcadia 2001</name>
 		<description>Emerson Arcadia 2001</description>
 		<category>No Subfolders</category>
-		<version>20251225</version>
-		<date>25 December 2025</date>
+		<version>20260428</version>
+		<date>28 April 2026</date>
 		<author>AzgoRAth, NeoRetroGamer (Contributor), Jumphil (Contributor)</author>
 		<homepage>https://retroachievements.org</homepage>
 		<url>https://retroachievements.org/system/73/games</url>
-		<titlecount>29</titlecount>
-		<hashcount>31</hashcount>
+		<titlecount>32</titlecount>
+		<hashcount>34</hashcount>
 	</header>
-	<game name="JTron (World) (2003) (Amigan Software) (Aftermarket)">
+	<game name="JTron (World) (2003) (Amigan Software)">
 		<category>Homebrew</category>
-		<description>JTron (World) (2003) (Amigan Software) (Aftermarket)</description>
-		<release name="JTron (World) (2003) (Amigan Software) (Aftermarket)" region="World"/>
-		<rom name="JTron (World) (2003) (Amigan Software) (Aftermarket).bin" size="2048" crc="a768c764" md5="906040af349e793bae5b062f3074e71e" sha1="9f6ace424cfbba87eaf06c165fa561099f8d8634"/>
+		<description>JTron (World) (2003) (Amigan Software)</description>
+		<release name="JTron (World) (2003) (Amigan Software)" region="World"/>
+		<rom name="JTron (World) (2003) (Amigan Software).bin" size="2048" crc="a768c764" md5="906040af349e793bae5b062f3074e71e" sha1="9f6ace424cfbba87eaf06c165fa561099f8d8634"/>
 		<url>https://retroachievements.org/game/24924/hashes</url>
 		<hash>906040af349e793bae5b062f3074e71e</hash>
 	</game>
 	
-	<game name="Tetris (Austria) (2003) (Peter Trauner) (Aftermarket)">
+	<game name="Tetris (Austria) (2003) (Peter Trauner)">
 		<category>Homebrew</category>
-		<description>Tetris (Austria) (2003) (Peter Trauner) (Aftermarket)</description>
-		<release name="Tetris (Austria) (2003) (Peter Trauner) (Aftermarket)" region="World"/>
-		<rom name="Tetris (Austria) (2003) (Peter Trauner) (Aftermarket).bin" size="4096" crc="296c8465" md5="69cf3728f7db96c311bc8b3b8917baff" sha1="ee910ce4753986989ac44fc9ead97920f14d1571"/>
+		<description>Tetris (Austria) (2003) (Peter Trauner)</description>
+		<release name="Tetris (Austria) (2003) (Peter Trauner)" region="World"/>
+		<rom name="Tetris (Austria) (2003) (Peter Trauner).bin" size="4096" crc="296c8465" md5="69cf3728f7db96c311bc8b3b8917baff" sha1="ee910ce4753986989ac44fc9ead97920f14d1571"/>
 		<url>https://retroachievements.org/game/24691/hashes</url>
 		<hash>69cf3728f7db96c311bc8b3b8917baff</hash>
 	</game>
@@ -107,6 +107,15 @@
 		<hash>2938509d9c2a2316b460b2a617581771</hash>
 	</game>
 	
+	<game name="Dr. Slump (Japan) (1983) (Bandai)">
+		<category>Retail</category>
+		<description>Dr. Slump (Japan) (1983) (Bandai)</description>
+		<release name="Dr. Slump (Japan) (1983) (Bandai)" region="Japan"/>
+		<rom name="Dr. Slump (Japan) (1983) (Bandai).bin" size="8192" crc="927c375a" md5="2a636fc1b2c414f87c078c06f279d618" sha1="389259f1505deef5c0fb83f9cf8b0f7fa4ed5d04"/>
+		<url>https://retroachievements.org/game/24687/hashes</url>
+		<hash>2a636fc1b2c414f87c078c06f279d618</hash>
+	</game>
+	
 	<game name="Escape (USA, Europe)">
 		<category>Retail</category>
 		<description>Escape (USA, Europe)</description>
@@ -135,11 +144,11 @@
 		<hash>9640b53728b797b11f90c912a8ccadaf</hash>
 	</game>
 	
-	<game name="Jump Bug (1982) (UA) (DE)" cloneof="Jump Bug (Europe)">
+	<game name="Jump Bug (1982)(UA)(DE)" cloneof="Jump Bug (Europe)">
 		<category>Retail</category>
-		<description>Jump Bug (1982) (UA) (DE)</description>
-		<release name="Jump Bug (1982) (UA) (DE)" region="Germany"/>
-		<rom name="Jump Bug (1982) (UA) (DE).bin" size="8192" crc="dc0264b8" md5="6f2cfbf3c07d1b096f096fc8a763e500" sha1="bf3ccf7a54409f22ca4295b1df1c01bfbbe9f0a2"/>
+		<description>Jump Bug (1982)(UA)(DE)</description>
+		<release name="Jump Bug (1982)(UA)(DE)" region="Germany"/>
+		<rom name="Jump Bug (1982)(UA)(DE).bin" size="8192" crc="dc0264b8" md5="6f2cfbf3c07d1b096f096fc8a763e500" sha1="bf3ccf7a54409f22ca4295b1df1c01bfbbe9f0a2"/>
 		<url>https://retroachievements.org/game/21597/hashes</url>
 		<hash>6f2cfbf3c07d1b096f096fc8a763e500</hash>
 	</game>
@@ -172,11 +181,11 @@
 		<hash>4a9404e44df9a747549f7af0b18df632</hash>
 	</game>
 	
-	<game name="Mobile Soldier Gundam (1983) (Bandai) (JP)">
+	<game name="Mobile Soldier Gundam (1983)(Bandai)(JP)">
 		<category>Retail</category>
-		<description>Mobile Soldier Gundam (1983) (Bandai) (JP)</description>
-		<release name="Mobile Soldier Gundam (1983) (Bandai) (JP)" region="Japan"/>
-		<rom name="Mobile Soldier Gundam (1983) (Bandai) (JP).bin" size="8192" crc="1241f128" md5="eca02a18e0ff4222283ab16947fe6911" sha1="4b07a88b06008ddfc3676983e826e107caf3ba0f"/>
+		<description>Mobile Soldier Gundam (1983)(Bandai)(JP)</description>
+		<release name="Mobile Soldier Gundam (1983)(Bandai)(JP)" region="Japan"/>
+		<rom name="Mobile Soldier Gundam (1983)(Bandai)(JP).bin" size="8192" crc="1241f128" md5="eca02a18e0ff4222283ab16947fe6911" sha1="4b07a88b06008ddfc3676983e826e107caf3ba0f"/>
 		<url>https://retroachievements.org/game/24688/hashes</url>
 		<hash>eca02a18e0ff4222283ab16947fe6911</hash>
 	</game>
@@ -243,6 +252,16 @@
 		<hash>376d97f9f74ab1c64fc888385506027b</hash>
 	</game>
 	
+	<game name="Space Attack (USA, Europe)">
+		<category>Retail</category>
+		<description>Space Attack (USA, Europe)</description>
+		<release name="Space Attack (USA, Europe)" region="Europe"/>
+		<release name="Space Attack (USA, Europe)" region="USA"/>
+		<rom name="Space Attack (USA, Europe).bin" size="4096" crc="e3794a2c" md5="dbd76221e35fa6c8133a03f57dfe79d2" sha1="25a27466dc3ffb6013cd4f632947834002c80105"/>
+		<url>https://retroachievements.org/game/21610/hashes</url>
+		<hash>dbd76221e35fa6c8133a03f57dfe79d2</hash>
+	</game>
+	
 	<game name="Space Mission (USA, Europe)">
 		<category>Retail</category>
 		<description>Space Mission (USA, Europe)</description>
@@ -272,20 +291,20 @@
 		<hash>463fcdc2f5667e23700e6c8f75495fa9</hash>
 	</game>
 	
-	<game name="Super Bug (Europe)">
+	<game name="Super Bug (1983)(UA)(EU)">
 		<category>Retail</category>
-		<description>Super Bug (Europe)</description>
-		<release name="Super Bug (Europe)" region="Europe"/>
-		<rom name="Super Bug (Europe).bin" size="4096" crc="fef2aae9" md5="40c65c30b00b8458d3567389d777a47a" sha1="1e7f7b81ecd2f766c94bd5ff17763374fb0318f1"/>
+		<description>Super Bug (1983)(UA)(EU)</description>
+		<release name="Super Bug (1983)(UA)(EU)" region="Europe"/>
+		<rom name="Super Bug (1983)(UA)(EU).bin" size="4096" crc="fef2aae9" md5="40c65c30b00b8458d3567389d777a47a" sha1="1e7f7b81ecd2f766c94bd5ff17763374fb0318f1"/>
 		<url>https://retroachievements.org/game/24923/hashes</url>
 		<hash>40c65c30b00b8458d3567389d777a47a</hash>
 	</game>
 	
-	<game name="Super Dimension Fortress Macross (1983) (Bandai) (JP)">
+	<game name="Super Dimension Fortress Macross (1983)(Bandai)(JP)">
 		<category>Retail</category>
-		<description>Super Dimension Fortress Macross (1983) (Bandai) (JP)</description>
-		<release name="Super Dimension Fortress Macross (1983) (Bandai) (JP)" region="Japan"/>
-		<rom name="Super Dimension Fortress Macross (1983) (Bandai) (JP).bin" size="8192" crc="4c885af2" md5="60ee33a137802d27b5b0567ff4de52ae" sha1="3d24ab9e42ff44a223bb53c5491dea7f41691df2"/>
+		<description>Super Dimension Fortress Macross (1983)(Bandai)(JP)</description>
+		<release name="Super Dimension Fortress Macross (1983)(Bandai)(JP)" region="Japan"/>
+		<rom name="Super Dimension Fortress Macross (1983)(Bandai)(JP).bin" size="8192" crc="4c885af2" md5="60ee33a137802d27b5b0567ff4de52ae" sha1="3d24ab9e42ff44a223bb53c5491dea7f41691df2"/>
 		<url>https://retroachievements.org/game/24689/hashes</url>
 		<hash>60ee33a137802d27b5b0567ff4de52ae</hash>
 	</game>

--- a/DATs/RetroAchievements (No Subfolders)/RA - Fairchild Channel F.dat
+++ b/DATs/RetroAchievements (No Subfolders)/RA - Fairchild Channel F.dat
@@ -5,13 +5,13 @@
 		<name>RA - Fairchild Channel F</name>
 		<description>Fairchild Channel F</description>
 		<category>No Subfolders</category>
-		<version>20260417</version>
-		<date>17 April 2026</date>
+		<version>20260426</version>
+		<date>26 April 2026</date>
 		<author>AzgoRAth, NeoRetroGamer (Contributor), Jumphil (Contributor)</author>
 		<homepage>https://retroachievements.org</homepage>
 		<url>https://retroachievements.org/system/57/games</url>
-		<titlecount>33</titlecount>
-		<hashcount>36</hashcount>
+		<titlecount>36</titlecount>
+		<hashcount>39</hashcount>
 	</header>
 	<game name="2048-F8 (USA) (Aftermarket) (Unl)">
 		<category>Homebrew</category>
@@ -29,6 +29,15 @@
 		<rom name="3rees (USA) (Aftermarket) (Unl).bin" size="5444" crc="f203f9cf" md5="1a7590de88e21345f60ec2bc8b2b9269" sha1="bc2c1f82a6568d5724c46e152af1b846b869a3aa"/>
 		<url>https://retroachievements.org/game/10302/hashes</url>
 		<hash>1a7590de88e21345f60ec2bc8b2b9269</hash>
+	</game>
+	
+	<game name="Adventures of the Stalk of Celery! (World) (v42) (Chris Read)">
+		<category>Homebrew</category>
+		<description>Adventures of the Stalk of Celery! (World) (v42) (Chris Read)</description>
+		<release name="Adventures of the Stalk of Celery! (World) (v42) (Chris Read)" region="World"/>
+		<rom name="Adventures of the Stalk of Celery! (World) (v42) (Chris Read).bin" size="30720" crc="84aa9472" md5="a7f0df802a1eaba82dd9cf2aa7ce3cd4" sha1="12b291950507fb7df148008f4da1c8141c48a008"/>
+		<url>https://retroachievements.org/game/37897/hashes</url>
+		<hash>a7f0df802a1eaba82dd9cf2aa7ce3cd4</hash>
 	</game>
 	
 	<game name="Boxing (USA) (Aftermarket) (Unl)">
@@ -223,6 +232,15 @@
 		<hash>4c10fa5c7316c59efa241043fc67dfa8</hash>
 	</game>
 	
+	<game name="Drag Race (USA)">
+		<category>Retail</category>
+		<description>Drag Race (USA)</description>
+		<release name="Drag Race (USA)" region="USA"/>
+		<rom name="Drag Race (USA).bin" size="2048" crc="6a64dda3" md5="f80af74b09d058b90e719bb7dfbdd50e" sha1="d915c8997f56ae09548498feecebf3c3bfcdf6c4"/>
+		<url>https://retroachievements.org/game/9016/hashes</url>
+		<hash>f80af74b09d058b90e719bb7dfbdd50e</hash>
+	</game>
+	
 	<game name="Maze, Jailbreak, Blind-man's-bluff, Trailblazer (USA)">
 		<category>Retail</category>
 		<description>Maze, Jailbreak, Blind-man's-bluff, Trailblazer (USA)</description>
@@ -336,6 +354,15 @@
 		<rom name="Galactic Space Wars, Lunar Lander (USA).bin" size="2048" crc="c8ef3410" md5="9e0711b140e22729687db1e1354980ab" sha1="fc3cadc90d73ce7e3b32b5c9a855d621e79c592a"/>
 		<url>https://retroachievements.org/game/10306/hashes</url>
 		<hash>9e0711b140e22729687db1e1354980ab</hash>
+	</game>
+	
+	<game name="Casino Poker (USA)">
+		<category>Retail</category>
+		<description>Casino Poker (USA)</description>
+		<release name="Casino Poker (USA)" region="USA"/>
+		<rom name="Casino Poker (USA).bin" size="4096" crc="5aa30c12" md5="bb7f7bbbe21f142591cdcafa98d7f6e4" sha1="4540b1cfca461d6eba26754c34090aa74822a4bd"/>
+		<url>https://retroachievements.org/game/8995/hashes</url>
+		<hash>bb7f7bbbe21f142591cdcafa98d7f6e4</hash>
 	</game>
 	
 	<game name="Alien Invasion (USA)">

--- a/DATs/RetroAchievements (No Subfolders)/RA - Fairchild Channel F.dat
+++ b/DATs/RetroAchievements (No Subfolders)/RA - Fairchild Channel F.dat
@@ -13,126 +13,126 @@
 		<titlecount>33</titlecount>
 		<hashcount>36</hashcount>
 	</header>
-	<game name="2048-F8 (USA) (Aftermarket)">
+	<game name="2048-F8 (USA) (Aftermarket) (Unl)">
 		<category>Homebrew</category>
-		<description>2048-F8 (USA) (Aftermarket)</description>
-		<release name="2048-F8 (USA) (Aftermarket)" region="World"/>
-		<rom name="2048-F8 (USA) (Aftermarket).bin" size="4702" crc="d737aadd" md5="88c078fe7229add65f031b601064543e" sha1="726676f0a204d05f8c2f754d6369cc384c3b7925"/>
+		<description>2048-F8 (USA) (Aftermarket) (Unl)</description>
+		<release name="2048-F8 (USA) (Aftermarket) (Unl)" region="World"/>
+		<rom name="2048-F8 (USA) (Aftermarket) (Unl).bin" size="4702" crc="d737aadd" md5="88c078fe7229add65f031b601064543e" sha1="726676f0a204d05f8c2f754d6369cc384c3b7925"/>
 		<url>https://retroachievements.org/game/20267/hashes</url>
 		<hash>88c078fe7229add65f031b601064543e</hash>
 	</game>
 	
-	<game name="3rees (USA) (Aftermarket)">
+	<game name="3rees (USA) (Aftermarket) (Unl)">
 		<category>Homebrew</category>
-		<description>3rees (USA) (Aftermarket)</description>
-		<release name="3rees (USA) (Aftermarket)" region="World"/>
-		<rom name="3rees (USA) (Aftermarket).bin" size="5444" crc="f203f9cf" md5="1a7590de88e21345f60ec2bc8b2b9269" sha1="bc2c1f82a6568d5724c46e152af1b846b869a3aa"/>
+		<description>3rees (USA) (Aftermarket) (Unl)</description>
+		<release name="3rees (USA) (Aftermarket) (Unl)" region="World"/>
+		<rom name="3rees (USA) (Aftermarket) (Unl).bin" size="5444" crc="f203f9cf" md5="1a7590de88e21345f60ec2bc8b2b9269" sha1="bc2c1f82a6568d5724c46e152af1b846b869a3aa"/>
 		<url>https://retroachievements.org/game/10302/hashes</url>
 		<hash>1a7590de88e21345f60ec2bc8b2b9269</hash>
 	</game>
 	
-	<game name="Boxing (USA) (Aftermarket)">
+	<game name="Boxing (USA) (Aftermarket) (Unl)">
 		<category>Homebrew</category>
-		<description>Boxing (USA) (Aftermarket)</description>
-		<release name="Boxing (USA) (Aftermarket)" region="World"/>
-		<rom name="Boxing (USA) (Aftermarket).bin" size="4096" crc="2e8aa291" md5="65a71a450cae1e60589efcf9b1a10456" sha1="f34411ab9d872bc5899dd6c6f1e9dd7daf9d37fd"/>
+		<description>Boxing (USA) (Aftermarket) (Unl)</description>
+		<release name="Boxing (USA) (Aftermarket) (Unl)" region="World"/>
+		<rom name="Boxing (USA) (Aftermarket) (Unl).bin" size="4096" crc="2e8aa291" md5="65a71a450cae1e60589efcf9b1a10456" sha1="f34411ab9d872bc5899dd6c6f1e9dd7daf9d37fd"/>
 		<url>https://retroachievements.org/game/22567/hashes</url>
 		<hash>65a71a450cae1e60589efcf9b1a10456</hash>
 	</game>
 	
-	<game name="Centipede (USA) (v1.01) (Aftermarket)">
+	<game name="Centipede (USA) (v1.01) (Aftermarket) (Unl)">
 		<category>Homebrew</category>
-		<description>Centipede (USA) (v1.01) (Aftermarket)</description>
-		<release name="Centipede (USA) (v1.01) (Aftermarket)" region="World"/>
-		<rom name="Centipede (USA) (v1.01) (Aftermarket).bin" size="8105" crc="146e2370" md5="74c3961468a024d30095b0b4314e4eb0" sha1="87353ed1e8794f68378e16634908fe08c215f51c"/>
+		<description>Centipede (USA) (v1.01) (Aftermarket) (Unl)</description>
+		<release name="Centipede (USA) (v1.01) (Aftermarket) (Unl)" region="World"/>
+		<rom name="Centipede (USA) (v1.01) (Aftermarket) (Unl).bin" size="8105" crc="146e2370" md5="74c3961468a024d30095b0b4314e4eb0" sha1="87353ed1e8794f68378e16634908fe08c215f51c"/>
 		<url>https://retroachievements.org/game/20237/hashes</url>
 		<hash>74c3961468a024d30095b0b4314e4eb0</hash>
 	</game>
 	
-	<game name="Fnvader (USA) (Aftermarket)">
+	<game name="Fnvader (USA) (Aftermarket) (Unl)">
 		<category>Homebrew</category>
-		<description>Fnvader (USA) (Aftermarket)</description>
-		<release name="Fnvader (USA) (Aftermarket)" region="World"/>
-		<rom name="Fnvader (USA) (Aftermarket).bin" size="4349" crc="9e52e997" md5="5f2c587bf948be2b67cfae924e4508bb" sha1="e047f0406b46381b1ee94042d89131763daca8e7"/>
+		<description>Fnvader (USA) (Aftermarket) (Unl)</description>
+		<release name="Fnvader (USA) (Aftermarket) (Unl)" region="World"/>
+		<rom name="Fnvader (USA) (Aftermarket) (Unl).bin" size="4349" crc="9e52e997" md5="5f2c587bf948be2b67cfae924e4508bb" sha1="e047f0406b46381b1ee94042d89131763daca8e7"/>
 		<url>https://retroachievements.org/game/8985/hashes</url>
 		<hash>5f2c587bf948be2b67cfae924e4508bb</hash>
 	</game>
 	
-	<game name="Shark (USA) (Aftermarket)">
+	<game name="Shark (USA) (Aftermarket) (Unl)">
 		<category>Homebrew</category>
-		<description>Shark (USA) (Aftermarket)</description>
-		<release name="Shark (USA) (Aftermarket)" region="World"/>
-		<rom name="Shark (USA) (Aftermarket).bin" size="3072" crc="e4bd59a1" md5="3f101828e1e64235a673f337addb3952" sha1="65a529a63407c7bc467af445af851207600f73be"/>
+		<description>Shark (USA) (Aftermarket) (Unl)</description>
+		<release name="Shark (USA) (Aftermarket) (Unl)" region="World"/>
+		<rom name="Shark (USA) (Aftermarket) (Unl).bin" size="3072" crc="e4bd59a1" md5="3f101828e1e64235a673f337addb3952" sha1="65a529a63407c7bc467af445af851207600f73be"/>
 		<url>https://retroachievements.org/game/22416/hashes</url>
 		<hash>3f101828e1e64235a673f337addb3952</hash>
 	</game>
 	
-	<game name="Space Race (USA) (v2023) (MikeBloke) (Aftermarket)">
+	<game name="Space Race (USA) (v2023) (Aftermarket) (MikeBloke)">
 		<category>Homebrew</category>
-		<description>Space Race (USA) (v2023) (MikeBloke) (Aftermarket)</description>
-		<release name="Space Race (USA) (v2023) (MikeBloke) (Aftermarket)" region="World"/>
-		<rom name="Space Race (USA) (v2023) (MikeBloke) (Aftermarket).bin" size="4094" crc="55a76115" md5="b604104cacfda30315b60b00b3ca5ade" sha1="c6faa060ce3483f885205f9e1c070c5193712435"/>
+		<description>Space Race (USA) (v2023) (Aftermarket) (MikeBloke)</description>
+		<release name="Space Race (USA) (v2023) (Aftermarket) (MikeBloke)" region="World"/>
+		<rom name="Space Race (USA) (v2023) (Aftermarket) (MikeBloke).bin" size="4094" crc="55a76115" md5="b604104cacfda30315b60b00b3ca5ade" sha1="c6faa060ce3483f885205f9e1c070c5193712435"/>
 		<url>https://retroachievements.org/game/22592/hashes</url>
 		<hash>b604104cacfda30315b60b00b3ca5ade</hash>
 	</game>
 	
-	<game name="Speed Race (USA) (Directional Controls) (Aftermarket)">
+	<game name="Speed Race (Directional Controls) (USA) (Aftermarket) (Unl)">
 		<category>Homebrew</category>
-		<description>Speed Race (USA) (Directional Controls) (Aftermarket)</description>
-		<release name="Speed Race (USA) (Directional Controls) (Aftermarket)" region="World"/>
-		<rom name="Speed Race (USA) (Directional Controls) (Aftermarket).bin" size="2046" crc="29897ff8" md5="a7b94e4941ed058ff4af9cedc21b808b" sha1="99e4af26bbcc5df10995ffbcd73fd7cd8629611f"/>
+		<description>Speed Race (Directional Controls) (USA) (Aftermarket) (Unl)</description>
+		<release name="Speed Race (Directional Controls) (USA) (Aftermarket) (Unl)" region="World"/>
+		<rom name="Speed Race (Directional Controls) (USA) (Aftermarket) (Unl).bin" size="2046" crc="29897ff8" md5="a7b94e4941ed058ff4af9cedc21b808b" sha1="99e4af26bbcc5df10995ffbcd73fd7cd8629611f"/>
 		<url>https://retroachievements.org/game/9086/hashes</url>
 		<hash>a7b94e4941ed058ff4af9cedc21b808b</hash>
 	</game>
-	<game name="Speed Race (USA) (Twist Controls) (Aftermarket)" cloneof="Speed Race (USA) (Directional Controls) (Aftermarket)">
+	<game name="Speed Race (Twist Controls) (USA) (Aftermarket) (Unl)" cloneof="Speed Race (Directional Controls) (USA) (Aftermarket) (Unl)">
 		<category>Homebrew</category>
-		<description>Speed Race (USA) (Twist Controls) (Aftermarket)</description>
-		<rom name="Speed Race (USA) (Twist Controls) (Aftermarket).bin" size="2046" crc="7635b11f" md5="b17b3c8744c4ac8a550212b016dcae5b" sha1="dadadc3a23347c6efe2f5f5020c269bbfcdea61a"/>
+		<description>Speed Race (Twist Controls) (USA) (Aftermarket) (Unl)</description>
+		<rom name="Speed Race (Twist Controls) (USA) (Aftermarket) (Unl).bin" size="2046" crc="7635b11f" md5="b17b3c8744c4ac8a550212b016dcae5b" sha1="dadadc3a23347c6efe2f5f5020c269bbfcdea61a"/>
 		<url>https://retroachievements.org/game/9086/hashes</url>
 		<hash>b17b3c8744c4ac8a550212b016dcae5b</hash>
 	</game>
 	
-	<game name="Submarine (USA) (Aftermarket)">
+	<game name="Submarine (USA) (Aftermarket) (Unl)">
 		<category>Homebrew</category>
-		<description>Submarine (USA) (Aftermarket)</description>
-		<release name="Submarine (USA) (Aftermarket)" region="World"/>
-		<rom name="Submarine (USA) (Aftermarket).bin" size="2046" crc="636b4ea1" md5="ece8baaf22ef385939e5c37e496cc60c" sha1="f8629ca015312dea362fbeaae32359431048c4e3"/>
+		<description>Submarine (USA) (Aftermarket) (Unl)</description>
+		<release name="Submarine (USA) (Aftermarket) (Unl)" region="World"/>
+		<rom name="Submarine (USA) (Aftermarket) (Unl).bin" size="2046" crc="636b4ea1" md5="ece8baaf22ef385939e5c37e496cc60c" sha1="f8629ca015312dea362fbeaae32359431048c4e3"/>
 		<url>https://retroachievements.org/game/25416/hashes</url>
 		<hash>ece8baaf22ef385939e5c37e496cc60c</hash>
 	</game>
 	
-	<game name="Tents and Trees (USA) (Aftermarket)">
+	<game name="Tents and Trees (USA) (Aftermarket) (Unl)">
 		<category>Homebrew</category>
-		<description>Tents and Trees (USA) (Aftermarket)</description>
-		<release name="Tents and Trees (USA) (Aftermarket)" region="World"/>
-		<rom name="Tents and Trees (USA) (Aftermarket).bin" size="3800" crc="02257e89" md5="0d272a1c51bfe148ad12105f3f39446d" sha1="f01a3956ec1d39018541a7be731776eaee191914"/>
+		<description>Tents and Trees (USA) (Aftermarket) (Unl)</description>
+		<release name="Tents and Trees (USA) (Aftermarket) (Unl)" region="World"/>
+		<rom name="Tents and Trees (USA) (Aftermarket) (Unl).bin" size="3800" crc="02257e89" md5="0d272a1c51bfe148ad12105f3f39446d" sha1="f01a3956ec1d39018541a7be731776eaee191914"/>
 		<url>https://retroachievements.org/game/20238/hashes</url>
 		<hash>0d272a1c51bfe148ad12105f3f39446d</hash>
 	</game>
 	
-	<game name="Pac-Man (USA) (v2006-02-20,b28) (Aftermarket)">
+	<game name="Pac-Man (USA) (v2006-02-20,b28) (Aftermarket) (Unl)">
 		<category>Homebrew</category>
-		<description>Pac-Man (USA) (v2006-02-20,b28) (Aftermarket)</description>
-		<release name="Pac-Man (USA) (v2006-02-20,b28) (Aftermarket)" region="World"/>
-		<rom name="Pac-Man (USA) (v2006-02-20,b28) (Aftermarket).bin" size="4096" crc="39ec3044" md5="1ae3fb8784c395c07bbd37bb44476871" sha1="633de00bb19b8dcc41658ba9601a3393aa044cf6"/>
+		<description>Pac-Man (USA) (v2006-02-20,b28) (Aftermarket) (Unl)</description>
+		<release name="Pac-Man (USA) (v2006-02-20,b28) (Aftermarket) (Unl)" region="World"/>
+		<rom name="Pac-Man (USA) (v2006-02-20,b28) (Aftermarket) (Unl).bin" size="4096" crc="39ec3044" md5="1ae3fb8784c395c07bbd37bb44476871" sha1="633de00bb19b8dcc41658ba9601a3393aa044cf6"/>
 		<url>https://retroachievements.org/game/20217/hashes</url>
 		<hash>1ae3fb8784c395c07bbd37bb44476871</hash>
 	</game>
 	
-	<game name="Tetris (USA) (2004) (Trauner, Peter) (Aftermarket)">
+	<game name="Tetris (2004) (Trauner, Peter) (USA) (Aftermarket) (Unl)">
 		<category>Homebrew</category>
-		<description>Tetris (USA) (2004) (Trauner, Peter) (Aftermarket)</description>
-		<release name="Tetris (USA) (2004) (Trauner, Peter) (Aftermarket)" region="World"/>
-		<rom name="Tetris (USA) (2004) (Trauner, Peter) (Aftermarket).bin" size="4096" crc="44c556fa" md5="2aebeda05478e8b7f5c1eca037ac6c2f" sha1="98f73b2119ec2195117c6fcd290d8eb2d6410907"/>
+		<description>Tetris (2004) (Trauner, Peter) (USA) (Aftermarket) (Unl)</description>
+		<release name="Tetris (2004) (Trauner, Peter) (USA) (Aftermarket) (Unl)" region="World"/>
+		<rom name="Tetris (2004) (Trauner, Peter) (USA) (Aftermarket) (Unl).bin" size="4096" crc="44c556fa" md5="2aebeda05478e8b7f5c1eca037ac6c2f" sha1="98f73b2119ec2195117c6fcd290d8eb2d6410907"/>
 		<url>https://retroachievements.org/game/20220/hashes</url>
 		<hash>2aebeda05478e8b7f5c1eca037ac6c2f</hash>
 	</game>
 	
-	<game name="wrdl-f (World) (Aftermarket)">
+	<game name="wrdl-f (USA) (Aftermarket) (Unl)">
 		<category>Homebrew</category>
-		<description>wrdl-f (World) (Aftermarket)</description>
-		<release name="wrdl-f (World) (Aftermarket)" region="World"/>
-		<rom name="wrdl-f (World) (Aftermarket).rom" size="8161" crc="0ae07b86" md5="745479a23fb09dda3df3179c56719ca8" sha1="cbe3eef9b8de73f600f704b381b594be29c1f345"/>
+		<description>wrdl-f (USA) (Aftermarket) (Unl)</description>
+		<release name="wrdl-f (USA) (Aftermarket) (Unl)" region="World"/>
+		<rom name="wrdl-f (USA) (Aftermarket) (Unl).rom" size="8161" crc="0ae07b86" md5="745479a23fb09dda3df3179c56719ca8" sha1="cbe3eef9b8de73f600f704b381b594be29c1f345"/>
 		<url>https://retroachievements.org/game/20231/hashes</url>
 		<hash>745479a23fb09dda3df3179c56719ca8</hash>
 	</game>

--- a/DATs/RetroAchievements (No Subfolders)/RA - Fairchild Channel F.dat
+++ b/DATs/RetroAchievements (No Subfolders)/RA - Fairchild Channel F.dat
@@ -5,8 +5,8 @@
 		<name>RA - Fairchild Channel F</name>
 		<description>Fairchild Channel F</description>
 		<category>No Subfolders</category>
-		<version>20251225</version>
-		<date>25 December 2025</date>
+		<version>20260417</version>
+		<date>17 April 2026</date>
 		<author>AzgoRAth, NeoRetroGamer (Contributor), Jumphil (Contributor)</author>
 		<homepage>https://retroachievements.org</homepage>
 		<url>https://retroachievements.org/system/57/games</url>

--- a/DATs/RetroAchievements (No Subfolders)/RA - GCE Vectrex.dat
+++ b/DATs/RetroAchievements (No Subfolders)/RA - GCE Vectrex.dat
@@ -13,126 +13,126 @@
 		<titlecount>32</titlecount>
 		<hashcount>34</hashcount>
 	</header>
-	<game name="Beluga Dreams (World) (v2019) (Aftermarket)">
+	<game name="Beluga Dreams (World) (v2019) (Aftermarket) (Unl)">
 		<category>Homebrew</category>
-		<description>Beluga Dreams (World) (v2019) (Aftermarket)</description>
-		<release name="Beluga Dreams (World) (v2019) (Aftermarket)" region="World"/>
-		<rom name="Beluga Dreams (World) (v2019) (Aftermarket).bin" size="10778" crc="1ea3b7b4" md5="e3f901324b064e0eec6aa5f655518afa" sha1="34c232b2a9d43a2c9e39f181f7a38872120e0296"/>
+		<description>Beluga Dreams (World) (v2019) (Aftermarket) (Unl)</description>
+		<release name="Beluga Dreams (World) (v2019) (Aftermarket) (Unl)" region="World"/>
+		<rom name="Beluga Dreams (World) (v2019) (Aftermarket) (Unl).bin" size="10778" crc="1ea3b7b4" md5="e3f901324b064e0eec6aa5f655518afa" sha1="34c232b2a9d43a2c9e39f181f7a38872120e0296"/>
 		<url>https://retroachievements.org/game/25165/hashes</url>
 		<hash>e3f901324b064e0eec6aa5f655518afa</hash>
 	</game>
 	
-	<game name="Every Day Is Halloween (World) (v1.0) (Aftermarket)">
+	<game name="Every Day Is Halloween (World) (v1.0) (Aftermarket) (Unl)">
 		<category>Homebrew</category>
-		<description>Every Day Is Halloween (World) (v1.0) (Aftermarket)</description>
-		<release name="Every Day Is Halloween (World) (v1.0) (Aftermarket)" region="World"/>
-		<rom name="Every Day Is Halloween (World) (v1.0) (Aftermarket).bin" size="32768" crc="277a58fa" md5="806c2ae784e05b12ec5f0c734c341765" sha1="2a5bcc2c7911a19c5a0e21124b0382cae31b2c88"/>
+		<description>Every Day Is Halloween (World) (v1.0) (Aftermarket) (Unl)</description>
+		<release name="Every Day Is Halloween (World) (v1.0) (Aftermarket) (Unl)" region="World"/>
+		<rom name="Every Day Is Halloween (World) (v1.0) (Aftermarket) (Unl).bin" size="32768" crc="277a58fa" md5="806c2ae784e05b12ec5f0c734c341765" sha1="2a5bcc2c7911a19c5a0e21124b0382cae31b2c88"/>
 		<url>https://retroachievements.org/game/25172/hashes</url>
 		<hash>806c2ae784e05b12ec5f0c734c341765</hash>
 	</game>
 	
-	<game name="Galaxy Wars - Space Launcher (World) (v1.0) (Aftermarket)">
+	<game name="Galaxy Wars - Space Launcher (World) (v1.0) (Aftermarket) (Unl)">
 		<category>Homebrew</category>
-		<description>Galaxy Wars - Space Launcher (World) (v1.0) (Aftermarket)</description>
-		<release name="Galaxy Wars - Space Launcher (World) (v1.0) (Aftermarket)" region="World"/>
-		<rom name="Galaxy Wars - Space Launcher (World) (v1.0) (Aftermarket).bin" size="32768" crc="da706fa2" md5="490674405868a95e614c9b492f18e45b" sha1="ab41c9c6ebf3e145b8c29f60754fbf733a1f0c2a"/>
+		<description>Galaxy Wars - Space Launcher (World) (v1.0) (Aftermarket) (Unl)</description>
+		<release name="Galaxy Wars - Space Launcher (World) (v1.0) (Aftermarket) (Unl)" region="World"/>
+		<rom name="Galaxy Wars - Space Launcher (World) (v1.0) (Aftermarket) (Unl).bin" size="32768" crc="da706fa2" md5="490674405868a95e614c9b492f18e45b" sha1="ab41c9c6ebf3e145b8c29f60754fbf733a1f0c2a"/>
 		<url>https://retroachievements.org/game/25173/hashes</url>
 		<hash>490674405868a95e614c9b492f18e45b</hash>
 	</game>
 	
-	<game name="Hex (World) (v20140310) (Aftermarket)">
+	<game name="Hex (World) (v20140310) (Aftermarket) (Unl)">
 		<category>Homebrew</category>
-		<description>Hex (World) (v20140310) (Aftermarket)</description>
-		<release name="Hex (World) (v20140310) (Aftermarket)" region="World"/>
-		<rom name="Hex (World) (v20140310) (Aftermarket).bin" size="4224" crc="5b0b4605" md5="a5eed865b98c73f062c023e65b727c93" sha1="967f7d04235411c62a840a2f8fea8736bf1959f1"/>
+		<description>Hex (World) (v20140310) (Aftermarket) (Unl)</description>
+		<release name="Hex (World) (v20140310) (Aftermarket) (Unl)" region="World"/>
+		<rom name="Hex (World) (v20140310) (Aftermarket) (Unl).bin" size="4224" crc="5b0b4605" md5="a5eed865b98c73f062c023e65b727c93" sha1="967f7d04235411c62a840a2f8fea8736bf1959f1"/>
 		<url>https://retroachievements.org/game/25177/hashes</url>
 		<hash>a5eed865b98c73f062c023e65b727c93</hash>
 	</game>
 	
-	<game name="Moon Knight (World) (v1.0) (Aftermarket)">
+	<game name="Moon Knight (World) (v1.0) (Aftermarket) (Unl)">
 		<category>Homebrew</category>
-		<description>Moon Knight (World) (v1.0) (Aftermarket)</description>
-		<release name="Moon Knight (World) (v1.0) (Aftermarket)" region="World"/>
-		<rom name="Moon Knight (World) (v1.0) (Aftermarket).bin" size="7349" crc="76cf8a06" md5="92620a41b504045b9cc0d18434ce46a1" sha1="1fccfcf861abe27410a5683b0db6236bcb5bdadd"/>
+		<description>Moon Knight (World) (v1.0) (Aftermarket) (Unl)</description>
+		<release name="Moon Knight (World) (v1.0) (Aftermarket) (Unl)" region="World"/>
+		<rom name="Moon Knight (World) (v1.0) (Aftermarket) (Unl).bin" size="7349" crc="76cf8a06" md5="92620a41b504045b9cc0d18434ce46a1" sha1="1fccfcf861abe27410a5683b0db6236bcb5bdadd"/>
 		<url>https://retroachievements.org/game/26956/hashes</url>
 		<hash>92620a41b504045b9cc0d18434ce46a1</hash>
 	</game>
 	
-	<game name="Quartz's Quest (World) (v1.2) (Aftermarket)">
+	<game name="Quartz's Quest (World) (v1.2) (Aftermarket) (Unl)">
 		<category>Homebrew</category>
-		<description>Quartz's Quest (World) (v1.2) (Aftermarket)</description>
-		<release name="Quartz's Quest (World) (v1.2) (Aftermarket)" region="World"/>
-		<rom name="Quartz's Quest (World) (v1.2) (Aftermarket).vec" size="23741" crc="cd9d1623" md5="e018b905f4a6be9b162beca5611c6010" sha1="f0e02abef5048902b523bd6ae58561fd1c0bbdf6"/>
+		<description>Quartz's Quest (World) (v1.2) (Aftermarket) (Unl)</description>
+		<release name="Quartz's Quest (World) (v1.2) (Aftermarket) (Unl)" region="World"/>
+		<rom name="Quartz's Quest (World) (v1.2) (Aftermarket) (Unl).vec" size="23741" crc="cd9d1623" md5="e018b905f4a6be9b162beca5611c6010" sha1="f0e02abef5048902b523bd6ae58561fd1c0bbdf6"/>
 		<url>https://retroachievements.org/game/23000/hashes</url>
 		<hash>e018b905f4a6be9b162beca5611c6010</hash>
 	</game>
 	
-	<game name="Storm Storm (World) (v2017) (Aftermarket)">
+	<game name="Storm Storm (World) (v2017) (Aftermarket) (Unl)">
 		<category>Homebrew</category>
-		<description>Storm Storm (World) (v2017) (Aftermarket)</description>
-		<release name="Storm Storm (World) (v2017) (Aftermarket)" region="World"/>
-		<rom name="Storm Storm (World) (v2017) (Aftermarket).bin" size="2374" crc="e4e4682d" md5="7e32709fa556f0df6b73adfa86de292f" sha1="49f7428cb459fb67d7a6a20feb17367c4693ce9a"/>
+		<description>Storm Storm (World) (v2017) (Aftermarket) (Unl)</description>
+		<release name="Storm Storm (World) (v2017) (Aftermarket) (Unl)" region="World"/>
+		<rom name="Storm Storm (World) (v2017) (Aftermarket) (Unl).bin" size="2374" crc="e4e4682d" md5="7e32709fa556f0df6b73adfa86de292f" sha1="49f7428cb459fb67d7a6a20feb17367c4693ce9a"/>
 		<url>https://retroachievements.org/game/29174/hashes</url>
 		<hash>7e32709fa556f0df6b73adfa86de292f</hash>
 	</game>
 	
-	<game name="Turkey Hero (World) (v0.97) (Aftermarket)">
+	<game name="Turkey Hero (World) (v0.97) (Aftermarket) (Unl)">
 		<category>Homebrew</category>
-		<description>Turkey Hero (World) (v0.97) (Aftermarket)</description>
-		<release name="Turkey Hero (World) (v0.97) (Aftermarket)" region="World"/>
-		<rom name="Turkey Hero (World) (v0.97) (Aftermarket).bin" size="27356" crc="9882e195" md5="af799d55b39593eaa844df3235a51fd6" sha1="f02f1952dee7786b1f982987eac0347534889251"/>
+		<description>Turkey Hero (World) (v0.97) (Aftermarket) (Unl)</description>
+		<release name="Turkey Hero (World) (v0.97) (Aftermarket) (Unl)" region="World"/>
+		<rom name="Turkey Hero (World) (v0.97) (Aftermarket) (Unl).bin" size="27356" crc="9882e195" md5="af799d55b39593eaa844df3235a51fd6" sha1="f02f1952dee7786b1f982987eac0347534889251"/>
 		<url>https://retroachievements.org/game/25170/hashes</url>
 		<hash>af799d55b39593eaa844df3235a51fd6</hash>
 	</game>
 	
-	<game name="Vec-Man (World) (v2.5 - ParaJVE Version) (Aftermarket)" cloneof="Vec-Man (World) (v2.5) (Aftermarket)">
+	<game name="Vec-Man (World) (v2.5 - ParaJVE Version) (Aftermarket) (Unl)" cloneof="Vec-Man (World) (v2.5) (Aftermarket) (Unl)">
 		<category>Homebrew</category>
-		<description>Vec-Man (World) (v2.5 - ParaJVE Version) (Aftermarket)</description>
-		<rom name="Vec-Man (World) (v2.5 - ParaJVE Version) (Aftermarket).bin" size="27224" crc="cf1a247d" md5="bf8dc3f580487a61f8034c7defa79d9c" sha1="d6a7c33d812a8da3563aca8838797a693ac8d2d2"/>
+		<description>Vec-Man (World) (v2.5 - ParaJVE Version) (Aftermarket) (Unl)</description>
+		<rom name="Vec-Man (World) (v2.5 - ParaJVE Version) (Aftermarket) (Unl).bin" size="27224" crc="cf1a247d" md5="bf8dc3f580487a61f8034c7defa79d9c" sha1="d6a7c33d812a8da3563aca8838797a693ac8d2d2"/>
 		<url>https://retroachievements.org/game/25297/hashes</url>
 		<hash>bf8dc3f580487a61f8034c7defa79d9c</hash>
 	</game>
-	<game name="Vec-Man (World) (v2.5) (Aftermarket)">
+	<game name="Vec-Man (World) (v2.5) (Aftermarket) (Unl)">
 		<category>Homebrew</category>
-		<description>Vec-Man (World) (v2.5) (Aftermarket)</description>
-		<release name="Vec-Man (World) (v2.5) (Aftermarket)" region="World"/>
-		<rom name="Vec-Man (World) (v2.5) (Aftermarket).bin" size="28171" crc="ebb800ed" md5="b4e85c762a44f2bdff59ddb9e4d35fb5" sha1="e271f67e5196353a141f2cf083de578dc695c220"/>
+		<description>Vec-Man (World) (v2.5) (Aftermarket) (Unl)</description>
+		<release name="Vec-Man (World) (v2.5) (Aftermarket) (Unl)" region="World"/>
+		<rom name="Vec-Man (World) (v2.5) (Aftermarket) (Unl).bin" size="28171" crc="ebb800ed" md5="b4e85c762a44f2bdff59ddb9e4d35fb5" sha1="e271f67e5196353a141f2cf083de578dc695c220"/>
 		<url>https://retroachievements.org/game/25297/hashes</url>
 		<hash>b4e85c762a44f2bdff59ddb9e4d35fb5</hash>
 	</game>
 	
-	<game name="Veccy Bird (World) (v1.5) (Aftermarket)">
+	<game name="Veccy Bird (World) (v1.5) (Aftermarket) (Unl)">
 		<category>Homebrew</category>
-		<description>Veccy Bird (World) (v1.5) (Aftermarket)</description>
-		<release name="Veccy Bird (World) (v1.5) (Aftermarket)" region="World"/>
-		<rom name="Veccy Bird (World) (v1.5) (Aftermarket).bin" size="5649" crc="f2c6e043" md5="0f91dc3b4acddf52baec0b12cb6ffe85" sha1="cbfd50fe2d558635286779ee7378d0a049d22393"/>
+		<description>Veccy Bird (World) (v1.5) (Aftermarket) (Unl)</description>
+		<release name="Veccy Bird (World) (v1.5) (Aftermarket) (Unl)" region="World"/>
+		<rom name="Veccy Bird (World) (v1.5) (Aftermarket) (Unl).bin" size="5649" crc="f2c6e043" md5="0f91dc3b4acddf52baec0b12cb6ffe85" sha1="cbfd50fe2d558635286779ee7378d0a049d22393"/>
 		<url>https://retroachievements.org/game/19526/hashes</url>
 		<hash>0f91dc3b4acddf52baec0b12cb6ffe85</hash>
 	</game>
 	
-	<game name="Vector Pong (World) (v1.04) (Aftermarket)">
+	<game name="Vector Pong (World) (v1.04) (Aftermarket) (Unl)">
 		<category>Homebrew</category>
-		<description>Vector Pong (World) (v1.04) (Aftermarket)</description>
-		<release name="Vector Pong (World) (v1.04) (Aftermarket)" region="World"/>
-		<rom name="Vector Pong (World) (v1.04) (Aftermarket).bin" size="10674" crc="10506248" md5="c92f22327e3ba5750d061d817531761a" sha1="1a06cee551489ef156332a62f43ac1a3794efc06"/>
+		<description>Vector Pong (World) (v1.04) (Aftermarket) (Unl)</description>
+		<release name="Vector Pong (World) (v1.04) (Aftermarket) (Unl)" region="World"/>
+		<rom name="Vector Pong (World) (v1.04) (Aftermarket) (Unl).bin" size="10674" crc="10506248" md5="c92f22327e3ba5750d061d817531761a" sha1="1a06cee551489ef156332a62f43ac1a3794efc06"/>
 		<url>https://retroachievements.org/game/20041/hashes</url>
 		<hash>c92f22327e3ba5750d061d817531761a</hash>
 	</game>
 	
-	<game name="Vectrexagon (World) (v1.2) (Aftermarket)">
+	<game name="Vectrexagon (World) (v1.2) (Aftermarket) (Unl)">
 		<category>Homebrew</category>
-		<description>Vectrexagon (World) (v1.2) (Aftermarket)</description>
-		<release name="Vectrexagon (World) (v1.2) (Aftermarket)" region="World"/>
-		<rom name="Vectrexagon (World) (v1.2) (Aftermarket).bin" size="24685" crc="bcc8e15b" md5="7fd05f6a7b71e44f8b6b2fc4519e39cb" sha1="224584ad88ffde4c2e7d1518cca417b72b2a71c7"/>
+		<description>Vectrexagon (World) (v1.2) (Aftermarket) (Unl)</description>
+		<release name="Vectrexagon (World) (v1.2) (Aftermarket) (Unl)" region="World"/>
+		<rom name="Vectrexagon (World) (v1.2) (Aftermarket) (Unl).bin" size="24685" crc="bcc8e15b" md5="7fd05f6a7b71e44f8b6b2fc4519e39cb" sha1="224584ad88ffde4c2e7d1518cca417b72b2a71c7"/>
 		<url>https://retroachievements.org/game/22998/hashes</url>
 		<hash>7fd05f6a7b71e44f8b6b2fc4519e39cb</hash>
 	</game>
 	
-	<game name="Dark Tower (USA) (Proto) (Fred Taft)">
+	<game name="Dark Tower (USA) (Proto)">
 		<category>Prototype</category>
-		<description>Dark Tower (USA) (Proto) (Fred Taft)</description>
-		<release name="Dark Tower (USA) (Proto) (Fred Taft)" region="World"/>
-		<rom name="Dark Tower (USA) (Proto) (Fred Taft).vec" size="12288" crc="09f51459" md5="6ac9f45324a62a5edeb9a7a94c45ac50" sha1="fbfd58464d42986d10f1b37f321071ec74525469"/>
+		<description>Dark Tower (USA) (Proto)</description>
+		<release name="Dark Tower (USA) (Proto)" region="World"/>
+		<rom name="Dark Tower (USA) (Proto).vec" size="12288" crc="09f51459" md5="6ac9f45324a62a5edeb9a7a94c45ac50" sha1="fbfd58464d42986d10f1b37f321071ec74525469"/>
 		<url>https://retroachievements.org/game/2120/hashes</url>
 		<hash>6ac9f45324a62a5edeb9a7a94c45ac50</hash>
 	</game>
@@ -146,12 +146,11 @@
 		<hash>9657037a461eee919462eb6a01879685</hash>
 	</game>
 	
-	<game name="Bedlam (USA, Europe)">
+	<game name="Bedlam (World)">
 		<category>Retail</category>
-		<description>Bedlam (USA, Europe)</description>
-		<release name="Bedlam (USA, Europe)" region="Europe"/>
-		<release name="Bedlam (USA, Europe)" region="USA"/>
-		<rom name="Bedlam (USA, Europe).vec" size="4096" crc="a2fa649b" md5="268e75778f282d853d77acf42c6c8734" sha1="3ff3fa4feda6d562dedff2a10cfa8679d8318044"/>
+		<description>Bedlam (World)</description>
+		<release name="Bedlam (World)" region="World"/>
+		<rom name="Bedlam (World).vec" size="4096" crc="a2fa649b" md5="268e75778f282d853d77acf42c6c8734" sha1="3ff3fa4feda6d562dedff2a10cfa8679d8318044"/>
 		<url>https://retroachievements.org/game/4158/hashes</url>
 		<hash>268e75778f282d853d77acf42c6c8734</hash>
 	</game>
@@ -183,12 +182,11 @@
 		<hash>9b61653ed9dafd4cfb7f9d94404259ac</hash>
 	</game>
 	
-	<game name="Fortress of Narzod (USA, Europe)">
+	<game name="Fortress of Narzod (USA)">
 		<category>Retail</category>
-		<description>Fortress of Narzod (USA, Europe)</description>
-		<release name="Fortress of Narzod (USA, Europe)" region="Europe"/>
-		<release name="Fortress of Narzod (USA, Europe)" region="USA"/>
-		<rom name="Fortress of Narzod (USA, Europe).vec" size="8192" crc="13a35c8a" md5="e65b3262e9447a747d93e0ccb1dbb7df" sha1="286e061331289b031de33725a4966c379c1df47f"/>
+		<description>Fortress of Narzod (USA)</description>
+		<release name="Fortress of Narzod (USA)" region="USA"/>
+		<rom name="Fortress of Narzod (USA).vec" size="8192" crc="13a35c8a" md5="e65b3262e9447a747d93e0ccb1dbb7df" sha1="286e061331289b031de33725a4966c379c1df47f"/>
 		<url>https://retroachievements.org/game/2215/hashes</url>
 		<hash>e65b3262e9447a747d93e0ccb1dbb7df</hash>
 	</game>
@@ -229,12 +227,11 @@
 		<hash>f94173910549038d4d8f329413a5aa54</hash>
 	</game>
 	
-	<game name="Scramble (USA, Europe)">
+	<game name="Scramble (World)">
 		<category>Retail</category>
-		<description>Scramble (USA, Europe)</description>
-		<release name="Scramble (USA, Europe)" region="Europe"/>
-		<release name="Scramble (USA, Europe)" region="USA"/>
-		<rom name="Scramble (USA, Europe).vec" size="4096" crc="707c8ffe" md5="95370908561a782edf138df41ccb8f18" sha1="38e38b5c60466146d4648f8929b5ce3a08dcbe0d"/>
+		<description>Scramble (World)</description>
+		<release name="Scramble (World)" region="World"/>
+		<rom name="Scramble (World).vec" size="4096" crc="707c8ffe" md5="95370908561a782edf138df41ccb8f18" sha1="38e38b5c60466146d4648f8929b5ce3a08dcbe0d"/>
 		<url>https://retroachievements.org/game/7495/hashes</url>
 		<hash>95370908561a782edf138df41ccb8f18</hash>
 	</game>
@@ -257,21 +254,20 @@
 		<hash>2decdf9f55df7fb99761b2fe51425e40</hash>
 	</game>
 	
-	<game name="Spike (USA, Europe)">
+	<game name="Spike (World)">
 		<category>Retail</category>
-		<description>Spike (USA, Europe)</description>
-		<release name="Spike (USA, Europe)" region="Europe"/>
-		<release name="Spike (USA, Europe)" region="USA"/>
-		<rom name="Spike (USA, Europe).vec" size="8192" crc="62a61843" md5="5a90ab748f7b220edaf8c1d67e0bfe89" sha1="8bba6705e6f69f55ab6d105eac2fd5b0c0d16d9f"/>
+		<description>Spike (World)</description>
+		<release name="Spike (World)" region="World"/>
+		<rom name="Spike (World).vec" size="8192" crc="62a61843" md5="5a90ab748f7b220edaf8c1d67e0bfe89" sha1="8bba6705e6f69f55ab6d105eac2fd5b0c0d16d9f"/>
 		<url>https://retroachievements.org/game/6242/hashes</url>
 		<hash>5a90ab748f7b220edaf8c1d67e0bfe89</hash>
 	</game>
 	
-	<game name="Spinball (USA)">
+	<game name="Spinball (World)">
 		<category>Retail</category>
-		<description>Spinball (USA)</description>
-		<release name="Spinball (USA)" region="USA"/>
-		<rom name="Spinball (USA).vec" size="8192" crc="02f41733" md5="ecc143f87a702af7a1786b58a78ace01" sha1="2e8285061530ccadfa2d8d11c374ae244449ebfa"/>
+		<description>Spinball (World)</description>
+		<release name="Spinball (World)" region="World"/>
+		<rom name="Spinball (World).vec" size="8192" crc="02f41733" md5="ecc143f87a702af7a1786b58a78ace01" sha1="2e8285061530ccadfa2d8d11c374ae244449ebfa"/>
 		<url>https://retroachievements.org/game/7603/hashes</url>
 		<hash>ecc143f87a702af7a1786b58a78ace01</hash>
 	</game>
@@ -303,11 +299,11 @@
 		<hash>0b67a6339e9c1d8385e8fdfc48f447bc</hash>
 	</game>
 	
-	<game name="WebWars (USA)" cloneof="WebWarp (Europe)">
+	<game name="WebWars (World)" cloneof="WebWarp (Europe)">
 		<category>Retail</category>
-		<description>WebWars (USA)</description>
-		<release name="WebWars (USA)" region="USA"/>
-		<rom name="WebWars (USA).vec" size="8192" crc="2ee20103" md5="a398c18b4ce87929471b559b2bc7e79f" sha1="08e2df9f7769c16a4d730adf8d659f8ea4be7f9d"/>
+		<description>WebWars (World)</description>
+		<release name="WebWars (World)" region="World"/>
+		<rom name="WebWars (World).vec" size="8192" crc="2ee20103" md5="a398c18b4ce87929471b559b2bc7e79f" sha1="08e2df9f7769c16a4d730adf8d659f8ea4be7f9d"/>
 		<url>https://retroachievements.org/game/7017/hashes</url>
 		<hash>a398c18b4ce87929471b559b2bc7e79f</hash>
 	</game>

--- a/DATs/RetroAchievements (No Subfolders)/RA - GCE Vectrex.dat
+++ b/DATs/RetroAchievements (No Subfolders)/RA - GCE Vectrex.dat
@@ -5,8 +5,8 @@
 		<name>RA - GCE Vectrex</name>
 		<description>GCE Vectrex</description>
 		<category>No Subfolders</category>
-		<version>20250622</version>
-		<date>22 June 2025</date>
+		<version>20260417</version>
+		<date>17 April 2026</date>
 		<author>AzgoRAth, NeoRetroGamer (Contributor), Jumphil (Contributor)</author>
 		<homepage>https://retroachievements.org</homepage>
 		<url>https://retroachievements.org/system/46/games</url>

--- a/DATs/RetroAchievements (No Subfolders)/RA - GCE Vectrex.dat
+++ b/DATs/RetroAchievements (No Subfolders)/RA - GCE Vectrex.dat
@@ -5,13 +5,13 @@
 		<name>RA - GCE Vectrex</name>
 		<description>GCE Vectrex</description>
 		<category>No Subfolders</category>
-		<version>20260417</version>
-		<date>17 April 2026</date>
+		<version>20260426</version>
+		<date>26 April 2026</date>
 		<author>AzgoRAth, NeoRetroGamer (Contributor), Jumphil (Contributor)</author>
 		<homepage>https://retroachievements.org</homepage>
 		<url>https://retroachievements.org/system/46/games</url>
-		<titlecount>32</titlecount>
-		<hashcount>34</hashcount>
+		<titlecount>34</titlecount>
+		<hashcount>36</hashcount>
 	</header>
 	<game name="Beluga Dreams (World) (v2019) (Aftermarket) (Unl)">
 		<category>Homebrew</category>
@@ -38,6 +38,15 @@
 		<rom name="Galaxy Wars - Space Launcher (World) (v1.0) (Aftermarket) (Unl).bin" size="32768" crc="da706fa2" md5="490674405868a95e614c9b492f18e45b" sha1="ab41c9c6ebf3e145b8c29f60754fbf733a1f0c2a"/>
 		<url>https://retroachievements.org/game/25173/hashes</url>
 		<hash>490674405868a95e614c9b492f18e45b</hash>
+	</game>
+	
+	<game name="Gravitrex (World) (v2002) (Aftermarket) (Unl)">
+		<category>Homebrew</category>
+		<description>Gravitrex (World) (v2002) (Aftermarket) (Unl)</description>
+		<release name="Gravitrex (World) (v2002) (Aftermarket) (Unl)" region="World"/>
+		<rom name="Gravitrex (World) (v2002) (Aftermarket) (Unl).vec" size="32768" crc="83b06492" md5="d5012ddedd1a9fe2b9d14e82eddaa55d" sha1="4120a657ce2a702371d09fe7fd58dc9cc4b7e5cb"/>
+		<url>https://retroachievements.org/game/25302/hashes</url>
+		<hash>d5012ddedd1a9fe2b9d14e82eddaa55d</hash>
 	</game>
 	
 	<game name="Hex (World) (v20140310) (Aftermarket) (Unl)">
@@ -83,6 +92,15 @@
 		<rom name="Turkey Hero (World) (v0.97) (Aftermarket) (Unl).bin" size="27356" crc="9882e195" md5="af799d55b39593eaa844df3235a51fd6" sha1="f02f1952dee7786b1f982987eac0347534889251"/>
 		<url>https://retroachievements.org/game/25170/hashes</url>
 		<hash>af799d55b39593eaa844df3235a51fd6</hash>
+	</game>
+	
+	<game name="Turkey Runner (World) (v0.90) (Aftermarket) (Brett Walach)">
+		<category>Homebrew</category>
+		<description>Turkey Runner (World) (v0.90) (Aftermarket) (Brett Walach)</description>
+		<release name="Turkey Runner (World) (v0.90) (Aftermarket) (Brett Walach)" region="World"/>
+		<rom name="Turkey Runner (World) (v0.90) (Aftermarket) (Brett Walach).vec" size="29693" crc="176e33d2" md5="f03893002b146a458c894cddadfc738d" sha1="e174c2d7180a850e6d4e586e141ceb64004661ab"/>
+		<url>https://retroachievements.org/game/25211/hashes</url>
+		<hash>f03893002b146a458c894cddadfc738d</hash>
 	</game>
 	
 	<game name="Vec-Man (World) (v2.5 - ParaJVE Version) (Aftermarket) (Unl)" cloneof="Vec-Man (World) (v2.5) (Aftermarket) (Unl)">

--- a/DATs/RetroAchievements (No Subfolders)/RA - Interton VC 4000.dat
+++ b/DATs/RetroAchievements (No Subfolders)/RA - Interton VC 4000.dat
@@ -5,37 +5,37 @@
 		<name>RA - Interton VC 4000</name>
 		<description>Interton VC 4000</description>
 		<category>No Subfolders</category>
-		<version>20251225</version>
-		<date>25 December 2025</date>
+		<version>20260428</version>
+		<date>28 April 2026</date>
 		<author>AzgoRAth, NeoRetroGamer (Contributor), Jumphil (Contributor)</author>
 		<homepage>https://retroachievements.org</homepage>
 		<url>https://retroachievements.org/system/74/games</url>
-		<titlecount>34</titlecount>
-		<hashcount>37</hashcount>
+		<titlecount>36</titlecount>
+		<hashcount>39</hashcount>
 	</header>
-	<game name="Canabalt (World) (v20180101) (senilyDeluxe) (Aftermarket)">
+	<game name="Canabalt (World) (v20180101) (Aftermarket) (senilyDeluxe)">
 		<category>Homebrew</category>
-		<description>Canabalt (World) (v20180101) (senilyDeluxe) (Aftermarket)</description>
-		<release name="Canabalt (World) (v20180101) (senilyDeluxe) (Aftermarket)" region="World"/>
-		<rom name="Canabalt (World) (v20180101) (senilyDeluxe) (Aftermarket).bin" size="4031" crc="c8311b54" md5="82c999bc12e38600ad9e70508d2dab8c" sha1="17c2adfd214a273114a9519ccce8d0a0de1efd38"/>
+		<description>Canabalt (World) (v20180101) (Aftermarket) (senilyDeluxe)</description>
+		<release name="Canabalt (World) (v20180101) (Aftermarket) (senilyDeluxe)" region="World"/>
+		<rom name="Canabalt (World) (v20180101) (Aftermarket) (senilyDeluxe).bin" size="4031" crc="c8311b54" md5="82c999bc12e38600ad9e70508d2dab8c" sha1="17c2adfd214a273114a9519ccce8d0a0de1efd38"/>
 		<url>https://retroachievements.org/game/24634/hashes</url>
 		<hash>82c999bc12e38600ad9e70508d2dab8c</hash>
 	</game>
 	
-	<game name="Flappy Birds 2 (World) (v20170530) (senilyDeluxe) (Aftermarket)">
+	<game name="Flappy Birds 2 (World) (v20170530) (Aftermarket) (senilyDeluxe)">
 		<category>Homebrew</category>
-		<description>Flappy Birds 2 (World) (v20170530) (senilyDeluxe) (Aftermarket)</description>
-		<release name="Flappy Birds 2 (World) (v20170530) (senilyDeluxe) (Aftermarket)" region="World"/>
-		<rom name="Flappy Birds 2 (World) (v20170530) (senilyDeluxe) (Aftermarket).bin" size="2048" crc="e6f6830a" md5="312050bd0346e2bb54ec2308d7f281ef" sha1="7a78690e755a4634437e653a272b1ba17fad82f6"/>
+		<description>Flappy Birds 2 (World) (v20170530) (Aftermarket) (senilyDeluxe)</description>
+		<release name="Flappy Birds 2 (World) (v20170530) (Aftermarket) (senilyDeluxe)" region="World"/>
+		<rom name="Flappy Birds 2 (World) (v20170530) (Aftermarket) (senilyDeluxe).bin" size="2048" crc="e6f6830a" md5="312050bd0346e2bb54ec2308d7f281ef" sha1="7a78690e755a4634437e653a272b1ba17fad82f6"/>
 		<url>https://retroachievements.org/game/24633/hashes</url>
 		<hash>312050bd0346e2bb54ec2308d7f281ef</hash>
 	</game>
 	
-	<game name="Tetris (World) (v20200922) (SimonAugustin) (Aftermarket)">
+	<game name="Tetris (World) (v20200922) (Aftermarket) (SimonAugustin)">
 		<category>Homebrew</category>
-		<description>Tetris (World) (v20200922) (SimonAugustin) (Aftermarket)</description>
-		<release name="Tetris (World) (v20200922) (SimonAugustin) (Aftermarket)" region="World"/>
-		<rom name="Tetris (World) (v20200922) (SimonAugustin) (Aftermarket).bin" size="4096" crc="9cbb3c2e" md5="0cbac5ace65a63613587152d2ef87311" sha1="abeb3c61a7818914b3219ee74018a8d2d3176dcc"/>
+		<description>Tetris (World) (v20200922) (Aftermarket) (SimonAugustin)</description>
+		<release name="Tetris (World) (v20200922) (Aftermarket) (SimonAugustin)" region="World"/>
+		<rom name="Tetris (World) (v20200922) (Aftermarket) (SimonAugustin).bin" size="4096" crc="9cbb3c2e" md5="0cbac5ace65a63613587152d2ef87311" sha1="abeb3c61a7818914b3219ee74018a8d2d3176dcc"/>
 		<url>https://retroachievements.org/game/24632/hashes</url>
 		<hash>0cbac5ace65a63613587152d2ef87311</hash>
 	</game>
@@ -83,6 +83,15 @@
 		<rom name="Circus (Europe).bin" size="2048" crc="0ab80f3e" md5="7f3916bb403c86b40f12847362ef3904" sha1="cff0b7066669aad1e35803767fd98ecef4ea162d"/>
 		<url>https://retroachievements.org/game/21629/hashes</url>
 		<hash>7f3916bb403c86b40f12847362ef3904</hash>
+	</game>
+	
+	<game name="Come Come (Europe) (19xx) (Palson)">
+		<category>Retail</category>
+		<description>Come Come (Europe) (19xx) (Palson)</description>
+		<release name="Come Come (Europe) (19xx) (Palson)" region="Europe"/>
+		<rom name="Come Come (Europe) (19xx) (Palson).bin" size="4096" crc="bd90fca7" md5="dd262c3a2df1e273c012cd076ce7b8bf" sha1="a739e585b6e7a58295b656d81d7781f9646546ca"/>
+		<url>https://retroachievements.org/game/24635/hashes</url>
+		<hash>dd262c3a2df1e273c012cd076ce7b8bf</hash>
 	</game>
 	
 	<game name="Crazy Crab (World) (1983) (Radofin Electronics)">
@@ -254,10 +263,10 @@
 		<hash>dff0d751378612a78da0dfa015374664</hash>
 	</game>
 	
-	<game name="Munch &amp; Crunch - Enhanced (World) (1982) (Voltmace - Derek Andrews)" cloneof="Munch &amp; Crunch (World) (1982) (Voltmace - Derek Andrews)">
+	<game name="Munch &amp; Crunch (World) (1982) (Voltmace - Derek Andrews) (Enhanced)" cloneof="Munch &amp; Crunch (World) (1982) (Voltmace - Derek Andrews)">
 		<category>Retail</category>
-		<description>Munch &amp; Crunch - Enhanced (World) (1982) (Voltmace - Derek Andrews)</description>
-		<rom name="Munch &amp; Crunch - Enhanced (World) (1982) (Voltmace - Derek Andrews).bin" size="4121" crc="2bef2934" md5="266bd11247683b0ff4da015fb305b9c4" sha1="157cf0085e8663efe33f3a64415bf8e2bbe3f70f"/>
+		<description>Munch &amp; Crunch (World) (1982) (Voltmace - Derek Andrews) (Enhanced)</description>
+		<rom name="Munch &amp; Crunch (World) (1982) (Voltmace - Derek Andrews) (Enhanced).bin" size="4121" crc="2bef2934" md5="266bd11247683b0ff4da015fb305b9c4" sha1="157cf0085e8663efe33f3a64415bf8e2bbe3f70f"/>
 		<url>https://retroachievements.org/game/24639/hashes</url>
 		<hash>266bd11247683b0ff4da015fb305b9c4</hash>
 	</game>

--- a/DATs/RetroAchievements (No Subfolders)/RA - Magnavox Odyssey 2.dat
+++ b/DATs/RetroAchievements (No Subfolders)/RA - Magnavox Odyssey 2.dat
@@ -5,37 +5,37 @@
 		<name>RA - Magnavox Odyssey 2</name>
 		<description>Magnavox Odyssey 2</description>
 		<category>No Subfolders</category>
-		<version>20251225</version>
-		<date>25 December 2025</date>
+		<version>20260428</version>
+		<date>28 April 2025</date>
 		<author>AzgoRAth, NeoRetroGamer (Contributor), Jumphil (Contributor)</author>
 		<homepage>https://retroachievements.org</homepage>
 		<url>https://retroachievements.org/system/23/games</url>
-		<titlecount>29</titlecount>
-		<hashcount>36</hashcount>
+		<titlecount>31</titlecount>
+		<hashcount>37</hashcount>
 	</header>
-	<game name="Boobs (World) (v1.3a) (Chris Read) (Aftermarket)">
+	<game name="Boobs (Homebrew) (v1.3a) (Chris Read)">
 		<category>Homebrew</category>
-		<description>Boobs (World) (v1.3a) (Chris Read) (Aftermarket)</description>
-		<release name="Boobs (World) (v1.3a) (Chris Read) (Aftermarket)" region="World"/>
-		<rom name="Boobs (World) (v1.3a) (Chris Read) (Aftermarket).bin" size="2048" crc="9847f5d0" md5="2ff854e7bdaf79ebacc70610d7129a63" sha1="0d6b44e2445dbb3bf70c4e05f222822845c29762"/>
+		<description>Boobs (Homebrew) (v1.3a) (Chris Read)</description>
+		<release name="Boobs (Homebrew) (v1.3a) (Chris Read)" region="World"/>
+		<rom name="Boobs (Homebrew) (v1.3a) (Chris Read).bin" size="2048" crc="9847f5d0" md5="2ff854e7bdaf79ebacc70610d7129a63" sha1="0d6b44e2445dbb3bf70c4e05f222822845c29762"/>
 		<url>https://retroachievements.org/game/20059/hashes</url>
 		<hash>2ff854e7bdaf79ebacc70610d7129a63</hash>
 	</game>
 	
-	<game name="GoSub 2 (World) (v3.7) (Chris Read) (Unl) (Aftermarket)">
+	<game name="GoSub 2 (World) (v3.7) (Aftermarket) (Unl) (Chris Read)">
 		<category>Homebrew</category>
-		<description>GoSub 2 (World) (v3.7) (Chris Read) (Unl) (Aftermarket)</description>
-		<release name="GoSub 2 (World) (v3.7) (Chris Read) (Unl) (Aftermarket)" region="World"/>
-		<rom name="GoSub 2 (World) (v3.7) (Chris Read) (Unl) (Aftermarket).bin" size="2048" crc="f5fa8d31" md5="262eb2a2a228c9d5877af6acc13b6cec" sha1="85a44a99b254d92a7433ee46e4caa91483d7fea2"/>
+		<description>GoSub 2 (World) (v3.7) (Aftermarket) (Unl) (Chris Read)</description>
+		<release name="GoSub 2 (World) (v3.7) (Aftermarket) (Unl) (Chris Read)" region="World"/>
+		<rom name="GoSub 2 (World) (v3.7) (Aftermarket) (Unl) (Chris Read).bin" size="2048" crc="f5fa8d31" md5="262eb2a2a228c9d5877af6acc13b6cec" sha1="85a44a99b254d92a7433ee46e4caa91483d7fea2"/>
 		<url>https://retroachievements.org/game/20045/hashes</url>
 		<hash>262eb2a2a228c9d5877af6acc13b6cec</hash>
 	</game>
 	
-	<game name="Happy Bird (World) (Rafael Cardoso-2600 Connection) (Aftermarket)">
+	<game name="Happy Bird (Homebrew) (Rafael Cardoso-2600 Connection)">
 		<category>Homebrew</category>
-		<description>Happy Bird (World) (Rafael Cardoso-2600 Connection) (Aftermarket)</description>
-		<release name="Happy Bird (World) (Rafael Cardoso-2600 Connection) (Aftermarket)" region="World"/>
-		<rom name="Happy Bird (World) (Rafael Cardoso-2600 Connection) (Aftermarket).bin" size="4096" crc="28e6901b" md5="449661989f35b981901fef21330e005c" sha1="2b34ef0e1a8c0371f00a33d6950e0807f3cb886e"/>
+		<description>Happy Bird (Homebrew) (Rafael Cardoso-2600 Connection)</description>
+		<release name="Happy Bird (Homebrew) (Rafael Cardoso-2600 Connection)" region="World"/>
+		<rom name="Happy Bird (Homebrew) (Rafael Cardoso-2600 Connection).bin" size="4096" crc="28e6901b" md5="449661989f35b981901fef21330e005c" sha1="2b34ef0e1a8c0371f00a33d6950e0807f3cb886e"/>
 		<url>https://retroachievements.org/game/20039/hashes</url>
 		<hash>449661989f35b981901fef21330e005c</hash>
 	</game>

--- a/DATs/RetroAchievements (No Subfolders)/RA - Mattel Intellivision.dat
+++ b/DATs/RetroAchievements (No Subfolders)/RA - Mattel Intellivision.dat
@@ -5,74 +5,82 @@
 		<name>RA - Mattel Intellivision</name>
 		<description>Mattel Intellivision</description>
 		<category>No Subfolders</category>
-		<version>20260227</version>
-		<date>27 February 2026</date>
+		<version>20260428</version>
+		<date>28 April 2026</date>
 		<author>AzgoRAth, NeoRetroGamer (Contributor), Jumphil (Contributor)</author>
 		<homepage>https://retroachievements.org</homepage>
 		<url>https://retroachievements.org/system/45/games</url>
-		<titlecount>36</titlecount>
-		<hashcount>36</hashcount>
+		<titlecount>38</titlecount>
+		<hashcount>38</hashcount>
 	</header>
-	<game name="4-Tris (World) (Aftermarket)">
+	<game name="4-Tris (World) (Aftermarket) (Unl)">
 		<category>Homebrew</category>
-		<description>4-Tris (World) (Aftermarket)</description>
-		<rom name="4-Tris (World) (Aftermarket).rom" size="16441" crc="7fd2a11a" md5="bdf1ffe620738e6f54740ded6e175693" sha1="17efae049715528a2a85c9412f5c0ec4824f3557"/>
+		<description>4-Tris (World) (Aftermarket) (Unl)</description>
+		<rom name="4-Tris (World) (Aftermarket) (Unl).rom" size="16441" crc="7fd2a11a" md5="bdf1ffe620738e6f54740ded6e175693" sha1="17efae049715528a2a85c9412f5c0ec4824f3557"/>
 		<url>https://retroachievements.org/game/17712/hashes</url>
 		<hash>bdf1ffe620738e6f54740ded6e175693</hash>
 	</game>
 	
-	<game name="Antarctic Tales - Enhanced Edition (World) (v20210707) (Aftermarket)">
+	<game name="Antarctic Tales (World) (Aftermarket) (Unl)">
 		<category>Homebrew</category>
-		<description>Antarctic Tales - Enhanced Edition (World) (v20210707) (Aftermarket)</description>
-		<rom name="Antarctic Tales - Enhanced Edition (World) (v20210707) (Aftermarket).rom" size="77396" crc="9ba5a798" md5="27051b100ff89970d8a24291e8b6cb67" sha1="bc8d07fc972770dabf6a77ef73a7be15c0521c3e"/>
+		<description>Antarctic Tales (World) (Aftermarket) (Unl)</description>
+		<rom name="Antarctic Tales (World) (Aftermarket) (Unl).rom" size="77396" crc="9ba5a798" md5="27051b100ff89970d8a24291e8b6cb67" sha1="bc8d07fc972770dabf6a77ef73a7be15c0521c3e"/>
 		<url>https://retroachievements.org/game/24890/hashes</url>
 		<hash>27051b100ff89970d8a24291e8b6cb67</hash>
 	</game>
 	
-	<game name="DK Arcade (World) (Intelligentvision) (Aftermarket)">
+	<game name="DK Arcade (World) (Intelligentvision) (Aftermarket) (Unl)">
 		<category>Homebrew</category>
-		<description>DK Arcade (World) (Intelligentvision) (Aftermarket)</description>
-		<rom name="DK Arcade (World) (Intelligentvision) (Aftermarket).int" size="49152" crc="ef1bec41" md5="607d0a959d1c64f6feb66433b4171d5f" sha1="fad323a8c88b7155ec4456e8909fe21e3cdbbe07"/>
+		<description>DK Arcade (World) (Intelligentvision) (Aftermarket) (Unl)</description>
+		<rom name="DK Arcade (World) (Intelligentvision) (Aftermarket) (Unl).int" size="49152" crc="ef1bec41" md5="607d0a959d1c64f6feb66433b4171d5f" sha1="fad323a8c88b7155ec4456e8909fe21e3cdbbe07"/>
 		<url>https://retroachievements.org/game/31167/hashes</url>
 		<hash>607d0a959d1c64f6feb66433b4171d5f</hash>
 	</game>
 	
-	<game name="Flapee Bird (World) (Aftermarket)">
+	<game name="Flapee Bird (World) (Aftermarket) (Unl)">
 		<category>Homebrew</category>
-		<description>Flapee Bird (World) (Aftermarket)</description>
-		<rom name="Flapee Bird (World) (Aftermarket).bin" size="9728" crc="9c7de352" md5="5b065c30735a4b0feee2aac48ebaf633" sha1="f91d4507baf41626d839308659e68de048c767c8"/>
+		<description>Flapee Bird (World) (Aftermarket) (Unl)</description>
+		<rom name="Flapee Bird (World) (Aftermarket) (Unl).bin" size="9728" crc="9c7de352" md5="5b065c30735a4b0feee2aac48ebaf633" sha1="f91d4507baf41626d839308659e68de048c767c8"/>
 		<url>https://retroachievements.org/game/20037/hashes</url>
 		<hash>5b065c30735a4b0feee2aac48ebaf633</hash>
 	</game>
 	
-	<game name="Princess Quest (World) (Aftermarket)">
+	<game name="Intellivania (World) (Aftermarket) (Unl)">
 		<category>Homebrew</category>
-		<description>Princess Quest (World) (Aftermarket)</description>
-		<rom name="Princess Quest (World) (Aftermarket).rom" size="76357" crc="38e9ef48" md5="ed8e8a3c94b8f3b59579047a297cac32" sha1="a9841432efa5aeea64ca44155a034efaded2201e"/>
+		<description>Intellivania (World) (Aftermarket) (Unl)</description>
+		<rom name="Intellivania (World) (Aftermarket) (Unl).int" size="88656" crc="b7a33e8e" md5="7431758763b233ab4b14155c4cf0f001" sha1="6490f5cfba9bd69c05ad89a0d1a7a9d71bc0e43a"/>
+		<url>https://retroachievements.org/game/33028/hashes</url>
+		<hash>7431758763b233ab4b14155c4cf0f001</hash>
+	</game>
+	
+	<game name="Princess Quest (World) (Aftermarket) (Unl)">
+		<category>Homebrew</category>
+		<description>Princess Quest (World) (Aftermarket) (Unl)</description>
+		<rom name="Princess Quest (World) (Aftermarket) (Unl).rom" size="76357" crc="38e9ef48" md5="ed8e8a3c94b8f3b59579047a297cac32" sha1="a9841432efa5aeea64ca44155a034efaded2201e"/>
 		<url>https://retroachievements.org/game/22456/hashes</url>
 		<hash>ed8e8a3c94b8f3b59579047a297cac32</hash>
 	</game>
 	
-	<game name="Pumpkin Attack (World) (Aftermarket)">
+	<game name="Pumpkin Attack (World) (Aftermarket) (Unl)">
 		<category>Homebrew</category>
-		<description>Pumpkin Attack (World) (Aftermarket)</description>
-		<rom name="Pumpkin Attack (World) (Aftermarket).rom" size="26685" crc="26e0bcaa" md5="b593690baa3643df336e2385e9c24dfe" sha1="4288013866edc5e398fc58ba2c686fe2ac781fb4"/>
+		<description>Pumpkin Attack (World) (Aftermarket) (Unl)</description>
+		<rom name="Pumpkin Attack (World) (Aftermarket) (Unl).rom" size="26685" crc="26e0bcaa" md5="b593690baa3643df336e2385e9c24dfe" sha1="4288013866edc5e398fc58ba2c686fe2ac781fb4"/>
 		<url>https://retroachievements.org/game/29151/hashes</url>
 		<hash>b593690baa3643df336e2385e9c24dfe</hash>
 	</game>
 	
-	<game name="Tag-Along Todd (World) (v3.13) (Aftermarket)">
+	<game name="Tag-Along Todd (World) (v3.13) (Aftermarket) (Unl)">
 		<category>Homebrew</category>
-		<description>Tag-Along Todd (World) (v3.13) (Aftermarket)</description>
-		<rom name="Tag-Along Todd (World) (v3.13) (Aftermarket).bin" size="10752" crc="1ecdd51b" md5="57e82ac5ef6c1bff0b810874c4b2c30c" sha1="9e1666a68d50bb4a1f618cc2f9bcd7dfbadc8188"/>
+		<description>Tag-Along Todd (World) (v3.13) (Aftermarket) (Unl)</description>
+		<rom name="Tag-Along Todd (World) (v3.13) (Aftermarket) (Unl).bin" size="10752" crc="1ecdd51b" md5="57e82ac5ef6c1bff0b810874c4b2c30c" sha1="9e1666a68d50bb4a1f618cc2f9bcd7dfbadc8188"/>
 		<url>https://retroachievements.org/game/20050/hashes</url>
 		<hash>57e82ac5ef6c1bff0b810874c4b2c30c</hash>
 	</game>
 	
-	<game name="Ultimate Pong (World) (v9.0) (Aftermarket)">
+	<game name="Ultimate Pong (World) (v9.0) (Aftermarket) (Unl)">
 		<category>Homebrew</category>
-		<description>Ultimate Pong (World) (v9.0) (Aftermarket)</description>
-		<rom name="Ultimate Pong (World) (v9.0) (Aftermarket).bin" size="57925" crc="30575596" md5="03a20a7287601bdae309693ca4f6f0b9" sha1="9469d231a910777b8f46276fa497dc75d7a6a88f"/>
+		<description>Ultimate Pong (World) (v9.0) (Aftermarket) (Unl)</description>
+		<rom name="Ultimate Pong (World) (v9.0) (Aftermarket) (Unl).bin" size="57925" crc="30575596" md5="03a20a7287601bdae309693ca4f6f0b9" sha1="9469d231a910777b8f46276fa497dc75d7a6a88f"/>
 		<url>https://retroachievements.org/game/24463/hashes</url>
 		<hash>03a20a7287601bdae309693ca4f6f0b9</hash>
 	</game>

--- a/DATs/RetroAchievements (No Subfolders)/RA - Mega Duck.dat
+++ b/DATs/RetroAchievements (No Subfolders)/RA - Mega Duck.dat
@@ -5,114 +5,132 @@
 		<name>RA - Mega Duck</name>
 		<description>Mega Duck</description>
 		<category>No Subfolders</category>
-		<version>20251225</version>
-		<date>25 December 2025</date>
+		<version>20262704</version>
+		<date>27 April 2026</date>
 		<author>AzgoRAth, NeoRetroGamer (Contributor), Jumphil (Contributor)</author>
 		<homepage>https://retroachievements.org</homepage>
 		<url>https://retroachievements.org/system/69/games</url>
-		<titlecount>32</titlecount>
-		<hashcount>35</hashcount>
+		<titlecount>34</titlecount>
+		<hashcount>37</hashcount>
 	</header>
-	<game name="Aerial (World) (Inufuto) (Aftermarket)">
+	<game name="Aerial (World) (Aftermarket) (Inufuto)">
 		<category>Homebrew</category>
-		<description>Aerial (World) (Inufuto) (Aftermarket)</description>
-		<release name="Aerial (World) (Inufuto) (Aftermarket)" region="World"/>
-		<rom name="Aerial (World) (Inufuto) (Aftermarket).bin" size="16384" crc="6a324ac3" md5="b26307c090211b85672a3a71ef3bd53f" sha1="6028dd33cf97caffa9025010399127ee5fd75669"/>
+		<description>Aerial (World) (Aftermarket) (Inufuto)</description>
+		<release name="Aerial (World) (Aftermarket) (Inufuto)" region="World"/>
+		<rom name="Aerial (World) (Aftermarket) (Inufuto).bin" size="16384" crc="6a324ac3" md5="b26307c090211b85672a3a71ef3bd53f" sha1="6028dd33cf97caffa9025010399127ee5fd75669"/>
 		<url>https://retroachievements.org/game/31453/hashes</url>
 		<hash>b26307c090211b85672a3a71ef3bd53f</hash>
 	</game>
 	
-	<game name="Black Castle (World) (Aftermarket)">
+	<game name="Battlot (World) (v20241021) (Aftermarket) (Inufuto)">
 		<category>Homebrew</category>
-		<description>Black Castle (World) (Aftermarket)</description>
-		<release name="Black Castle (World) (Aftermarket)" region="World"/>
-		<rom name="Black Castle (World) (Aftermarket).bin" size="65536" crc="312fec34" md5="0b41ffad1c44a3252f2ece6ee0f502f3" sha1="96ec1dea0b406905338a6ff71149662a132b3209"/>
+		<description>Battlot (World) (v20241021) (Aftermarket) (Inufuto)</description>
+		<release name="Battlot (World) (v20241021) (Aftermarket) (Inufuto)" region="World"/>
+		<rom name="Battlot (World) (v20241021) (Aftermarket) (Inufuto).bin" size="16384" crc="0972ECFD" md5="d1d16b0fe4d8dc9e08a10bdc92b2e732" sha1="e8931410ea6aa36bfe38775c84217ffaec9ac420"/>
+		<url>https://retroachievements.org/game/38259/hashes</url>
+		<hash>d1d16b0fe4d8dc9e08a10bdc92b2e732</hash>
+	</game>
+	
+	<game name="Black Castle (World) (Aftermarket) (Unl)">
+		<category>Homebrew</category>
+		<description>Black Castle (World) (Aftermarket) (Unl)</description>
+		<release name="Black Castle (World) (Aftermarket) (Unl)" region="World"/>
+		<rom name="Black Castle (World) (Aftermarket) (Unl).bin" size="65536" crc="312fec34" md5="0b41ffad1c44a3252f2ece6ee0f502f3" sha1="96ec1dea0b406905338a6ff71149662a132b3209"/>
 		<url>https://retroachievements.org/game/24049/hashes</url>
 		<hash>0b41ffad1c44a3252f2ece6ee0f502f3</hash>
 	</game>
 	
-	<game name="Cacorm Mini (World) (v20241020) (Inufuto) (Aftermarket)">
+	<game name="Cacorm Mini (World) (v20241020) (Aftermarket) (Inufuto)">
 		<category>Homebrew</category>
-		<description>Cacorm Mini (World) (v20241020) (Inufuto) (Aftermarket)</description>
-		<release name="Cacorm Mini (World) (v20241020) (Inufuto) (Aftermarket)" region="World"/>
-		<rom name="Cacorm Mini (World) (v20241020) (Inufuto) (Aftermarket).bin" size="16384" crc="58c63d67" md5="30fd14ff650d9d77a601ec4ce21b6f52" sha1="e929debce85d951da3ab5302f58ba75615e4e066"/>
+		<description>Cacorm Mini (World) (v20241020) (Aftermarket) (Inufuto)</description>
+		<release name="Cacorm Mini (World) (v20241020) (Aftermarket) (Inufuto)" region="World"/>
+		<rom name="Cacorm Mini (World) (v20241020) (Aftermarket) (Inufuto).bin" size="16384" crc="58c63d67" md5="30fd14ff650d9d77a601ec4ce21b6f52" sha1="e929debce85d951da3ab5302f58ba75615e4e066"/>
 		<url>https://retroachievements.org/game/33639/hashes</url>
 		<hash>30fd14ff650d9d77a601ec4ce21b6f52</hash>
 	</game>
 	
-	<game name="Canyon Racer (World) (v0.7.6) (Aftermarket)">
+	<game name="Canyon Racer (World) (v0.7.6) (Aftermarket) (Unl)">
 		<category>Homebrew</category>
-		<description>Canyon Racer (World) (v0.7.6) (Aftermarket)</description>
-		<release name="Canyon Racer (World) (v0.7.6) (Aftermarket)" region="World"/>
-		<rom name="Canyon Racer (World) (v0.7.6) (Aftermarket).bin" size="32768" crc="f794d8cf" md5="b5811af4ede6a03dc85aa23da8bbc1e7" sha1="50b382e0f54f98311809a292913a885c85b9f694"/>
+		<description>Canyon Racer (World) (v0.7.6) (Aftermarket) (Unl)</description>
+		<release name="Canyon Racer (World) (v0.7.6) (Aftermarket) (Unl)" region="World"/>
+		<rom name="Canyon Racer (World) (v0.7.6) (Aftermarket) (Unl).bin" size="32768" crc="f794d8cf" md5="b5811af4ede6a03dc85aa23da8bbc1e7" sha1="50b382e0f54f98311809a292913a885c85b9f694"/>
 		<url>https://retroachievements.org/game/24082/hashes</url>
 		<hash>b5811af4ede6a03dc85aa23da8bbc1e7</hash>
 	</game>
-	<game name="Canyon Racer (World) (v0.7.6) (No FX) (Aftermarket)" cloneof="Canyon Racer (World) (v0.7.6) (Aftermarket)">
+	<game name="Canyon Racer (World) (v0.7.6) (No FX) (Aftermarket) (Unl)" cloneof="Canyon Racer (World) (v0.7.6) (Aftermarket) (Unl)">
 		<category>Homebrew</category>
-		<description>Canyon Racer (World) (v0.7.6) (No FX) (Aftermarket)</description>
-		<rom name="Canyon Racer (World) (v0.7.6) (No FX) (Aftermarket).bin" size="32768" crc="9fa63c31" md5="fcb469fa705f23d493689e2f7312d822" sha1="f85491c8ed827483f45ff5f13ee5e195fdcaff1e"/>
+		<description>Canyon Racer (World) (v0.7.6) (No FX) (Aftermarket) (Unl)</description>
+		<rom name="Canyon Racer (World) (v0.7.6) (No FX) (Aftermarket) (Unl).bin" size="32768" crc="9fa63c31" md5="fcb469fa705f23d493689e2f7312d822" sha1="f85491c8ed827483f45ff5f13ee5e195fdcaff1e"/>
 		<url>https://retroachievements.org/game/24082/hashes</url>
 		<hash>fcb469fa705f23d493689e2f7312d822</hash>
 	</game>
 	
-	<game name="Hopman (World) (Inufuto) (Aftermarket)">
+	<game name="Hopman (World) (Aftermarket) (Inufuto)">
 		<category>Homebrew</category>
-		<description>Hopman (World) (Inufuto) (Aftermarket)</description>
-		<release name="Hopman (World) (Inufuto) (Aftermarket)" region="World"/>
-		<rom name="Hopman (World) (Inufuto) (Aftermarket).bin" size="16384" crc="a7b2ba02" md5="115a709d9d524c1ea5d36c65d9b8dbe8" sha1="95102b92b7d52332f0ea7ad04e36b92561687958"/>
+		<description>Hopman (World) (Aftermarket) (Inufuto)</description>
+		<release name="Hopman (World) (Aftermarket) (Inufuto)" region="World"/>
+		<rom name="Hopman (World) (Aftermarket) (Inufuto).bin" size="16384" crc="a7b2ba02" md5="115a709d9d524c1ea5d36c65d9b8dbe8" sha1="95102b92b7d52332f0ea7ad04e36b92561687958"/>
 		<url>https://retroachievements.org/game/31699/hashes</url>
 		<hash>115a709d9d524c1ea5d36c65d9b8dbe8</hash>
 	</game>
 	
-	<game name="Max Pirate (World) (v20240504) (Aftermarket)">
+	<game name="Max Pirate (World) (v20240504) (Aftermarket) (Unl)">
 		<category>Homebrew</category>
-		<description>Max Pirate (World) (v20240504) (Aftermarket)</description>
-		<release name="Max Pirate (World) (v20240504) (Aftermarket)" region="World"/>
-		<rom name="Max Pirate (World) (v20240504) (Aftermarket).bin" size="32768" crc="2eacd525" md5="ac17e9ce88054fde0132242e23873923" sha1="539b18cd46ef8090b01941d37cc5c0c731c332d6"/>
+		<description>Max Pirate (World) (v20240504) (Aftermarket) (Unl)</description>
+		<release name="Max Pirate (World) (v20240504) (Aftermarket) (Unl)" region="World"/>
+		<rom name="Max Pirate (World) (v20240504) (Aftermarket) (Unl).bin" size="32768" crc="2eacd525" md5="ac17e9ce88054fde0132242e23873923" sha1="539b18cd46ef8090b01941d37cc5c0c731c332d6"/>
 		<url>https://retroachievements.org/game/30904/hashes</url>
 		<hash>ac17e9ce88054fde0132242e23873923</hash>
 	</game>
 	
-	<game name="Pegged (World) (v1.2) (Under4Mhz) (Aftermarket)">
+	<game name="Pegged (World) (v1.2) (Aftermarket) (Under4Mhz)">
 		<category>Homebrew</category>
-		<description>Pegged (World) (v1.2) (Under4Mhz) (Aftermarket)</description>
-		<release name="Pegged (World) (v1.2) (Under4Mhz) (Aftermarket)" region="World"/>
-		<rom name="Pegged (World) (v1.2) (Under4Mhz) (Aftermarket).cb" size="32768" crc="c8afd1d2" md5="651635c9b964bdd1fde94adf6b6f38ec" sha1="ab492a3c815a9558d29a90dfa837c571080616fd"/>
+		<description>Pegged (World) (v1.2) (Aftermarket) (Under4Mhz)</description>
+		<release name="Pegged (World) (v1.2) (Aftermarket) (Under4Mhz)" region="World"/>
+		<rom name="Pegged (World) (v1.2) (Aftermarket) (Under4Mhz).cb" size="32768" crc="c8afd1d2" md5="651635c9b964bdd1fde94adf6b6f38ec" sha1="ab492a3c815a9558d29a90dfa837c571080616fd"/>
 		<url>https://retroachievements.org/game/24917/hashes</url>
 		<hash>651635c9b964bdd1fde94adf6b6f38ec</hash>
 	</game>
 	
-	<game name="Penguin Migrant (World) (SunnyChowTheGuy) (Aftermarket)">
+	<game name="Penguin Migrant (World) (Aftermarket) (SunnyChowTheGuy)">
 		<category>Homebrew</category>
-		<description>Penguin Migrant (World) (SunnyChowTheGuy) (Aftermarket)</description>
-		<release name="Penguin Migrant (World) (SunnyChowTheGuy) (Aftermarket)" region="World"/>
-		<rom name="Penguin Migrant (World) (SunnyChowTheGuy) (Aftermarket).bin" size="32768" crc="94237a93" md5="4f78024f2102292fc03929cdd957319e" sha1="017606edfb915e320c2ff10a7aa12d205cb0b5dc"/>
+		<description>Penguin Migrant (World) (Aftermarket) (SunnyChowTheGuy)</description>
+		<release name="Penguin Migrant (World) (Aftermarket) (SunnyChowTheGuy)" region="World"/>
+		<rom name="Penguin Migrant (World) (Aftermarket) (SunnyChowTheGuy).bin" size="32768" crc="94237a93" md5="4f78024f2102292fc03929cdd957319e" sha1="017606edfb915e320c2ff10a7aa12d205cb0b5dc"/>
 		<url>https://retroachievements.org/game/29153/hashes</url>
 		<hash>4f78024f2102292fc03929cdd957319e</hash>
 	</game>
 	
-	<game name="Vexed (World) (v1.08) (Aftermarket)" cloneof="Vexed (World) (v1.09) (Aftermarket)">
+	<game name="Sushi Nights (World) (v1.0) (Aftermarket) (untoxa)">
 		<category>Homebrew</category>
-		<description>Vexed (World) (v1.08) (Aftermarket)</description>
-		<rom name="Vexed (World) (v1.08) (Aftermarket).bin" size="32768" crc="2279c9c8" md5="ae0594e43294653ecf58532316c59cca" sha1="2dfa082c008b6c4725184aff1727d794cd655cbd"/>
+		<description>Sushi Nights (World) (v1.0) (Aftermarket) (untoxa)</description>
+		<release name="Sushi Nights (World) (v1.0) (Aftermarket) (untoxa)" region="World"/>
+		<rom name="Sushi Nights (World) (v1.0) (Aftermarket) (untoxa).duck" size="131072" crc="B3CDC6BB" md5="accd004bb0b89a4e113fc7b3cca7d973" sha1="ea5c87ce1f83daccfa4b6d9902aea48b1ca107c2"/>
+		<url>https://retroachievements.org/game/38351/hashes</url>
+		<hash>accd004bb0b89a4e113fc7b3cca7d973</hash>
+	</game>
+	
+	<game name="Vexed (World) (v1.08) (Aftermarket) (Unl)" cloneof="Vexed (World) (v1.09) (Aftermarket) (Unl)">
+		<category>Homebrew</category>
+		<description>Vexed (World) (v1.08) (Aftermarket) (Unl)</description>
+		<rom name="Vexed (World) (v1.08) (Aftermarket) (Unl).bin" size="32768" crc="2279c9c8" md5="ae0594e43294653ecf58532316c59cca" sha1="2dfa082c008b6c4725184aff1727d794cd655cbd"/>
 		<url>https://retroachievements.org/game/24916/hashes</url>
 		<hash>ae0594e43294653ecf58532316c59cca</hash>
 	</game>
-	<game name="Vexed (World) (v1.09) (Aftermarket)">
+	<game name="Vexed (World) (v1.09) (Aftermarket) (Unl)">
 		<category>Homebrew</category>
-		<description>Vexed (World) (v1.09) (Aftermarket)</description>
-		<release name="Vexed (World) (v1.09) (Aftermarket)" region="World"/>
-		<rom name="Vexed (World) (v1.09) (Aftermarket).bin" size="32768" crc="02a2467e" md5="cb62769fabf28a722bf21e41844cc053" sha1="a168115a121188634a6435278f7746c2e398e498"/>
+		<description>Vexed (World) (v1.09) (Aftermarket) (Unl)</description>
+		<release name="Vexed (World) (v1.09) (Aftermarket) (Unl)" region="World"/>
+		<rom name="Vexed (World) (v1.09) (Aftermarket) (Unl).bin" size="32768" crc="02a2467e" md5="cb62769fabf28a722bf21e41844cc053" sha1="a168115a121188634a6435278f7746c2e398e498"/>
 		<url>https://retroachievements.org/game/24916/hashes</url>
 		<hash>cb62769fabf28a722bf21e41844cc053</hash>
 	</game>
 	
-	<game name="Waternet (World) (Aftermarket)">
+	<game name="Waternet (World) (Aftermarket) (Unl)">
 		<category>Homebrew</category>
-		<description>Waternet (World) (Aftermarket)</description>
-		<release name="Waternet (World) (Aftermarket)" region="World"/>
-		<rom name="Waternet (World) (Aftermarket).bin" size="32768" crc="d6f9dcfa" md5="34d48f05d6be1d64b22732fc03b19301" sha1="c7181cee5ddee2f665d21c38b5a44838f7b8f511"/>
+		<description>Waternet (World) (Aftermarket) (Unl)</description>
+		<release name="Waternet (World) (Aftermarket) (Unl)" region="World"/>
+		<rom name="Waternet (World) (Aftermarket) (Unl).bin" size="32768" crc="d6f9dcfa" md5="34d48f05d6be1d64b22732fc03b19301" sha1="c7181cee5ddee2f665d21c38b5a44838f7b8f511"/>
 		<url>https://retroachievements.org/game/20221/hashes</url>
 		<hash>34d48f05d6be1d64b22732fc03b19301</hash>
 	</game>

--- a/DATs/RetroAchievements (No Subfolders)/RA - NEC TurboGrafx-16.dat
+++ b/DATs/RetroAchievements (No Subfolders)/RA - NEC TurboGrafx-16.dat
@@ -5,40 +5,40 @@
 		<name>RA - NEC TurboGrafx-16</name>
 		<description>NEC TurboGrafx-16</description>
 		<category>No Subfolders</category>
-		<version>20260208</version>
-		<date>08 February 2026</date>
+		<version>20260429</version>
+		<date>29 April 2026</date>
 		<author>AzgoRAth, NeoRetroGamer (Contributor), Jumphil (Contributor)</author>
 		<homepage>https://retroachievements.org</homepage>
 		<url>https://retroachievements.org/system/8/games</url>
-		<titlecount>136</titlecount>
-		<hashcount>177/228</hashcount>
+		<titlecount>134</titlecount>
+		<hashcount>176/227</hashcount>
 	</header>
-	<game name="Atlantean (World) (Aftermarket)">
+	<game name="Atlantean (World) (Aftermarket) (Unl)">
 		<category>Homebrew</category>
-		<description>Atlantean (World) (Aftermarket)</description>
-		<release name="Atlantean (World) (Aftermarket)" region="World"/>
-		<rom name="Atlantean (World) (Aftermarket).pce" size="524800" crc="ef596649" md5="b407192527c9472a489fea0aeac00f8d" sha1="d76f867256c3ff192b0cde8a1c685d558c2066c2"/>
+		<description>Atlantean (World) (Aftermarket) (Unl)</description>
+		<release name="Atlantean (World) (Aftermarket) (Unl)" region="World"/>
+		<rom name="Atlantean (World) (Aftermarket) (Unl).pce" size="524288" crc="fddc5814" md5="29abb6671fc4a4217473cd955cb76ae8" sha1="518341d715c8fb651edc1bacb2848dbb0acae097"/>
 		<url>https://retroachievements.org/game/18084/hashes</url>
 		<hash>29abb6671fc4a4217473cd955cb76ae8</hash>
 	</game>
 	
-	<game name="HuZERO (World) (Aftermarket)">
+	<game name="HuZERO (World) (Aftermarket) (Unl)">
 		<category>Homebrew</category>
-		<description>HuZERO (World) (Aftermarket)</description>
-		<release name="HuZERO (World) (Aftermarket)" region="World"/>
-		<rom name="HuZERO (World) (Aftermarket).pce" size="262144" crc="2871c4c0" md5="b14e14493c7c45b8d61c160236ac0f85" sha1="4328878a56f4cf34a9b62f6a4a2982bb57d695e8"/>
+		<description>HuZERO (World) (Aftermarket) (Unl)</description>
+		<release name="HuZERO (World) (Aftermarket) (Unl)" region="World"/>
+		<rom name="HuZERO (World) (Aftermarket) (Unl).pce" size="262144" crc="2871c4c0" md5="b14e14493c7c45b8d61c160236ac0f85" sha1="4328878a56f4cf34a9b62f6a4a2982bb57d695e8"/>
 		<url>https://retroachievements.org/game/20488/hashes</url>
 		<hash>b14e14493c7c45b8d61c160236ac0f85</hash>
 	</game>
 	
-	<game name="Maria (World) (Aftermarket) (No-Intro)">
+	<game name="Maria (World) (Aftermarket) (Unl)">
 		<category>Homebrew</category>
-		<description>Maria (World) (Aftermarket) (No-Intro)</description>
-		<rom name="Maria (World) (Aftermarket) (No-Intro).pce" size="491520" crc="192a5924" md5="de25a604c8f59525ef061ac5bb3567bd" sha1="cf64c8cf29c11310924362ff03dd7d8120debf8f"/>
+		<description>Maria (World) (Aftermarket) (Unl)</description>
+		<rom name="Maria (World) (Aftermarket) (Unl).pce" size="491520" crc="192a5924" md5="de25a604c8f59525ef061ac5bb3567bd" sha1="cf64c8cf29c11310924362ff03dd7d8120debf8f"/>
 		<url>https://retroachievements.org/game/13669/hashes</url>
 		<hash>de25a604c8f59525ef061ac5bb3567bd</hash>
 	</game>
-	<game name="Maria (World) (Aftermarket) (Itch.io)" cloneof="Maria (World) (Aftermarket) (No-Intro)">
+	<game name="Maria (World) (Aftermarket) (Itch.io)" cloneof="Maria (World) (Aftermarket) (Unl)">
 		<category>Homebrew</category>
 		<description>Maria (World) (Aftermarket) (Itch.io)</description>
 		<release name="Maria (World) (Aftermarket) (Itch.io)" region="World"/>
@@ -47,65 +47,65 @@
 		<hash>79e74b94605e3842fe5958bc0e37cc3f</hash>
 	</game>
 	
-	<game name="Mega Man 2 (World) (v0.87) (Aftermarket)">
+	<game name="Mega Man 2 (World) (v0.87) (Proto) (Aftermarket) (Unl)">
 		<category>Homebrew</category>
-		<description>Mega Man 2 (World) (v0.87) (Aftermarket)</description>
-		<release name="Mega Man 2 (World) (v0.87) (Aftermarket)" region="World"/>
-		<rom name="Mega Man 2 (World) (v0.87) (Aftermarket).pce" size="524288" crc="2fc86aff" md5="83079124c8efce1eee4c3a34a89441a5" sha1="3bad484a43682a11b79bb5e3ca39755922807e19"/>
+		<description>Mega Man 2 (World) (v0.87) (Proto) (Aftermarket) (Unl)</description>
+		<release name="Mega Man 2 (World) (v0.87) (Proto) (Aftermarket) (Unl)" region="World"/>
+		<rom name="Mega Man 2 (World) (v0.87) (Proto) (Aftermarket) (Unl).pce" size="524288" crc="2fc86aff" md5="83079124c8efce1eee4c3a34a89441a5" sha1="3bad484a43682a11b79bb5e3ca39755922807e19"/>
 		<url>https://retroachievements.org/game/18611/hashes</url>
 		<hash>83079124c8efce1eee4c3a34a89441a5</hash>
 	</game>
 	
-	<game name="Mega Man 2 (World) (v0.87) (Aftermarket) (Subset - Bonus)">
+	<game name="Mega Man 2 (World) (v0.87) (Proto) (Aftermarket) (Unl) (Subset - Bonus)">
 		<category>Subset</category>
-		<description>Mega Man 2 (World) (v0.87) (Aftermarket) (Subset - Bonus)</description>
-		<release name="Mega Man 2 (World) (v0.87) (Aftermarket) (Subset - Bonus)" region="World"/>
-		<rom name="Mega Man 2 (World) (v0.87) (Aftermarket) (Subset - Bonus).pce" size="524288" crc="64c67a8f" md5="e68b97f12b236e7b827dc77f98d29cd5" sha1="a6ac4b848d3d0d168c22a1d9954d636c5528aaea"/>
+		<description>Mega Man 2 (World) (v0.87) (Proto) (Aftermarket) (Unl) (Subset - Bonus)</description>
+		<release name="Mega Man 2 (World) (v0.87) (Proto) (Aftermarket) (Unl) (Subset - Bonus)" region="World"/>
+		<rom name="Mega Man 2 (World) (v0.87) (Proto) (Aftermarket) (Unl) (Subset - Bonus).pce" size="524288" crc="64c67a8f" md5="e68b97f12b236e7b827dc77f98d29cd5" sha1="a6ac4b848d3d0d168c22a1d9954d636c5528aaea"/>
 		<url>https://retroachievements.org/game/18643/hashes</url>
 		<hash>e68b97f12b236e7b827dc77f98d29cd5</hash>
 	</game>
 	
-	<game name="Nantettatte Engine (World) (Aftermarket)">
+	<game name="Nantettatte Engine (World) (Aftermarket) (Unl)">
 		<category>Homebrew</category>
-		<description>Nantettatte Engine (World) (Aftermarket)</description>
-		<release name="Nantettatte Engine (World) (Aftermarket)" region="World"/>
-		<rom name="Nantettatte Engine (World) (Aftermarket).pce" size="262144" crc="3974fb41" md5="a8264f87f8c2a9a97fe46c2fa3249deb" sha1="4b9cd0d86b6406142a306adcafe6ae9efbcd9b6b"/>
+		<description>Nantettatte Engine (World) (Aftermarket) (Unl)</description>
+		<release name="Nantettatte Engine (World) (Aftermarket) (Unl)" region="World"/>
+		<rom name="Nantettatte Engine (World) (Aftermarket) (Unl).pce" size="262144" crc="3974fb41" md5="a8264f87f8c2a9a97fe46c2fa3249deb" sha1="4b9cd0d86b6406142a306adcafe6ae9efbcd9b6b"/>
 		<url>https://retroachievements.org/game/28326/hashes</url>
 		<hash>a8264f87f8c2a9a97fe46c2fa3249deb</hash>
 	</game>
 	
-	<game name="Reflectron (World) (Aftermarket)">
+	<game name="Reflectron (World) (Aftermarket) (Unl)">
 		<category>Homebrew</category>
-		<description>Reflectron (World) (Aftermarket)</description>
-		<release name="Reflectron (World) (Aftermarket)" region="World"/>
-		<rom name="Reflectron (World) (Aftermarket).pce" size="262144" crc="6a3727e2" md5="40540be45e4f802344cfcb9f43b527b0" sha1="982a7627233c30cc23b85c666536d69faf3c2dbc"/>
+		<description>Reflectron (World) (Aftermarket) (Unl)</description>
+		<release name="Reflectron (World) (Aftermarket) (Unl)" region="World"/>
+		<rom name="Reflectron (World) (Aftermarket) (Unl).pce" size="262144" crc="6a3727e2" md5="40540be45e4f802344cfcb9f43b527b0" sha1="982a7627233c30cc23b85c666536d69faf3c2dbc"/>
 		<url>https://retroachievements.org/game/26878/hashes</url>
 		<hash>40540be45e4f802344cfcb9f43b527b0</hash>
 	</game>
 	
-	<game name="Santatlantean (World) (Aftermarket)">
+	<game name="Santatlantean (World) (Aftermarket) (Unl)">
 		<category>Homebrew</category>
-		<description>Santatlantean (World) (Aftermarket)</description>
-		<release name="Santatlantean (World) (Aftermarket)" region="World"/>
-		<rom name="Santatlantean (World) (Aftermarket).pce" size="524288" crc="f436b4ac" md5="12c9cb92855185a15b315435ec8eadf7" sha1="9e79251dc99a24ea03a2a431cac26a66e6c6a543"/>
+		<description>Santatlantean (World) (Aftermarket) (Unl)</description>
+		<release name="Santatlantean (World) (Aftermarket) (Unl)" region="World"/>
+		<rom name="Santatlantean (World) (Aftermarket) (Unl).pce" size="524288" crc="f436b4ac" md5="12c9cb92855185a15b315435ec8eadf7" sha1="9e79251dc99a24ea03a2a431cac26a66e6c6a543"/>
 		<url>https://retroachievements.org/game/18085/hashes</url>
 		<hash>12c9cb92855185a15b315435ec8eadf7</hash>
 	</game>
 	
-	<game name="Great Fumo Binning, The (World) (Aftermarket)">
+	<game name="Great Fumo Binning, The (World) (Aftermarket) (Unl)">
 		<category>Homebrew</category>
-		<description>Great Fumo Binning, The (World) (Aftermarket)</description>
-		<release name="Great Fumo Binning, The (World) (Aftermarket)" region="World"/>
-		<rom name="Great Fumo Binning, The (World) (Aftermarket).pce" size="73728" crc="8f92ac67" md5="de60a6746244d36a1bc9b8cc0abc481b" sha1="f81162d7eee56ab1e69abc33d7048e8ad127f11f"/>
+		<description>Great Fumo Binning, The (World) (Aftermarket) (Unl)</description>
+		<release name="Great Fumo Binning, The (World) (Aftermarket) (Unl)" region="World"/>
+		<rom name="Great Fumo Binning, The (World) (Aftermarket) (Unl).pce" size="73728" crc="8f92ac67" md5="de60a6746244d36a1bc9b8cc0abc481b" sha1="f81162d7eee56ab1e69abc33d7048e8ad127f11f"/>
 		<url>https://retroachievements.org/game/25183/hashes</url>
 		<hash>de60a6746244d36a1bc9b8cc0abc481b</hash>
 	</game>
 	
-	<game name="Tongueman's Logic (World) (Aftermarket)">
+	<game name="Tongueman's Logic (World) (Aftermarket) (Unl)">
 		<category>Homebrew</category>
-		<description>Tongueman's Logic (World) (Aftermarket)</description>
-		<release name="Tongueman's Logic (World) (Aftermarket)" region="World"/>
-		<rom name="Tongueman's Logic (World) (Aftermarket).pce" size="524288" crc="fe451c22" md5="15107f07c3b7a65a7e784add44349961" sha1="456c4a07b6e5d0a4e231aad3a479f97f3df02e21"/>
+		<description>Tongueman's Logic (World) (Aftermarket) (Unl)</description>
+		<release name="Tongueman's Logic (World) (Aftermarket) (Unl)" region="World"/>
+		<rom name="Tongueman's Logic (World) (Aftermarket) (Unl).pce" size="524288" crc="fe451c22" md5="15107f07c3b7a65a7e784add44349961" sha1="456c4a07b6e5d0a4e231aad3a479f97f3df02e21"/>
 		<url>https://retroachievements.org/game/14467/hashes</url>
 		<hash>15107f07c3b7a65a7e784add44349961</hash>
 	</game>
@@ -118,11 +118,11 @@
 		<url>https://retroachievements.org/game/9565/hashes</url>
 		<hash>71c5cffeab1cb60a04b5e77a338117ac</hash>
 	</game>
-	<game name="Lady Sword (Japan) (En) (v1.0) (EsperKnight,filler,Grant Laughlin,Tomaitheous) (Unl)" cloneof="Lady Sword - Ryakudatsu Sareta 10-nin no Otome (Japan) (Unl)">
+	<game name="Lady Sword - Ryakudatsu Sareta 10-nin no Otome (Japan) (En) (v1.0) (EsperKnight,filler,Grant Laughlin,Tomaitheous) (Unl)" cloneof="Lady Sword - Ryakudatsu Sareta 10-nin no Otome (Japan) (Unl)">
 		<category>Unlicensed</category>
-		<description>Lady Sword (Japan) (En) (v1.0) (EsperKnight,filler,Grant Laughlin,Tomaitheous) (Unl)</description>
-		<release name="Lady Sword (Japan) (En) (v1.0) (EsperKnight,filler,Grant Laughlin,Tomaitheous) (Unl)" region="English"/>
-		<rom name="Lady Sword (Japan) (En) (v1.0) (EsperKnight,filler,Grant Laughlin,Tomaitheous) (Unl).pce" size="1048576" crc="ff461dcd" md5="6b56d548b740cdbbc2993b5a8f03ffd4" sha1="7e6cf9b1c8ef96147129d297e0b39a2217d499f1"/>
+		<description>Lady Sword - Ryakudatsu Sareta 10-nin no Otome (Japan) (En) (v1.0) (EsperKnight,filler,Grant Laughlin,Tomaitheous) (Unl)</description>
+		<release name="Lady Sword - Ryakudatsu Sareta 10-nin no Otome (Japan) (En) (v1.0) (EsperKnight,filler,Grant Laughlin,Tomaitheous) (Unl)" region="English"/>
+		<rom name="Lady Sword - Ryakudatsu Sareta 10-nin no Otome (Japan) (En) (v1.0) (EsperKnight,filler,Grant Laughlin,Tomaitheous) (Unl).pce" size="1048576" crc="ff461dcd" md5="6b56d548b740cdbbc2993b5a8f03ffd4" sha1="7e6cf9b1c8ef96147129d297e0b39a2217d499f1"/>
 		<url>https://retroachievements.org/game/9565/hashes</url>
 		<hash>6b56d548b740cdbbc2993b5a8f03ffd4</hash>
 	</game>
@@ -391,7 +391,32 @@
 		<url>https://retroachievements.org/game/2285/hashes</url>
 		<hash>60bb0116b706fc30a76840ed0b5da458</hash>
 	</game>
-
+	
+	<game name="City Hunter (Japan)">
+		<category>Retail</category>
+		<description>City Hunter (Japan)</description>
+		<release name="City Hunter (Japan)" region="Japan"/>
+		<rom name="City Hunter (Japan).pce" size="393216" crc="f91b055f" md5="32a6a97aa9e69fa8091bfda374609922" sha1="8265cb33901609ec1cf156b8e0c7fc3884bc1acd"/>
+		<url>https://retroachievements.org/game/9171/hashes</url>
+		<hash>32a6a97aa9e69fa8091bfda374609922</hash>
+	</game>
+	<game name="City Hunter (Japan) (En) (v1.1) (filler,cabbage)" cloneof="City Hunter (Japan)">
+		<category>Retail</category>
+		<description>City Hunter (Japan) (En) (v1.1) (filler,cabbage)</description>
+		<release name="City Hunter (Japan) (En) (v1.1) (filler,cabbage)" region="English"/>
+		<rom name="City Hunter (Japan) (En) (v1.1) (filler,cabbage).pce" size="393216" crc="23f3df33" md5="9dcfed2ba5b59fa8f97387e01bb96f66" sha1="b92baeda4e71a0f348e2294a9deaa6fafa7bef6f"/>
+		<url>https://retroachievements.org/game/9171/hashes</url>
+		<hash>9dcfed2ba5b59fa8f97387e01bb96f66</hash>
+	</game>
+	<game name="City Hunter (Japan) (Fr) (v1.0) (Terminus Traduction)" cloneof="City Hunter (Japan)">
+		<category>Retail</category>
+		<description>City Hunter (Japan) (Fr) (v1.0) (Terminus Traduction)</description>
+		<release name="City Hunter (Japan) (Fr) (v1.0) (Terminus Traduction)" region="France"/>
+		<rom name="City Hunter (Japan) (Fr) (v1.0) (Terminus Traduction).pce" size="393216" crc="6301c5af" md5="ff76216eb5d8c0d773f20b3cb220f5ff" sha1="49e1113c8b3d8f4ea67c7a426a4c20d6967367ac"/>
+		<url>https://retroachievements.org/game/9171/hashes</url>
+		<hash>ff76216eb5d8c0d773f20b3cb220f5ff</hash>
+	</game>
+	
 	<game name="Columns (Japan)">
 		<category>Retail</category>
 		<description>Columns (Japan)</description>
@@ -637,11 +662,11 @@
 		<url>https://retroachievements.org/game/13409/hashes</url>
 		<hash>b928568fd7258f90b5ac410c7f65c48c</hash>
 	</game>
-	<game name="Energy (Japan) (En) (v1.01) (onionzoo, cabbage)" cloneof="Energy (Japan)">
+	<game name="Energy (Japan) (En) (v1.01) (onionzoo,cabbage)" cloneof="Energy (Japan)">
 		<category>Retail</category>
-		<description>Energy (Japan) (En) (v1.01) (onionzoo, cabbage)</description>
-		<release name="Energy (Japan) (En) (v1.01) (onionzoo, cabbage)" region="English"/>
-		<rom name="Energy (Japan) (En) (v1.01) (onionzoo, cabbage).pce" size="262144" crc="370fa62c" md5="7fc06f2e3131c1cfcddff6c69d54b8b9" sha1="d237dff176ef5193885fdc4abb469f6435dd2aac"/>
+		<description>Energy (Japan) (En) (v1.01) (onionzoo,cabbage)</description>
+		<release name="Energy (Japan) (En) (v1.01) (onionzoo,cabbage)" region="English"/>
+		<rom name="Energy (Japan) (En) (v1.01) (onionzoo,cabbage).pce" size="262144" crc="370fa62c" md5="7fc06f2e3131c1cfcddff6c69d54b8b9" sha1="d237dff176ef5193885fdc4abb469f6435dd2aac"/>
 		<url>https://retroachievements.org/game/13409/hashes</url>
 		<hash>7fc06f2e3131c1cfcddff6c69d54b8b9</hash>
 	</game>
@@ -689,11 +714,11 @@
 		<url>https://retroachievements.org/game/7193/hashes</url>
 		<hash>3e0cd9af31efe11acf733fb15dc31131</hash>
 	</game>
-	<game name="Fushigi no Yume no Alice (Japan) (En) (v1.0)" cloneof="Fushigi no Yume no Alice (Japan)">
+	<game name="Fushigi no Yume no Alice (Japan) (En) (v1.0) (Dave Shadoff,filler,MooZ,Diogo Ribeiro)" cloneof="Fushigi no Yume no Alice (Japan)">
 		<category>Retail</category>
-		<description>Fushigi no Yume no Alice (Japan) (En) (v1.0)</description>
-		<release name="Fushigi no Yume no Alice (Japan) (En) (v1.0)" region="English"/>
-		<rom name="Fushigi no Yume no Alice (Japan) (En) (v1.0).pce" size="393216" crc="c21f25c4" md5="4ed3f4820b238d5c1cb49dcaf24f382a" sha1="9868a3049e6bbc75a537415a2db8bbda17dc1864"/>
+		<description>Fushigi no Yume no Alice (Japan) (En) (v1.0) (Dave Shadoff,filler,MooZ,Diogo Ribeiro)</description>
+		<release name="Fushigi no Yume no Alice (Japan) (En) (v1.0) (Dave Shadoff,filler,MooZ,Diogo Ribeiro)" region="English"/>
+		<rom name="Fushigi no Yume no Alice (Japan) (En) (v1.0) (Dave Shadoff,filler,MooZ,Diogo Ribeiro).pce" size="393216" crc="c21f25c4" md5="4ed3f4820b238d5c1cb49dcaf24f382a" sha1="9868a3049e6bbc75a537415a2db8bbda17dc1864"/>
 		<url>https://retroachievements.org/game/7193/hashes</url>
 		<hash>4ed3f4820b238d5c1cb49dcaf24f382a</hash>
 	</game>
@@ -750,7 +775,7 @@
 		<url>https://retroachievements.org/game/14455/hashes</url>
 		<hash>144eb9109d75c8fd1fa09a20bde6a6cd</hash>
 	</game>
-
+	
 	<game name="Gomola Speed (Japan) (En)">
 		<category>Retail</category>
 		<description>Gomola Speed (Japan) (En)</description>
@@ -769,11 +794,11 @@
 		<hash>16fe78b1630a790bee6755e3c850a366</hash>
 	</game>
 	
-	<game name="Hanii in the Sky (Japan) (En) (v1.0) (filler, cabbage)">
+	<game name="Hanii in the Sky (Japan) (En) (v1.0) (filler,cabbage)">
 		<category>Retail</category>
-		<description>Hanii in the Sky (Japan) (En) (v1.0) (filler, cabbage)</description>
-		<release name="Hanii in the Sky (Japan) (En) (v1.0) (filler, cabbage)" region="English"/>
-		<rom name="Hanii in the Sky (Japan) (En) (v1.0) (filler, cabbage).pce" size="262144" crc="d1dc2f66" md5="015b8a761e1c3a8d0d474ef7e1063a55" sha1="ef3e666d73293e766e88c77e8bdfa331399789a6"/>
+		<description>Hanii in the Sky (Japan) (En) (v1.0) (filler,cabbage)</description>
+		<release name="Hanii in the Sky (Japan) (En) (v1.0) (filler,cabbage)" region="English"/>
+		<rom name="Hanii in the Sky (Japan) (En) (v1.0) (filler,cabbage).pce" size="262144" crc="d1dc2f66" md5="015b8a761e1c3a8d0d474ef7e1063a55" sha1="ef3e666d73293e766e88c77e8bdfa331399789a6"/>
 		<url>https://retroachievements.org/game/18741/hashes</url>
 		<hash>015b8a761e1c3a8d0d474ef7e1063a55</hash>
 	</game>
@@ -803,7 +828,7 @@
 		<url>https://retroachievements.org/game/7444/hashes</url>
 		<hash>23df0b354e83876a94e9c128a7a9eb80</hash>
 	</game>
-
+	
 	<game name="Jackie Chan's Action Kung Fu (USA)">
 		<category>Retail</category>
 		<description>Jackie Chan's Action Kung Fu (USA)</description>
@@ -891,7 +916,7 @@
 		<url>https://retroachievements.org/game/2306/hashes</url>
 		<hash>74d9f1bd96ba2690ed4cb989ebaeb948</hash>
 	</game>
-
+	
 	<game name="Makai Hakkenden - Shada (Japan)">
 		<category>Retail</category>
 		<description>Makai Hakkenden - Shada (Japan)</description>
@@ -900,11 +925,11 @@
 		<url>https://retroachievements.org/game/22775/hashes</url>
 		<hash>06c9c65e0e1c0669be28cc99ace61f54</hash>
 	</game>
-	<game name="Makai Hakkenden - Shada (Japan) (En) (v1.0) (Shubibiman, cabbage)" cloneof="Makai Hakkenden - Shada (Japan)">
+	<game name="Makai Hakkenden - Shada (Japan) (En) (v1.0) (Shubibiman,cabbage)" cloneof="Makai Hakkenden - Shada (Japan)">
 		<category>Retail</category>
-		<description>Makai Hakkenden - Shada (Japan) (En) (v1.0) (Shubibiman, cabbage)</description>
-		<release name="Makai Hakkenden - Shada (Japan) (En) (v1.0) (Shubibiman, cabbage)" region="English"/>
-		<rom name="Makai Hakkenden - Shada (Japan) (En) (v1.0) (Shubibiman, cabbage).pce" size="262144" crc="017de16d" md5="6b33184f381d3bfc9870f5ad55b8c78a" sha1="448991d34538c40cb8d7738ed1093b86c4dd1cfd"/>
+		<description>Makai Hakkenden - Shada (Japan) (En) (v1.0) (Shubibiman,cabbage)</description>
+		<release name="Makai Hakkenden - Shada (Japan) (En) (v1.0) (Shubibiman,cabbage)" region="English"/>
+		<rom name="Makai Hakkenden - Shada (Japan) (En) (v1.0) (Shubibiman,cabbage).pce" size="262144" crc="017de16d" md5="6b33184f381d3bfc9870f5ad55b8c78a" sha1="448991d34538c40cb8d7738ed1093b86c4dd1cfd"/>
 		<url>https://retroachievements.org/game/22775/hashes</url>
 		<hash>6b33184f381d3bfc9870f5ad55b8c78a</hash>
 	</game>
@@ -926,11 +951,11 @@
 		<url>https://retroachievements.org/game/19923/hashes</url>
 		<hash>887b9fa8296ff3c98839e11cc7039763</hash>
 	</game>
-	<game name="Maerchen Maze (Japan) (En) (v1.1) (MooZ &amp; Shubibiman)" cloneof="Maerchen Maze (Japan)">
+	<game name="Maerchen Maze (Japan) (En) (v1.1) (MooZ,Shubibiman)" cloneof="Maerchen Maze (Japan)">
 		<category>Retail</category>
-		<description>Maerchen Maze (Japan) (En) (v1.1) (MooZ &amp; Shubibiman)</description>
-		<release name="Maerchen Maze (Japan) (En) (v1.1) (MooZ &amp; Shubibiman)" region="English"/>
-		<rom name="Maerchen Maze (Japan) (En) (v1.1) (MooZ &amp; Shubibiman).pce" size="262144" crc="b7166358" md5="f34299acd4a789ad51e7b10be3a8947d" sha1="caf03a4bd2b8e74746b98c0b8be312231e447064"/>
+		<description>Maerchen Maze (Japan) (En) (v1.1) (MooZ,Shubibiman)</description>
+		<release name="Maerchen Maze (Japan) (En) (v1.1) (MooZ,Shubibiman)" region="English"/>
+		<rom name="Maerchen Maze (Japan) (En) (v1.1) (MooZ,Shubibiman).pce" size="262144" crc="b7166358" md5="f34299acd4a789ad51e7b10be3a8947d" sha1="caf03a4bd2b8e74746b98c0b8be312231e447064"/>
 		<url>https://retroachievements.org/game/19923/hashes</url>
 		<hash>f34299acd4a789ad51e7b10be3a8947d</hash>
 	</game>
@@ -961,7 +986,7 @@
 		<url>https://retroachievements.org/game/2308/hashes</url>
 		<hash>1b10baf9f65c8339a507e382bda5ed44</hash>
 	</game>
-
+	
 	<game name="Neutopia - Frey no Shou (Japan)" cloneof="Neutopia (USA)">
 		<category>Retail</category>
 		<description>Neutopia - Frey no Shou (Japan)</description>
@@ -1222,7 +1247,7 @@
 		<url>https://retroachievements.org/game/6026/hashes</url>
 		<hash>1659d9fa2ed7628d342fd7c7fbe6d439</hash>
 	</game>
-
+	
 	<game name="Shiryou Sensen - War of the Dead (Japan) (En) (v1.0) (Nebulous Translations)" cloneof="Shiryou Sensen - War of the Dead (Japan)">
 		<category>Retail</category>
 		<description>Shiryou Sensen - War of the Dead (Japan) (En) (v1.0) (Nebulous Translations)</description>

--- a/DATs/RetroAchievements (No Subfolders)/RA - Nintendo Pokemon Mini.dat
+++ b/DATs/RetroAchievements (No Subfolders)/RA - Nintendo Pokemon Mini.dat
@@ -5,181 +5,181 @@
 		<name>RA - Nintendo Pokemon Mini</name>
 		<description>Nintendo Pokemon Mini</description>
 		<category>No Subfolders</category>
-		<version>20260227</version>
-		<date>27 February 2026</date>
+		<version>20260428</version>
+		<date>28 April 2026</date>
 		<author>AzgoRAth, NeoRetroGamer (Contributor), Jumphil (Contributor)</author>
 		<homepage>https://retroachievements.org</homepage>
 		<url>https://retroachievements.org/system/24/games</url>
-		<titlecount>38</titlecount>
-		<hashcount>50</hashcount>
+		<titlecount>40</titlecount>
+		<hashcount>52</hashcount>
 	</header>
-	<game name="2048 (World) (Demo) (Aftermarket)">
+	<game name="2048 (World) (Aftermarket) (Unl)">
 		<category>Homebrew</category>
-		<description>2048 (World) (Demo) (Aftermarket)</description>
-		<release name="2048 (World) (Demo) (Aftermarket)" region="World"/>
-		<rom name="2048 (World) (Demo) (Aftermarket).min" size="65536" crc="f7e4e560" md5="59a694c43054a267c434424edfb7aa10" sha1="0e8912627e2ff35c9467ce6da6f03ceac8419524"/>
+		<description>2048 (World) (Aftermarket) (Unl)</description>
+		<release name="2048 (World) (Aftermarket) (Unl)" region="World"/>
+		<rom name="2048 (World) (Aftermarket) (Unl).min" size="65536" crc="f7e4e560" md5="59a694c43054a267c434424edfb7aa10" sha1="0e8912627e2ff35c9467ce6da6f03ceac8419524"/>
 		<url>https://retroachievements.org/game/24918/hashes</url>
 		<hash>59a694c43054a267c434424edfb7aa10</hash>
 	</game>
 	
-	<game name="GJPG (World) (Demo) (Aftermarket)">
+	<game name="GJPG (World) (Demo) (Aftermarket) (Unl)">
 		<category>Homebrew</category>
-		<description>GJPG (World) (Demo) (Aftermarket)</description>
-		<release name="GJPG (World) (Demo) (Aftermarket)" region="World"/>
-		<rom name="GJPG (World) (Demo) (Aftermarket).min" size="34176" crc="9bb36b84" md5="86756b56e0d2e6c40a9e746f67a2d1c0" sha1="6becf786c3975c57dc338add6f7f8b3f85b7bf7d"/>
+		<description>GJPG (World) (Demo) (Aftermarket) (Unl)</description>
+		<release name="GJPG (World) (Demo) (Aftermarket) (Unl)" region="World"/>
+		<rom name="GJPG (World) (Demo) (Aftermarket) (Unl).min" size="34176" crc="9bb36b84" md5="86756b56e0d2e6c40a9e746f67a2d1c0" sha1="6becf786c3975c57dc338add6f7f8b3f85b7bf7d"/>
 		<url>https://retroachievements.org/game/21565/hashes</url>
 		<hash>86756b56e0d2e6c40a9e746f67a2d1c0</hash>
 	</game>
 	
-	<game name="Loopover (World) (Demo) (Aftermarket)">
+	<game name="Loopover (World) (Demo) (Aftermarket) (Unl)">
 		<category>Homebrew</category>
-		<description>Loopover (World) (Demo) (Aftermarket)</description>
-		<release name="Loopover (World) (Demo) (Aftermarket)" region="World"/>
-		<rom name="Loopover (World) (Demo) (Aftermarket).min" size="65600" crc="fc2a1c6a" md5="be6a27e04fa02f2c7214431e0aa8a2cd" sha1="1a11c8abccffccddff2f760e8945bdf2e2af461a"/>
+		<description>Loopover (World) (Demo) (Aftermarket) (Unl)</description>
+		<release name="Loopover (World) (Demo) (Aftermarket) (Unl)" region="World"/>
+		<rom name="Loopover (World) (Demo) (Aftermarket) (Unl).min" size="65600" crc="fc2a1c6a" md5="be6a27e04fa02f2c7214431e0aa8a2cd" sha1="1a11c8abccffccddff2f760e8945bdf2e2af461a"/>
 		<url>https://retroachievements.org/game/21715/hashes</url>
 		<hash>be6a27e04fa02f2c7214431e0aa8a2cd</hash>
 	</game>
 	
-	<game name="P-Type (World) (Demo) (Aftermarket)">
+	<game name="P-Type (World) (Demo) (Aftermarket) (Unl)">
 		<category>Homebrew</category>
-		<description>P-Type (World) (Demo) (Aftermarket)</description>
-		<release name="P-Type (World) (Demo) (Aftermarket)" region="World"/>
-		<rom name="P-Type (World) (Demo) (Aftermarket).min" size="20864" crc="c02810fc" md5="389dc3409fe795b18a0894548dd7bed6" sha1="f2285e76442fa0f18b39f8153eb1912f96392447"/>
+		<description>P-Type (World) (Demo) (Aftermarket) (Unl)</description>
+		<release name="P-Type (World) (Demo) (Aftermarket) (Unl)" region="World"/>
+		<rom name="P-Type (World) (Demo) (Aftermarket) (Unl).min" size="20864" crc="c02810fc" md5="389dc3409fe795b18a0894548dd7bed6" sha1="f2285e76442fa0f18b39f8153eb1912f96392447"/>
 		<url>https://retroachievements.org/game/19505/hashes</url>
 		<hash>389dc3409fe795b18a0894548dd7bed6</hash>
 	</game>
 	
-	<game name="Pazuru (World) (Demo) (Aftermarket)">
+	<game name="Pazuru (World) (Aftermarket) (Unl)">
 		<category>Homebrew</category>
-		<description>Pazuru (World) (Demo) (Aftermarket)</description>
-		<release name="Pazuru (World) (Demo) (Aftermarket)" region="World"/>
-		<rom name="Pazuru (World) (Demo) (Aftermarket).min" size="29568" crc="08c07ddf" md5="ea7a26be47020af10058ac36a8b6d626" sha1="bf31fcc3b834be3d2deeb8e15b085be5dc87849b"/>
+		<description>Pazuru (World) (Aftermarket) (Unl)</description>
+		<release name="Pazuru (World) (Aftermarket) (Unl)" region="World"/>
+		<rom name="Pazuru (World) (Aftermarket) (Unl).min" size="29568" crc="08c07ddf" md5="ea7a26be47020af10058ac36a8b6d626" sha1="bf31fcc3b834be3d2deeb8e15b085be5dc87849b"/>
 		<url>https://retroachievements.org/game/15908/hashes</url>
 		<hash>ea7a26be47020af10058ac36a8b6d626</hash>
 	</game>
 	
-	<game name="Pokemon Orange (World) (v0.54) (Demo) (Aftermarket)">
+	<game name="Pokemon Orange (World) (Demo) (v0.54) (Aftermarket) (Unl)">
 		<category>Homebrew</category>
-		<description>Pokemon Orange (World) (v0.54) (Demo) (Aftermarket)</description>
-		<release name="Pokemon Orange (World) (v0.54) (Demo) (Aftermarket)" region="World"/>
-		<rom name="Pokemon Orange (World) (v0.54) (Demo) (Aftermarket).min" size="19280" crc="c81e7bd9" md5="de89be869046a1cd60ea469c6df8a2b3" sha1="1665a4f57e1b63f57046e1abeb00fd723fc3e772"/>
+		<description>Pokemon Orange (World) (Demo) (v0.54) (Aftermarket) (Unl)</description>
+		<release name="Pokemon Orange (World) (Demo) (v0.54) (Aftermarket) (Unl)" region="World"/>
+		<rom name="Pokemon Orange (World) (Demo) (v0.54) (Aftermarket) (Unl).min" size="19280" crc="c81e7bd9" md5="de89be869046a1cd60ea469c6df8a2b3" sha1="1665a4f57e1b63f57046e1abeb00fd723fc3e772"/>
 		<url>https://retroachievements.org/game/17393/hashes</url>
 		<hash>de89be869046a1cd60ea469c6df8a2b3</hash>
 	</game>
 	
-	<game name="Silver Falls - Monsters In North Island (World) (Demo) (Aftermarket)">
+	<game name="Silver Falls - Monsters In North Island (World) (Aftermarket) (Unl)">
 		<category>Homebrew</category>
-		<description>Silver Falls - Monsters In North Island (World) (Demo) (Aftermarket)</description>
-		<release name="Silver Falls - Monsters In North Island (World) (Demo) (Aftermarket)" region="World"/>
-		<rom name="Silver Falls - Monsters In North Island (World) (Demo) (Aftermarket).min" size="74419" crc="68e0da6f" md5="0ce0bead3ee9911765d3d0eb097ee7e7" sha1="f3b3a7e95738033712e5adb0acb3b26c8dc2bdb2"/>
+		<description>Silver Falls - Monsters In North Island (World) (Aftermarket) (Unl)</description>
+		<release name="Silver Falls - Monsters In North Island (World) (Aftermarket) (Unl)" region="World"/>
+		<rom name="Silver Falls - Monsters In North Island (World) (Aftermarket) (Unl).min" size="74419" crc="68e0da6f" md5="0ce0bead3ee9911765d3d0eb097ee7e7" sha1="f3b3a7e95738033712e5adb0acb3b26c8dc2bdb2"/>
 		<url>https://retroachievements.org/game/28820/hashes</url>
 		<hash>0ce0bead3ee9911765d3d0eb097ee7e7</hash>
 	</game>
 	
-	<game name="Wooloo's Run Away (World) (Demo) (Aftermarket)">
+	<game name="Wooloo's Run Away (World) (Demo) (Aftermarket) (Unl)">
 		<category>Homebrew</category>
-		<description>Wooloo's Run Away (World) (Demo) (Aftermarket)</description>
-		<release name="Wooloo's Run Away (World) (Demo) (Aftermarket)" region="World"/>
-		<rom name="Wooloo's Run Away (World) (Demo) (Aftermarket).min" size="67584" crc="5c2fde5f" md5="890fed94636776716a2b7b0754c8d5be" sha1="2feed40306fa4a253ab206b1e74ef4c407c7fdea"/>
+		<description>Wooloo's Run Away (World) (Demo) (Aftermarket) (Unl)</description>
+		<release name="Wooloo's Run Away (World) (Demo) (Aftermarket) (Unl)" region="World"/>
+		<rom name="Wooloo's Run Away (World) (Demo) (Aftermarket) (Unl).min" size="67584" crc="5c2fde5f" md5="890fed94636776716a2b7b0754c8d5be" sha1="2feed40306fa4a253ab206b1e74ef4c407c7fdea"/>
 		<url>https://retroachievements.org/game/21685/hashes</url>
 		<hash>890fed94636776716a2b7b0754c8d5be</hash>
 	</game>
 	
-	<game name="Zelda Mini (World) (v1.0) (Demo) (Aftermarket)">
+	<game name="Zelda Mini (World) (Demo) (v1.0) (Aftermarket) (Unl)">
 		<category>Homebrew</category>
-		<description>Zelda Mini (World) (v1.0) (Demo) (Aftermarket)</description>
-		<release name="Zelda Mini (World) (v1.0) (Demo) (Aftermarket)" region="World"/>
-		<rom name="Zelda Mini (World) (v1.0) (Demo) (Aftermarket).min" size="17995" crc="87d86d1c" md5="d204bb4f33c0034dc6cdd8c9b6ff9846" sha1="1e4dc752bfffeb7fc5a281d20d3b583aca8e7f20"/>
+		<description>Zelda Mini (World) (Demo) (v1.0) (Aftermarket) (Unl)</description>
+		<release name="Zelda Mini (World) (Demo) (v1.0) (Aftermarket) (Unl)" region="World"/>
+		<rom name="Zelda Mini (World) (Demo) (v1.0) (Aftermarket) (Unl).min" size="17995" crc="87d86d1c" md5="d204bb4f33c0034dc6cdd8c9b6ff9846" sha1="1e4dc752bfffeb7fc5a281d20d3b583aca8e7f20"/>
 		<url>https://retroachievements.org/game/18331/hashes</url>
 		<hash>d204bb4f33c0034dc6cdd8c9b6ff9846</hash>
 	</game>
 	
-	<game name="PokeMaze (World) (Proto) (Aftermarket)">
+	<game name="PokeMaze (World) (Proto) (Aftermarket) (Unl)">
 		<category>Homebrew</category>
-		<description>PokeMaze (World) (Proto) (Aftermarket)</description>
-		<release name="PokeMaze (World) (Proto) (Aftermarket)" region="World"/>
-		<rom name="PokeMaze (World) (Proto) (Aftermarket).min" size="14304" crc="6d45286a" md5="db53ab1335e95df2b33d4ef3735d7af6" sha1="c436ae6659b96d2290c6909c751247207e371bfe"/>
+		<description>PokeMaze (World) (Proto) (Aftermarket) (Unl)</description>
+		<release name="PokeMaze (World) (Proto) (Aftermarket) (Unl)" region="World"/>
+		<rom name="PokeMaze (World) (Proto) (Aftermarket) (Unl).min" size="14304" crc="6d45286a" md5="db53ab1335e95df2b33d4ef3735d7af6" sha1="c436ae6659b96d2290c6909c751247207e371bfe"/>
 		<url>https://retroachievements.org/game/15722/hashes</url>
 		<hash>db53ab1335e95df2b33d4ef3735d7af6</hash>
 	</game>
 	
-	<game name="Bat Trip (World) (Aftermarket)">
+	<game name="Bat Trip (World) (Aftermarket) (Unl)">
 		<category>Homebrew</category>
-		<description>Bat Trip (World) (Aftermarket)</description>
-		<release name="Bat Trip (World) (Aftermarket)" region="World"/>
-		<rom name="Bat Trip (World) (Aftermarket).min" size="78592" crc="82ef1716" md5="f8cac8a6bec766f8f6905b77aab3b29f" sha1="0afdd1a7242f0caa0fdd42f81b8a394b873adf9b"/>
+		<description>Bat Trip (World) (Aftermarket) (Unl)</description>
+		<release name="Bat Trip (World) (Aftermarket) (Unl)" region="World"/>
+		<rom name="Bat Trip (World) (Aftermarket) (Unl).min" size="78592" crc="82ef1716" md5="f8cac8a6bec766f8f6905b77aab3b29f" sha1="0afdd1a7242f0caa0fdd42f81b8a394b873adf9b"/>
 		<url>https://retroachievements.org/game/22050/hashes</url>
 		<hash>f8cac8a6bec766f8f6905b77aab3b29f</hash>
 	</game>
 	
-	<game name="Coretex (World) (v0.70) (Aftermarket)">
+	<game name="Coretex (World) (v0.70) (Aftermarket) (Unl)">
 		<category>Homebrew</category>
-		<description>Coretex (World) (v0.70) (Aftermarket)</description>
-		<release name="Coretex (World) (v0.70) (Aftermarket)" region="World"/>
-		<rom name="Coretex (World) (v0.70) (Aftermarket).min" size="29359" crc="892b1b54" md5="f03d77b9353c9b875a6331275bb480a5" sha1="161a2a6c0d34c59ac5353f82d5d87fc00d109834"/>
+		<description>Coretex (World) (v0.70) (Aftermarket) (Unl)</description>
+		<release name="Coretex (World) (v0.70) (Aftermarket) (Unl)" region="World"/>
+		<rom name="Coretex (World) (v0.70) (Aftermarket) (Unl).min" size="29359" crc="892b1b54" md5="f03d77b9353c9b875a6331275bb480a5" sha1="161a2a6c0d34c59ac5353f82d5d87fc00d109834"/>
 		<url>https://retroachievements.org/game/15725/hashes</url>
 		<hash>f03d77b9353c9b875a6331275bb480a5</hash>
 	</game>
 	
-	<game name="Deathtrap (World) (v1.1) (Aftermarket)">
+	<game name="Deathtrap (World) (v1.1) (Aftermarket) (Unl)">
 		<category>Homebrew</category>
-		<description>Deathtrap (World) (v1.1) (Aftermarket)</description>
-		<release name="Deathtrap (World) (v1.1) (Aftermarket)" region="World"/>
-		<rom name="Deathtrap (World) (v1.1) (Aftermarket).min" size="19520" crc="5645b12f" md5="e82230f90504c966610a31b8186ff419" sha1="894fb6f9f3e21ef644f62e569789a4f062e82c47"/>
+		<description>Deathtrap (World) (v1.1) (Aftermarket) (Unl)</description>
+		<release name="Deathtrap (World) (v1.1) (Aftermarket) (Unl)" region="World"/>
+		<rom name="Deathtrap (World) (v1.1) (Aftermarket) (Unl).min" size="19520" crc="5645b12f" md5="e82230f90504c966610a31b8186ff419" sha1="894fb6f9f3e21ef644f62e569789a4f062e82c47"/>
 		<url>https://retroachievements.org/game/19498/hashes</url>
 		<hash>e82230f90504c966610a31b8186ff419</hash>
 	</game>
 	
-	<game name="Flappy Bird (World) (Aftermarket)">
+	<game name="Flappy Bird (World) (Demo) (Aftermarket) (Unl)">
 		<category>Homebrew</category>
-		<description>Flappy Bird (World) (Aftermarket)</description>
-		<release name="Flappy Bird (World) (Aftermarket)" region="World"/>
-		<rom name="Flappy Bird (World) (Aftermarket).min" size="32176" crc="f370b21d" md5="613cb77ff503f8fd374727526b6a1581" sha1="46938f04135127201e6f10beacd69bf6710d5a18"/>
+		<description>Flappy Bird (World) (Demo) (Aftermarket) (Unl)</description>
+		<release name="Flappy Bird (World) (Demo) (Aftermarket) (Unl)" region="World"/>
+		<rom name="Flappy Bird (World) (Demo) (Aftermarket) (Unl).min" size="32176" crc="f370b21d" md5="613cb77ff503f8fd374727526b6a1581" sha1="46938f04135127201e6f10beacd69bf6710d5a18"/>
 		<url>https://retroachievements.org/game/17676/hashes</url>
 		<hash>613cb77ff503f8fd374727526b6a1581</hash>
 	</game>
 	
-	<game name="Franky the Fruit Fly (World) (v2021-05-21) (Aftermarket)">
+	<game name="Franky the Fruit Fly (World) (v2021-05-21) (Aftermarket) (Unl)">
 		<category>Homebrew</category>
-		<description>Franky the Fruit Fly (World) (v2021-05-21) (Aftermarket)</description>
-		<release name="Franky the Fruit Fly (World) (v2021-05-21) (Aftermarket)" region="World"/>
-		<rom name="Franky the Fruit Fly (World) (v2021-05-21) (Aftermarket).min" size="233456" crc="04c39c90" md5="3e3c37a97fa0c772bdb0237b3c220315" sha1="5fd05bc6e5746a311beb22ae5531210569f1e1a2"/>
+		<description>Franky the Fruit Fly (World) (v2021-05-21) (Aftermarket) (Unl)</description>
+		<release name="Franky the Fruit Fly (World) (v2021-05-21) (Aftermarket) (Unl)" region="World"/>
+		<rom name="Franky the Fruit Fly (World) (v2021-05-21) (Aftermarket) (Unl).min" size="233456" crc="04c39c90" md5="3e3c37a97fa0c772bdb0237b3c220315" sha1="5fd05bc6e5746a311beb22ae5531210569f1e1a2"/>
 		<url>https://retroachievements.org/game/14713/hashes</url>
 		<hash>3e3c37a97fa0c772bdb0237b3c220315</hash>
 	</game>
 	
-	<game name="Galactix (World) (Aftermarket)">
+	<game name="Galactix (World) (Aftermarket) (Unl)">
 		<category>Homebrew</category>
-		<description>Galactix (World) (Aftermarket)</description>
-		<release name="Galactix (World) (Aftermarket)" region="World"/>
-		<rom name="Galactix (World) (Aftermarket).min" size="70046" crc="4e6305b7" md5="4e66ffdb6eed6652e4a443247a74038a" sha1="90fd0d0f8fd8a5d7540e8d324482fb02ac6bec00"/>
+		<description>Galactix (World) (Aftermarket) (Unl)</description>
+		<release name="Galactix (World) (Aftermarket) (Unl)" region="World"/>
+		<rom name="Galactix (World) (Aftermarket) (Unl).min" size="70046" crc="4e6305b7" md5="4e66ffdb6eed6652e4a443247a74038a" sha1="90fd0d0f8fd8a5d7540e8d324482fb02ac6bec00"/>
 		<url>https://retroachievements.org/game/15726/hashes</url>
 		<hash>4e66ffdb6eed6652e4a443247a74038a</hash>
 	</game>
 	
-	<game name="Hamburger in Space! (World) (Aftermarket)">
+	<game name="Hamburger in Space! (World) (Aftermarket) (Unl)">
 		<category>Homebrew</category>
-		<description>Hamburger in Space! (World) (Aftermarket)</description>
-		<release name="Hamburger in Space! (World) (Aftermarket)" region="World"/>
-		<rom name="Hamburger in Space! (World) (Aftermarket).min" size="14592" crc="a340af09" md5="decbb5eacc06db3b4e9f6d206b3bffb9" sha1="27c673af03acee80da08340393edcf4568f13ceb"/>
+		<description>Hamburger in Space! (World) (Aftermarket) (Unl)</description>
+		<release name="Hamburger in Space! (World) (Aftermarket) (Unl)" region="World"/>
+		<rom name="Hamburger in Space! (World) (Aftermarket) (Unl).min" size="14592" crc="a340af09" md5="decbb5eacc06db3b4e9f6d206b3bffb9" sha1="27c673af03acee80da08340393edcf4568f13ceb"/>
 		<url>https://retroachievements.org/game/19708/hashes</url>
 		<hash>decbb5eacc06db3b4e9f6d206b3bffb9</hash>
 	</game>
 	
-	<game name="LightsOut (World) (v1.1) (Aftermarket)">
+	<game name="LightsOut (World) (v1.1) (Aftermarket) (Unl)">
 		<category>Homebrew</category>
-		<description>LightsOut (World) (v1.1) (Aftermarket)</description>
-		<release name="LightsOut (World) (v1.1) (Aftermarket)" region="World"/>
-		<rom name="LightsOut (World) (v1.1) (Aftermarket).min" size="69376" crc="a504bd34" md5="43dbd3bda79b2e72276ef444152b695f" sha1="cc98b80a9889044e80b408d79d42e4037130b439"/>
+		<description>LightsOut (World) (v1.1) (Aftermarket) (Unl)</description>
+		<release name="LightsOut (World) (v1.1) (Aftermarket) (Unl)" region="World"/>
+		<rom name="LightsOut (World) (v1.1) (Aftermarket) (Unl).min" size="69376" crc="a504bd34" md5="43dbd3bda79b2e72276ef444152b695f" sha1="cc98b80a9889044e80b408d79d42e4037130b439"/>
 		<url>https://retroachievements.org/game/15727/hashes</url>
 		<hash>43dbd3bda79b2e72276ef444152b695f</hash>
 	</game>
 	
-	<game name="Mini Cookie (World) (Aftermarket)">
+	<game name="Mini Cookie (World) (Demo) (Aftermarket) (Unl)">
 		<category>Homebrew</category>
-		<description>Mini Cookie (World) (Aftermarket)</description>
-		<release name="Mini Cookie (World) (Aftermarket)" region="World"/>
-		<rom name="Mini Cookie (World) (Aftermarket).min" size="12544" crc="b2a9a1ee" md5="78197d139406095e68b0043fbf004860" sha1="9dfc34364ab09fe3211a0b7188b214780a17e85e"/>
+		<description>Mini Cookie (World) (Demo) (Aftermarket) (Unl)</description>
+		<release name="Mini Cookie (World) (Demo) (Aftermarket) (Unl)" region="World"/>
+		<rom name="Mini Cookie (World) (Demo) (Aftermarket) (Unl).min" size="12544" crc="b2a9a1ee" md5="78197d139406095e68b0043fbf004860" sha1="9dfc34364ab09fe3211a0b7188b214780a17e85e"/>
 		<url>https://retroachievements.org/game/18257/hashes</url>
 		<hash>78197d139406095e68b0043fbf004860</hash>
 	</game>
@@ -193,29 +193,29 @@
 		<hash>ef8984f9e252298296f373598ca63e7e</hash>
 	</game>
 	
-	<game name="Pac-It (World) (Aftermarket)">
+	<game name="Pac-It (World) (Demo) (Aftermarket) (Unl)">
 		<category>Homebrew</category>
-		<description>Pac-It (World) (Aftermarket)</description>
-		<release name="Pac-It (World) (Aftermarket)" region="World"/>
-		<rom name="Pac-It (World) (Aftermarket).min" size="82688" crc="c9e2b23b" md5="c73d85b16295266a4e3fe62ecdb761b2" sha1="4057dd97313444d05db4264f57c0917e6b427d6b"/>
+		<description>Pac-It (World) (Demo) (Aftermarket) (Unl)</description>
+		<release name="Pac-It (World) (Demo) (Aftermarket) (Unl)" region="World"/>
+		<rom name="Pac-It (World) (Demo) (Aftermarket) (Unl).min" size="82688" crc="c9e2b23b" md5="c73d85b16295266a4e3fe62ecdb761b2" sha1="4057dd97313444d05db4264f57c0917e6b427d6b"/>
 		<url>https://retroachievements.org/game/19568/hashes</url>
 		<hash>c73d85b16295266a4e3fe62ecdb761b2</hash>
 	</game>
 	
-	<game name="Petals Around the Rose (World) (Aftermarket)">
+	<game name="Petals Around the Rose (World) (Demo) (Aftermarket) (Unl)">
 		<category>Homebrew</category>
-		<description>Petals Around the Rose (World) (Aftermarket)</description>
-		<release name="Petals Around the Rose (World) (Aftermarket)" region="World"/>
-		<rom name="Petals Around the Rose (World) (Aftermarket).min" size="17388" crc="555d19f0" md5="fc837a8a99829a4879dc37adb3435e5e" sha1="8728b7e566925afeaa701fb142c66d484b6d1850"/>
+		<description>Petals Around the Rose (World) (Demo) (Aftermarket) (Unl)</description>
+		<release name="Petals Around the Rose (World) (Demo) (Aftermarket) (Unl)" region="World"/>
+		<rom name="Petals Around the Rose (World) (Demo) (Aftermarket) (Unl).min" size="17388" crc="555d19f0" md5="fc837a8a99829a4879dc37adb3435e5e" sha1="8728b7e566925afeaa701fb142c66d484b6d1850"/>
 		<url>https://retroachievements.org/game/15730/hashes</url>
 		<hash>fc837a8a99829a4879dc37adb3435e5e</hash>
 	</game>
 	
-	<game name="PokeMaze (World) (Aftermarket)">
+	<game name="PokeMaze (World) (Aftermarket) (Unl)">
 		<category>Homebrew</category>
-		<description>PokeMaze (World) (Aftermarket)</description>
-		<release name="PokeMaze (World) (Aftermarket)" region="World"/>
-		<rom name="PokeMaze (World) (Aftermarket).min" size="36040" crc="3db4b128" md5="d48392de0e6a80497c1955042ad38611" sha1="f808813cc780be023848a594b9568a06a27f59f4"/>
+		<description>PokeMaze (World) (Aftermarket) (Unl)</description>
+		<release name="PokeMaze (World) (Aftermarket) (Unl)" region="World"/>
+		<rom name="PokeMaze (World) (Aftermarket) (Unl).min" size="36040" crc="3db4b128" md5="d48392de0e6a80497c1955042ad38611" sha1="f808813cc780be023848a594b9568a06a27f59f4"/>
 		<url>https://retroachievements.org/game/19706/hashes</url>
 		<hash>d48392de0e6a80497c1955042ad38611</hash>
 	</game>
@@ -229,70 +229,70 @@
 		<hash>0156b0b9c002b4f9b9fec777d4503594</hash>
 	</game>
 	
-	<game name="Pokemon Party mini 2 (World) (Aftermarket)">
+	<game name="Pokemon Party mini 2 (World) (Aftermarket) (Unl)">
 		<category>Homebrew</category>
-		<description>Pokemon Party mini 2 (World) (Aftermarket)</description>
-		<release name="Pokemon Party mini 2 (World) (Aftermarket)" region="World"/>
-		<rom name="Pokemon Party mini 2 (World) (Aftermarket).min" size="30528" crc="61bb6d4c" md5="8a69cc5a94afb712e9b313d13ef7a8a2" sha1="dccbf7376f07d1fbecfe0b7d0b0a1389a4360e9d"/>
+		<description>Pokemon Party mini 2 (World) (Aftermarket) (Unl)</description>
+		<release name="Pokemon Party mini 2 (World) (Aftermarket) (Unl)" region="World"/>
+		<rom name="Pokemon Party mini 2 (World) (Aftermarket) (Unl).min" size="30528" crc="61bb6d4c" md5="8a69cc5a94afb712e9b313d13ef7a8a2" sha1="dccbf7376f07d1fbecfe0b7d0b0a1389a4360e9d"/>
 		<url>https://retroachievements.org/game/19709/hashes</url>
 		<hash>8a69cc5a94afb712e9b313d13ef7a8a2</hash>
 	</game>
 	
-	<game name="Pokemon Psychic Seeds (World) (Aftermarket)">
+	<game name="Pokemon Psychic Seeds (World) (Aftermarket) (Unl)">
 		<category>Homebrew</category>
-		<description>Pokemon Psychic Seeds (World) (Aftermarket)</description>
-		<release name="Pokemon Psychic Seeds (World) (Aftermarket)" region="World"/>
-		<rom name="Pokemon Psychic Seeds (World) (Aftermarket).min" size="272704" crc="e2b0d791" md5="092819a9abe895f6a0b70a685a854aa7" sha1="66d6852ea00840627645c324b0cc0011ac1a85f6"/>
+		<description>Pokemon Psychic Seeds (World) (Aftermarket) (Unl)</description>
+		<release name="Pokemon Psychic Seeds (World) (Aftermarket) (Unl)" region="World"/>
+		<rom name="Pokemon Psychic Seeds (World) (Aftermarket) (Unl).min" size="272704" crc="e2b0d791" md5="092819a9abe895f6a0b70a685a854aa7" sha1="66d6852ea00840627645c324b0cc0011ac1a85f6"/>
 		<url>https://retroachievements.org/game/15724/hashes</url>
 		<hash>092819a9abe895f6a0b70a685a854aa7</hash>
 	</game>
-	<game name="Pokemon Psychic Seeds (World) (Demo) (Aftermarket)" cloneof="Pokemon Psychic Seeds (World) (Aftermarket)">
+	<game name="Pokemon Psychic Seeds (World) (Demo) (Aftermarket) (Unl)" cloneof="Pokemon Psychic Seeds (World) (Aftermarket) (Unl)">
 		<category>Homebrew</category>
-		<description>Pokemon Psychic Seeds (World) (Demo) (Aftermarket)</description>
-		<rom name="Pokemon Psychic Seeds (World) (Demo) (Aftermarket).min" size="233664" crc="ff04b931" md5="ab2d43a547fee0ae36db0eac3657242b" sha1="0c9f11dc7451d411bf8ab0dd8ff43ef599afa7e2"/>
+		<description>Pokemon Psychic Seeds (World) (Demo) (Aftermarket) (Unl)</description>
+		<rom name="Pokemon Psychic Seeds (World) (Demo) (Aftermarket) (Unl).min" size="233664" crc="ff04b931" md5="ab2d43a547fee0ae36db0eac3657242b" sha1="0c9f11dc7451d411bf8ab0dd8ff43ef599afa7e2"/>
 		<url>https://retroachievements.org/game/15724/hashes</url>
 		<hash>ab2d43a547fee0ae36db0eac3657242b</hash>
 	</game>
 	
-	<game name="PokeSnake (World) (Aftermarket)">
+	<game name="PokeSnake (World) (Aftermarket) (Unl)">
 		<category>Homebrew</category>
-		<description>PokeSnake (World) (Aftermarket)</description>
-		<release name="PokeSnake (World) (Aftermarket)" region="World"/>
-		<rom name="PokeSnake (World) (Aftermarket).min" size="13440" crc="1bcc7c21" md5="473b191bc7833fb62388e1d9f21a241c" sha1="d772d820eb914cc9a551cca4a59a3885187b134a"/>
+		<description>PokeSnake (World) (Aftermarket) (Unl)</description>
+		<release name="PokeSnake (World) (Aftermarket) (Unl)" region="World"/>
+		<rom name="PokeSnake (World) (Aftermarket) (Unl).min" size="13440" crc="1bcc7c21" md5="473b191bc7833fb62388e1d9f21a241c" sha1="d772d820eb914cc9a551cca4a59a3885187b134a"/>
 		<url>https://retroachievements.org/game/15723/hashes</url>
 		<hash>473b191bc7833fb62388e1d9f21a241c</hash>
 	</game>
 	
-	<game name="Pongemon (World) (Aftermarket)">
+	<game name="Pongemon (World) (Demo) (Aftermarket) (Unl)">
 		<category>Homebrew</category>
-		<description>Pongemon (World) (Aftermarket)</description>
-		<release name="Pongemon (World) (Aftermarket)" region="World"/>
-		<rom name="Pongemon (World) (Aftermarket).min" size="13440" crc="4afeca41" md5="3fbd1d94969da4070f37763861763486" sha1="d7c9ceb370718046870311c5fec9382e20b1738c"/>
+		<description>Pongemon (World) (Demo) (Aftermarket) (Unl)</description>
+		<release name="Pongemon (World) (Demo) (Aftermarket) (Unl)" region="World"/>
+		<rom name="Pongemon (World) (Demo) (Aftermarket) (Unl).min" size="13440" crc="4afeca41" md5="3fbd1d94969da4070f37763861763486" sha1="d7c9ceb370718046870311c5fec9382e20b1738c"/>
 		<url>https://retroachievements.org/game/17311/hashes</url>
 		<hash>3fbd1d94969da4070f37763861763486</hash>
 	</game>
 	
-	<game name="SOKOmini (World) (v1.0) (Hardware Fixed) (Aftermarket)">
+	<game name="SOKOmini (World) (v1.0) (Hardware Fixed) (Aftermarket) (Unl)">
 		<category>Homebrew</category>
-		<description>SOKOmini (World) (v1.0) (Hardware Fixed) (Aftermarket)</description>
-		<release name="SOKOmini (World) (v1.0) (Hardware Fixed) (Aftermarket)" region="World"/>
-		<rom name="SOKOmini (World) (v1.0) (Hardware Fixed) (Aftermarket).min" size="56288" crc="350f91e9" md5="2586b3aa4989969c0b200a57c13f5aae" sha1="9a4f9152d0fe3cc0f32255bab1d2f1edcc4b00b6"/>
+		<description>SOKOmini (World) (v1.0) (Hardware Fixed) (Aftermarket) (Unl)</description>
+		<release name="SOKOmini (World) (v1.0) (Hardware Fixed) (Aftermarket) (Unl)" region="World"/>
+		<rom name="SOKOmini (World) (v1.0) (Hardware Fixed) (Aftermarket) (Unl).min" size="56288" crc="350f91e9" md5="2586b3aa4989969c0b200a57c13f5aae" sha1="9a4f9152d0fe3cc0f32255bab1d2f1edcc4b00b6"/>
 		<url>https://retroachievements.org/game/15728/hashes</url>
 		<hash>2586b3aa4989969c0b200a57c13f5aae</hash>
 	</game>
-	<game name="SOKOmini (World) (v1.0) (Aftermarket)" cloneof="SOKOmini (World) (v1.0) (Hardware Fixed) (Aftermarket)">
+	<game name="SOKOmini (World) (v1.0) (Aftermarket) (Unl)" cloneof="SOKOmini (World) (v1.0) (Hardware Fixed) (Aftermarket) (Unl)">
 		<category>Homebrew</category>
-		<description>SOKOmini (World) (v1.0) (Aftermarket)</description>
-		<rom name="SOKOmini (World) (v1.0) (Aftermarket).min" size="524288" crc="28a67132" md5="6048dce48222e4d75e8fdce9c2f55c39" sha1="5f79e5ae22fca1e758fbd8c2f438497f12bad4ba"/>
+		<description>SOKOmini (World) (v1.0) (Aftermarket) (Unl)</description>
+		<rom name="SOKOmini (World) (v1.0) (Aftermarket) (Unl).min" size="524288" crc="28a67132" md5="6048dce48222e4d75e8fdce9c2f55c39" sha1="5f79e5ae22fca1e758fbd8c2f438497f12bad4ba"/>
 		<url>https://retroachievements.org/game/15728/hashes</url>
 		<hash>6048dce48222e4d75e8fdce9c2f55c39</hash>
 	</game>
 	
-	<game name="Sonic Arena (World) (v1.0) (En) (Aftermarket)">
+	<game name="Sonic Arena (World) (v1.0) (En) (Aftermarket) (Unl)">
 		<category>Homebrew</category>
-		<description>Sonic Arena (World) (v1.0) (En) (Aftermarket)</description>
-		<release name="Sonic Arena (World) (v1.0) (En) (Aftermarket)" region="World"/>
-		<rom name="Sonic Arena (World) (v1.0) (En) (Aftermarket).min" size="20224" crc="28c3eedd" md5="e1fc9f3b2a32990eb0c479c40d28049d" sha1="6f20b8f552b925b2d7827cd8197c67ffd0e7c61f"/>
+		<description>Sonic Arena (World) (v1.0) (En) (Aftermarket) (Unl)</description>
+		<release name="Sonic Arena (World) (v1.0) (En) (Aftermarket) (Unl)" region="World"/>
+		<rom name="Sonic Arena (World) (v1.0) (En) (Aftermarket) (Unl).min" size="20224" crc="28c3eedd" md5="e1fc9f3b2a32990eb0c479c40d28049d" sha1="6f20b8f552b925b2d7827cd8197c67ffd0e7c61f"/>
 		<url>https://retroachievements.org/game/15729/hashes</url>
 		<hash>e1fc9f3b2a32990eb0c479c40d28049d</hash>
 	</game>
@@ -460,11 +460,11 @@
 		<url>https://retroachievements.org/game/14701/hashes</url>
 		<hash>a4eb2facaa5beb947f306ced2bf5cd15</hash>
 	</game>
-	<game name="Togepi's Great Adventure (Japan) (En) (v1.0) (Mr. Blinky)" cloneof="Togepi no Daibouken (Japan)">
+	<game name="Togepi no Daibouken (Japan) (En) (v1.0) (Mr. Blinky)" cloneof="Togepi no Daibouken (Japan)">
 		<category>Retail</category>
-		<description>Togepi's Great Adventure (Japan) (En) (v1.0) (Mr. Blinky)</description>
-		<release name="Togepi's Great Adventure (Japan) (En) (v1.0) (Mr. Blinky)" region="English"/>
-		<rom name="Togepi's Great Adventure (Japan) (En) (v1.0) (Mr. Blinky).min" size="524288" crc="acab99f3" md5="cac3842f010dba9e4155e459111b6ebd" sha1="7f2de7dfabc1b52c916567a33d7bed1d655a5d44"/>
+		<description>Togepi no Daibouken (Japan) (En) (v1.0) (Mr. Blinky)</description>
+		<release name="Togepi no Daibouken (Japan) (En) (v1.0) (Mr. Blinky)" region="English"/>
+		<rom name="Togepi no Daibouken (Japan) (En) (v1.0) (Mr. Blinky).min" size="524288" crc="acab99f3" md5="cac3842f010dba9e4155e459111b6ebd" sha1="7f2de7dfabc1b52c916567a33d7bed1d655a5d44"/>
 		<url>https://retroachievements.org/game/14701/hashes</url>
 		<hash>cac3842f010dba9e4155e459111b6ebd</hash>
 	</game>

--- a/DATs/RetroAchievements (No Subfolders)/RA - Nintendo Virtual Boy.dat
+++ b/DATs/RetroAchievements (No Subfolders)/RA - Nintendo Virtual Boy.dat
@@ -5,143 +5,143 @@
 		<name>RA - Nintendo Virtual Boy</name>
 		<description>Nintendo Virtual Boy</description>
 		<category>No Subfolders</category>
-		<version>20251225</version>
-		<date>25 December 2025</date>
+		<version>20260428</version>
+		<date>28 April 2026</date>
 		<author>AzgoRAth, NeoRetroGamer (Contributor), Jumphil (Contributor)</author>
 		<homepage>https://retroachievements.org</homepage>
 		<url>https://retroachievements.org/system/28/games</url>
-		<titlecount>38</titlecount>
-		<hashcount>48</hashcount>
+		<titlecount>41</titlecount>
+		<hashcount>51</hashcount>
 	</header>
-	<game name="3D Crosswords (World) (Emulator Version) (Aftermarket)">
+	<game name="3D Crosswords (World) (Emulator Version) (Aftermarket) (Unl)">
 		<category>Homebrew</category>
-		<description>3D Crosswords (World) (Emulator Version) (Aftermarket)</description>
-		<release name="3D Crosswords (World) (Emulator Version) (Aftermarket)" region="World"/>
-		<rom name="3D Crosswords (World) (Emulator Version) (Aftermarket).vb" size="2097152" crc="bb061c9d" md5="cef10df7728f4398af46d51efc89d3d0" sha1="c778106d5c378022bbb078cd303bd0155e9fcabc"/>
+		<description>3D Crosswords (World) (Emulator Version) (Aftermarket) (Unl)</description>
+		<release name="3D Crosswords (World) (Emulator Version) (Aftermarket) (Unl)" region="World"/>
+		<rom name="3D Crosswords (World) (Emulator Version) (Aftermarket) (Unl).vb" size="2097152" crc="bb061c9d" md5="cef10df7728f4398af46d51efc89d3d0" sha1="c778106d5c378022bbb078cd303bd0155e9fcabc"/>
 		<url>https://retroachievements.org/game/17020/hashes</url>
 		<hash>cef10df7728f4398af46d51efc89d3d0</hash>
 	</game>
 	
-	<game name="Advanced Pasta Cooking Simulator (USA) (HorvatM) (Aftermarket)">
+	<game name="Advanced Pasta Cooking Simulator (USA) (Aftermarket) (Unl) (HorvatM)">
 		<category>Homebrew</category>
-		<description>Advanced Pasta Cooking Simulator (USA) (HorvatM) (Aftermarket)</description>
-		<release name="Advanced Pasta Cooking Simulator (USA) (HorvatM) (Aftermarket)" region="World"/>
-		<rom name="Advanced Pasta Cooking Simulator (USA) (HorvatM) (Aftermarket).vb" size="2097152" crc="639ca272" md5="a1b32c3b70ad0875fada464d681867f7" sha1="dd535b06c7b43ae3a122553c9b6fb9ace3bf11af"/>
+		<description>Advanced Pasta Cooking Simulator (USA) (Aftermarket) (Unl) (HorvatM)</description>
+		<release name="Advanced Pasta Cooking Simulator (USA) (Aftermarket) (Unl) (HorvatM)" region="World"/>
+		<rom name="Advanced Pasta Cooking Simulator (USA) (Aftermarket) (Unl) (HorvatM).vb" size="2097152" crc="639ca272" md5="a1b32c3b70ad0875fada464d681867f7" sha1="dd535b06c7b43ae3a122553c9b6fb9ace3bf11af"/>
 		<url>https://retroachievements.org/game/19567/hashes</url>
 		<hash>a1b32c3b70ad0875fada464d681867f7</hash>
 	</game>
 	
-	<game name="BLOX (World) (v1.1) (Aftermarket)">
+	<game name="BLOX (World) (v1.1) (Aftermarket) (Unl)">
 		<category>Homebrew</category>
-		<description>BLOX (World) (v1.1) (Aftermarket)</description>
-		<release name="BLOX (World) (v1.1) (Aftermarket)" region="World"/>
-		<rom name="BLOX (World) (v1.1) (Aftermarket).vb" size="1048576" crc="450feab5" md5="f82d4c9fdd81518537d88f70c6602bb5" sha1="f2105349dff09bdc00e4548460991dde9ac7c2af"/>
+		<description>BLOX (World) (v1.1) (Aftermarket) (Unl)</description>
+		<release name="BLOX (World) (v1.1) (Aftermarket) (Unl)" region="World"/>
+		<rom name="BLOX (World) (v1.1) (Aftermarket) (Unl).vb" size="1048576" crc="450feab5" md5="f82d4c9fdd81518537d88f70c6602bb5" sha1="f2105349dff09bdc00e4548460991dde9ac7c2af"/>
 		<url>https://retroachievements.org/game/13161/hashes</url>
 		<hash>f82d4c9fdd81518537d88f70c6602bb5</hash>
 	</game>
 	
-	<game name="BLOX 2 (World) (Aftermarket)">
+	<game name="BLOX 2 (World) (En,Fr,De,Es,It,Sv,Fi,Cs,Sl) (Aftermarket) (Unl)">
 		<category>Homebrew</category>
-		<description>BLOX 2 (World) (Aftermarket)</description>
-		<release name="BLOX 2 (World) (Aftermarket)" region="World"/>
-		<rom name="BLOX 2 (World) (Aftermarket).vb" size="2097152" crc="85460a25" md5="cc91d6389df2c9777919e8e8ab2c0e66" sha1="66b2a25ef8e1af74bed4bbba4785951a9d6edce0"/>
+		<description>BLOX 2 (World) (En,Fr,De,Es,It,Sv,Fi,Cs,Sl) (Aftermarket) (Unl)</description>
+		<release name="BLOX 2 (World) (En,Fr,De,Es,It,Sv,Fi,Cs,Sl) (Aftermarket) (Unl)" region="World"/>
+		<rom name="BLOX 2 (World) (En,Fr,De,Es,It,Sv,Fi,Cs,Sl) (Aftermarket) (Unl).vb" size="2097152" crc="85460a25" md5="cc91d6389df2c9777919e8e8ab2c0e66" sha1="66b2a25ef8e1af74bed4bbba4785951a9d6edce0"/>
 		<url>https://retroachievements.org/game/17019/hashes</url>
 		<hash>cc91d6389df2c9777919e8e8ab2c0e66</hash>
 	</game>
 	
-	<game name="Castle of Doom (USA) (VirtualChris) (Aftermarket)">
+	<game name="Castle of Doom (USA) (Aftermarket) (Unl) (VirtualChris)">
 		<category>Homebrew</category>
-		<description>Castle of Doom (USA) (VirtualChris) (Aftermarket)</description>
-		<release name="Castle of Doom (USA) (VirtualChris) (Aftermarket)" region="World"/>
-		<rom name="Castle of Doom (USA) (VirtualChris) (Aftermarket).vb" size="524288" crc="b8cea688" md5="fcfbeeca4bb33af756b025136c8b2549" sha1="eabde81ec527c671da6accd958120a57de03de15"/>
+		<description>Castle of Doom (USA) (Aftermarket) (Unl) (VirtualChris)</description>
+		<release name="Castle of Doom (USA) (Aftermarket) (Unl) (VirtualChris)" region="World"/>
+		<rom name="Castle of Doom (USA) (Aftermarket) (Unl) (VirtualChris).vb" size="524288" crc="b8cea688" md5="fcfbeeca4bb33af756b025136c8b2549" sha1="eabde81ec527c671da6accd958120a57de03de15"/>
 		<url>https://retroachievements.org/game/19564/hashes</url>
 		<hash>fcfbeeca4bb33af756b025136c8b2549</hash>
 	</game>
 	
-	<game name="Fishbone (World) (Aftermarket)">
+	<game name="Fishbone (World) (Aftermarket) (Unl)">
 		<category>Homebrew</category>
-		<description>Fishbone (World) (Aftermarket)</description>
-		<release name="Fishbone (World) (Aftermarket) (Unl" region="World"/>
-		<rom name="Fishbone (World) (Aftermarket).vb" size="2097152" crc="b5977e82" md5="eee8be03986ddbc3ada91b10a543f17e" sha1="c036c441bb3c16e5b2cc6ea7681f56a8605b932e"/>
+		<description>Fishbone (World) (Aftermarket) (Unl)</description>
+		<release name="Fishbone (World) (Aftermarket) (Unl) (Unl" region="World"/>
+		<rom name="Fishbone (World) (Aftermarket) (Unl).vb" size="2097152" crc="b5977e82" md5="eee8be03986ddbc3ada91b10a543f17e" sha1="c036c441bb3c16e5b2cc6ea7681f56a8605b932e"/>
 		<url>https://retroachievements.org/game/13162/hashes</url>
 		<hash>eee8be03986ddbc3ada91b10a543f17e</hash>
 	</game>
 	
-	<game name="Flappy Cheep Cheep (USA) (DogP) (Aftermarket)">
+	<game name="Flappy Cheep Cheep (USA) (Aftermarket) (Unl) (DogP)">
 		<category>Homebrew</category>
-		<description>Flappy Cheep Cheep (USA) (DogP) (Aftermarket)</description>
-		<release name="Flappy Cheep Cheep (USA) (DogP) (Aftermarket)" region="World"/>
-		<rom name="Flappy Cheep Cheep (USA) (DogP) (Aftermarket).vb" size="1048576" crc="68ec16aa" md5="2176fae66e175a5bf9fc0266b627cc6f" sha1="60e5fd56a52de4c451e09d3c5eac51a6c2af95bb"/>
+		<description>Flappy Cheep Cheep (USA) (Aftermarket) (Unl) (DogP)</description>
+		<release name="Flappy Cheep Cheep (USA) (Aftermarket) (Unl) (DogP)" region="World"/>
+		<rom name="Flappy Cheep Cheep (USA) (Aftermarket) (Unl) (DogP).vb" size="1048576" crc="68ec16aa" md5="2176fae66e175a5bf9fc0266b627cc6f" sha1="60e5fd56a52de4c451e09d3c5eac51a6c2af95bb"/>
 		<url>https://retroachievements.org/game/19509/hashes</url>
 		<hash>2176fae66e175a5bf9fc0266b627cc6f</hash>
 	</game>
 	
-	<game name="Game Hero (USA) (v1.1) (thunderstruck) (Aftermarket)">
+	<game name="Game Hero (USA) (v1.1) (Aftermarket) (Unl) (thunderstruck)">
 		<category>Homebrew</category>
-		<description>Game Hero (USA) (v1.1) (thunderstruck) (Aftermarket)</description>
-		<release name="Game Hero (USA) (v1.1) (thunderstruck) (Aftermarket)" region="World"/>
-		<rom name="Game Hero (USA) (v1.1) (thunderstruck) (Aftermarket).vb" size="2097152" crc="ebf05942" md5="d7adb3f627d0a3bf058e56eb7bd9c58d" sha1="54dab0037f1c672c545395f641b7286814872cfd"/>
+		<description>Game Hero (USA) (v1.1) (Aftermarket) (Unl) (thunderstruck)</description>
+		<release name="Game Hero (USA) (v1.1) (Aftermarket) (Unl) (thunderstruck)" region="World"/>
+		<rom name="Game Hero (USA) (v1.1) (Aftermarket) (Unl) (thunderstruck).vb" size="2097152" crc="ebf05942" md5="d7adb3f627d0a3bf058e56eb7bd9c58d" sha1="54dab0037f1c672c545395f641b7286814872cfd"/>
 		<url>https://retroachievements.org/game/19858/hashes</url>
 		<hash>d7adb3f627d0a3bf058e56eb7bd9c58d</hash>
 	</game>
 	
-	<game name="GoSub (USA) (VirtualChris) (Aftermarket)">
+	<game name="GoSub (USA) (Aftermarket) (Unl) (VirtualChris)">
 		<category>Homebrew</category>
-		<description>GoSub (USA) (VirtualChris) (Aftermarket)</description>
-		<release name="GoSub (USA) (VirtualChris) (Aftermarket)" region="World"/>
-		<rom name="GoSub (USA) (VirtualChris) (Aftermarket).vb" size="524288" crc="f9360e8b" md5="907c7f10093cfcab371754efae8ed279" sha1="c357f6fb487570cd741c32babb452dd634cda0f4"/>
+		<description>GoSub (USA) (Aftermarket) (Unl) (VirtualChris)</description>
+		<release name="GoSub (USA) (Aftermarket) (Unl) (VirtualChris)" region="World"/>
+		<rom name="GoSub (USA) (Aftermarket) (Unl) (VirtualChris).vb" size="524288" crc="f9360e8b" md5="907c7f10093cfcab371754efae8ed279" sha1="c357f6fb487570cd741c32babb452dd634cda0f4"/>
 		<url>https://retroachievements.org/game/19510/hashes</url>
 		<hash>907c7f10093cfcab371754efae8ed279</hash>
 	</game>
 	
-	<game name="Hamburgers En Route to Switzerland (World) (Aftermarket)">
+	<game name="Hamburgers En Route to Switzerland (World) (Aftermarket) (Unl)">
 		<category>Homebrew</category>
-		<description>Hamburgers En Route to Switzerland (World) (Aftermarket)</description>
-		<release name="Hamburgers En Route to Switzerland (World) (Aftermarket)" region="World"/>
-		<rom name="Hamburgers En Route to Switzerland (World) (Aftermarket).vb" size="524288" crc="efb7577c" md5="45aa19c4b2f10c7ef6782b0cb356e265" sha1="bf426b164378376e11dc0416ffa840a84fd1cd15"/>
+		<description>Hamburgers En Route to Switzerland (World) (Aftermarket) (Unl)</description>
+		<release name="Hamburgers En Route to Switzerland (World) (Aftermarket) (Unl)" region="World"/>
+		<rom name="Hamburgers En Route to Switzerland (World) (Aftermarket) (Unl).vb" size="524288" crc="efb7577c" md5="45aa19c4b2f10c7ef6782b0cb356e265" sha1="bf426b164378376e11dc0416ffa840a84fd1cd15"/>
 		<url>https://retroachievements.org/game/22399/hashes</url>
 		<hash>45aa19c4b2f10c7ef6782b0cb356e265</hash>
 	</game>
 	
-	<game name="Hyper Fighting (World) (Aftermarket)">
+	<game name="Hyper Fighting (World) (Aftermarket) (Unl)">
 		<category>Homebrew</category>
-		<description>Hyper Fighting (World) (Aftermarket)</description>
-		<rom name="Hyper Fighting (World) (Aftermarket).vb" size="4194304" crc="3f2a6ba2" md5="c2047a94dcb0db30794c8533ba625622" sha1="578355de83822ce67522033dd7545631124a71ab"/>
+		<description>Hyper Fighting (World) (Aftermarket) (Unl)</description>
+		<rom name="Hyper Fighting (World) (Aftermarket) (Unl).vb" size="4194304" crc="3f2a6ba2" md5="c2047a94dcb0db30794c8533ba625622" sha1="578355de83822ce67522033dd7545631124a71ab"/>
 		<url>https://retroachievements.org/game/17734/hashes</url>
 		<hash>c2047a94dcb0db30794c8533ba625622</hash>
 	</game>
-	<game name="Hyper Fighting (World) (Brightness Fix) (v1.0) (Guy Perfect) (Aftermarket)" cloneof="Hyper Fighting (World) (Aftermarket)">
+	<game name="Hyper Fighting (World) (Aftermarket) (Unl) (Brightness Fix) (v1.0) (Guy Perfect)" cloneof="Hyper Fighting (World) (Aftermarket) (Unl)">
 		<category>Homebrew</category>
-		<description>Hyper Fighting (World) (Brightness Fix) (v1.0) (Guy Perfect) (Aftermarket)</description>
-		<release name="Hyper Fighting (World) (Brightness Fix) (v1.0) (Guy Perfect) (Aftermarket)" region="World"/>
-		<rom name="Hyper Fighting (World) (Brightness Fix) (v1.0) (Guy Perfect) (Aftermarket).vb" size="4194304" crc="f30c1e99" md5="8d7068bc51669a2f0db46fef5b72e6cb" sha1="5cbc0400304b6cc0c97689ac84809a7a16737ca4"/>
+		<description>Hyper Fighting (World) (Aftermarket) (Unl) (Brightness Fix) (v1.0) (Guy Perfect)</description>
+		<release name="Hyper Fighting (World) (Aftermarket) (Unl) (Brightness Fix) (v1.0) (Guy Perfect)" region="World"/>
+		<rom name="Hyper Fighting (World) (Aftermarket) (Unl) (Brightness Fix) (v1.0) (Guy Perfect).vb" size="4194304" crc="f30c1e99" md5="8d7068bc51669a2f0db46fef5b72e6cb" sha1="5cbc0400304b6cc0c97689ac84809a7a16737ca4"/>
 		<url>https://retroachievements.org/game/17734/hashes</url>
 		<hash>8d7068bc51669a2f0db46fef5b72e6cb</hash>
 	</game>
 	
-	<game name="Mario Kart - Virtual Cup (World) (Aftermarket)">
+	<game name="Mario Kart - Virtual Cup (World) (Aftermarket) (Unl)">
 		<category>Homebrew</category>
-		<description>Mario Kart - Virtual Cup (World) (Aftermarket)</description>
-		<release name="Mario Kart - Virtual Cup (World) (Aftermarket)" region="World"/>
-		<rom name="Mario Kart - Virtual Cup (World) (Aftermarket).vb" size="1048576" crc="27988ab9" md5="4b8c8b6a7711a005dd896b3ee9b8d0f1" sha1="7743978a58a27b8e05e36d353439a8b11ead5235"/>
+		<description>Mario Kart - Virtual Cup (World) (Aftermarket) (Unl)</description>
+		<release name="Mario Kart - Virtual Cup (World) (Aftermarket) (Unl)" region="World"/>
+		<rom name="Mario Kart - Virtual Cup (World) (Aftermarket) (Unl).vb" size="1048576" crc="27988ab9" md5="4b8c8b6a7711a005dd896b3ee9b8d0f1" sha1="7743978a58a27b8e05e36d353439a8b11ead5235"/>
 		<url>https://retroachievements.org/game/13947/hashes</url>
 		<hash>4b8c8b6a7711a005dd896b3ee9b8d0f1</hash>
 	</game>
 	
-	<game name="Pineapple 64 (USA) (v2016-03-15) (VirtualChris) (Aftermarket)">
+	<game name="Pineapple 64 (USA) (v2016-03-15) (VirtualChris)">
 		<category>Homebrew</category>
-		<description>Pineapple 64 (USA) (v2016-03-15) (VirtualChris) (Aftermarket)</description>
-		<release name="Pineapple 64 (USA) (v2016-03-15) (VirtualChris) (Aftermarket)" region="World"/>
-		<rom name="Pineapple 64 (USA) (v2016-03-15) (VirtualChris) (Aftermarket).vb" size="1048576" crc="e40bfa61" md5="c81e121e78b63137305b9098bb5a2ad9" sha1="a6cacaa85c1b07d3dcadea7f657065f2293fff7c"/>
+		<description>Pineapple 64 (USA) (v2016-03-15) (VirtualChris)</description>
+		<release name="Pineapple 64 (USA) (v2016-03-15) (VirtualChris)" region="World"/>
+		<rom name="Pineapple 64 (USA) (v2016-03-15) (VirtualChris).vb" size="1048576" crc="e40bfa61" md5="c81e121e78b63137305b9098bb5a2ad9" sha1="a6cacaa85c1b07d3dcadea7f657065f2293fff7c"/>
 		<url>https://retroachievements.org/game/13163/hashes</url>
 		<hash>c81e121e78b63137305b9098bb5a2ad9</hash>
 	</game>
 	
-	<game name="Red Square (USA) (2019 Dream Diary Jam) (Kresna,Nyrator) (Aftermarket)">
+	<game name="Red Square (USA) (2019 Dream Diary Jam) (Aftermarket) (Unl) (Kresna,Nyrator)">
 		<category>Homebrew</category>
-		<description>Red Square (USA) (2019 Dream Diary Jam) (Kresna,Nyrator) (Aftermarket)</description>
-		<release name="Red Square (USA) (2019 Dream Diary Jam) (Kresna,Nyrator) (Aftermarket)" region="World"/>
-		<rom name="Red Square (USA) (2019 Dream Diary Jam) (Kresna,Nyrator) (Aftermarket).vb" size="524288" crc="cea4707a" md5="9c372321204b9fa65f9324f98aae53ff" sha1="a12529a0d7cf7f0711b913b8ae72fea193cebc17"/>
+		<description>Red Square (USA) (2019 Dream Diary Jam) (Aftermarket) (Unl) (Kresna,Nyrator)</description>
+		<release name="Red Square (USA) (2019 Dream Diary Jam) (Aftermarket) (Unl) (Kresna,Nyrator)" region="World"/>
+		<rom name="Red Square (USA) (2019 Dream Diary Jam) (Aftermarket) (Unl) (Kresna,Nyrator).vb" size="524288" crc="cea4707a" md5="9c372321204b9fa65f9324f98aae53ff" sha1="a12529a0d7cf7f0711b913b8ae72fea193cebc17"/>
 		<url>https://retroachievements.org/game/21681/hashes</url>
 		<hash>9c372321204b9fa65f9324f98aae53ff</hash>
 	</game>
@@ -155,29 +155,38 @@
 		<hash>74d21ea01f97ac19e018d7f5a3e3bc7c</hash>
 	</game>
 	
-	<game name="VB Racing (USA) (FlashBoy Version) (PVBCC) (M.K.) (Aftermarket)">
+	<game name="Soviet Union 2011 (World) (v1.2) (Aftermarket) (Unl)">
 		<category>Homebrew</category>
-		<description>VB Racing (USA) (FlashBoy Version) (PVBCC) (M.K.) (Aftermarket)</description>
-		<release name="VB Racing (USA) (FlashBoy Version) (PVBCC) (M.K.) (Aftermarket)" region="World"/>
-		<rom name="VB Racing (USA) (FlashBoy Version) (PVBCC) (M.K.) (Aftermarket).vb" size="524288" crc="d56448ec" md5="819b9dccf1437c3bb126670b171d7c59" sha1="ac6d441370994b3000119afffbd4a200014c5a51"/>
+		<description>Soviet Union 2011 (World) (v1.2) (Aftermarket) (Unl)</description>
+		<release name="Soviet Union 2011 (World) (v1.2) (Aftermarket) (Unl)" region="World"/>
+		<rom name="Soviet Union 2011 (World) (v1.2) (Aftermarket) (Unl).vb" size="2097152" crc="3a2e0413" md5="7209a6bd5d788f12e97b9247d28197ce" sha1="b6f9c7c86ecaaf37f1966c3480752531f9dd5515"/>
+		<url>https://retroachievements.org/game/34102/hashes</url>
+		<hash>7209a6bd5d788f12e97b9247d28197ce</hash>
+	</game>
+	
+	<game name="VB Racing (USA) (FlashBoy Version) (PVBCC) (Aftermarket) (Unl) (M.K.)">
+		<category>Homebrew</category>
+		<description>VB Racing (USA) (FlashBoy Version) (PVBCC) (Aftermarket) (Unl) (M.K.)</description>
+		<release name="VB Racing (USA) (FlashBoy Version) (PVBCC) (Aftermarket) (Unl) (M.K.)" region="World"/>
+		<rom name="VB Racing (USA) (FlashBoy Version) (PVBCC) (Aftermarket) (Unl) (M.K.).vb" size="524288" crc="d56448ec" md5="819b9dccf1437c3bb126670b171d7c59" sha1="ac6d441370994b3000119afffbd4a200014c5a51"/>
 		<url>https://retroachievements.org/game/13164/hashes</url>
 		<hash>819b9dccf1437c3bb126670b171d7c59</hash>
 	</game>
 	
-	<game name="VUE Snake (USA) (v1.1) (KR155E) (Aftermarket)">
+	<game name="VUE Snake (USA) (v1.1) (Aftermarket) (Unl) (KR155E)">
 		<category>Homebrew</category>
-		<description>VUE Snake (USA) (v1.1) (KR155E) (Aftermarket)</description>
-		<release name="VUE Snake (USA) (v1.1) (KR155E) (Aftermarket)" region="World"/>
-		<rom name="VUE Snake (USA) (v1.1) (KR155E) (Aftermarket).vb" size="262144" crc="ad054747" md5="ccfa400a0ff3d717dad36a3f736fd34d" sha1="77ebaf5dbe667d8347d098b6749b6f3be09f5814"/>
+		<description>VUE Snake (USA) (v1.1) (Aftermarket) (Unl) (KR155E)</description>
+		<release name="VUE Snake (USA) (v1.1) (Aftermarket) (Unl) (KR155E)" region="World"/>
+		<rom name="VUE Snake (USA) (v1.1) (Aftermarket) (Unl) (KR155E).vb" size="262144" crc="ad054747" md5="ccfa400a0ff3d717dad36a3f736fd34d" sha1="77ebaf5dbe667d8347d098b6749b6f3be09f5814"/>
 		<url>https://retroachievements.org/game/19544/hashes</url>
 		<hash>ccfa400a0ff3d717dad36a3f736fd34d</hash>
 	</game>
 	
-	<game name="Bound High (Japan) (En) (Proto)">
+	<game name="Bound High (World) (Proto 1) [b]">
 		<category>Prototype</category>
-		<description>Bound High (Japan) (En) (Proto)</description>
-		<release name="Bound High (Japan) (En) (Proto)" region="Japan"/>
-		<rom name="Bound High (Japan) (En) (Proto).vb" size="2097152" crc="e81a3703" md5="a460e2660fa951e9d4e3b05aee9f5018" sha1="1196ef8b9a96a0ff2f3634f8eb1c4865c0fb6b01"/>
+		<description>Bound High (World) (Proto 1) [b]</description>
+		<release name="Bound High (World) (Proto 1) [b]" region="World"/>
+		<rom name="Bound High (World) (Proto 1) [b].vb" size="2097152" crc="e81a3703" md5="a460e2660fa951e9d4e3b05aee9f5018" sha1="1196ef8b9a96a0ff2f3634f8eb1c4865c0fb6b01"/>
 		<url>https://retroachievements.org/game/16580/hashes</url>
 		<hash>a460e2660fa951e9d4e3b05aee9f5018</hash>
 	</game>
@@ -189,6 +198,15 @@
 		<rom name="Space Pinball (Japan) (En) (Proto).vb" size="2097152" crc="44c2b723" md5="31073126fad41777357391ecc36d6f7f" sha1="dc182360c7c8d26323db8921f09db76638e81ced"/>
 		<url>https://retroachievements.org/game/17749/hashes</url>
 		<hash>31073126fad41777357391ecc36d6f7f</hash>
+	</game>
+	
+	<game name="3-D Tetris (USA)">
+		<category>Retail</category>
+		<description>3-D Tetris (USA)</description>
+		<release name="3-D Tetris (USA)" region="USA"/>
+		<rom name="3-D Tetris (USA).vb" size="1048576" crc="bb71b522" md5="ecf1218706e9b547eab9e4be58d54e21" sha1="5177015a91442e56bd76af39447bca365e06c272"/>
+		<url>https://retroachievements.org/game/12719/hashes</url>
+		<hash>ecf1218706e9b547eab9e4be58d54e21</hash>
 	</game>
 	
 	<game name="Galactic Pinball (Japan, USA) (En)">
@@ -218,11 +236,11 @@
 		<url>https://retroachievements.org/game/13041/hashes</url>
 		<hash>1eb964d0eaa3223cfefdcc99a6265c88</hash>
 	</game>
-	<game name="Innsmouth no Yakata (Japan) (En) (v1.0) (Thunderstruck)" cloneof="Insmouth no Yakata (Japan)">
+	<game name="Insmouth no Yakata (Japan) (En) (v1.0) (Thunderstruck)" cloneof="Insmouth no Yakata (Japan)">
 		<category>Retail</category>
-		<description>Innsmouth no Yakata (Japan) (En) (v1.0) (Thunderstruck)</description>
-		<release name="Innsmouth no Yakata (Japan) (En) (v1.0) (Thunderstruck)" region="English"/>
-		<rom name="Innsmouth no Yakata (Japan) (En) (v1.0) (Thunderstruck).vb" size="1048576" crc="04ccbe94" md5="4698a0b151d95bbbb833e2a523a12be7" sha1="37f0351b1711a9580a7346127bc54b3927bc7e1e"/>
+		<description>Insmouth no Yakata (Japan) (En) (v1.0) (Thunderstruck)</description>
+		<release name="Insmouth no Yakata (Japan) (En) (v1.0) (Thunderstruck)" region="English"/>
+		<rom name="Insmouth no Yakata (Japan) (En) (v1.0) (Thunderstruck).vb" size="1048576" crc="04ccbe94" md5="4698a0b151d95bbbb833e2a523a12be7" sha1="37f0351b1711a9580a7346127bc54b3927bc7e1e"/>
 		<url>https://retroachievements.org/game/13041/hashes</url>
 		<hash>4698a0b151d95bbbb833e2a523a12be7</hash>
 	</game>
@@ -385,11 +403,11 @@
 		<hash>c1f23aa9a6b5130a4971b4566dc19289</hash>
 	</game>
 	
-	<game name="Virtual Bowling (Japan)">
+	<game name="Virtual Bowling (Japan) (En)">
 		<category>Retail</category>
-		<description>Virtual Bowling (Japan)</description>
-		<release name="Virtual Bowling (Japan)" region="Japan"/>
-		<rom name="Virtual Bowling (Japan).vb" size="1048576" crc="20688279" md5="5b11d402f7e322c71a7d4fa6503631fa" sha1="a5be7654037050f0a781e70efea0191f43d26f06"/>
+		<description>Virtual Bowling (Japan) (En)</description>
+		<release name="Virtual Bowling (Japan) (En)" region="Japan"/>
+		<rom name="Virtual Bowling (Japan) (En).vb" size="1048576" crc="20688279" md5="5b11d402f7e322c71a7d4fa6503631fa" sha1="a5be7654037050f0a781e70efea0191f43d26f06"/>
 		<url>https://retroachievements.org/game/13078/hashes</url>
 		<hash>5b11d402f7e322c71a7d4fa6503631fa</hash>
 	</game>

--- a/DATs/RetroAchievements (No Subfolders)/RA - SNK Neo Geo Pocket.dat
+++ b/DATs/RetroAchievements (No Subfolders)/RA - SNK Neo Geo Pocket.dat
@@ -5,100 +5,100 @@
 		<name>RA - SNK Neo Geo Pocket</name>
 		<description>SNK Neo Geo Pocket</description>
 		<category>No Subfolders</category>
-		<version>20260227</version>
-		<date>27 February 2026</date>
+		<version>20260428</version>
+		<date>28 April 2026</date>
 		<author>AzgoRAth, NeoRetroGamer (Contributor), Jumphil (Contributor)</author>
 		<homepage>https://retroachievements.org</homepage>
 		<url>https://retroachievements.org/system/14/games</url>
-		<titlecount>38</titlecount>
-		<hashcount>50/51</hashcount>
+		<titlecount>42</titlecount>
+		<hashcount>55/56</hashcount>
 	</header>
-	<game name="Another Day in Hell (World) (v1.1) (Aftermarket)">
+	<game name="Another Day in Hell (World) (v1.1) (Aftermarket) (Unl)">
 		<category>Homebrew</category>
-		<description>Another Day in Hell (World) (v1.1) (Aftermarket)</description>
-		<release name="Another Day in Hell (World) (v1.1) (Aftermarket)" region="World"/>
-		<rom name="Another Day in Hell (World) (v1.1) (Aftermarket).ngc" size="1494777" crc="73d4c2a4" md5="b66c0335be91d86650e31c5942a69323" sha1="8ede8a19190fb5e74658d06f2d076a9fcf440187"/>
+		<description>Another Day in Hell (World) (v1.1) (Aftermarket) (Unl)</description>
+		<release name="Another Day in Hell (World) (v1.1) (Aftermarket) (Unl)" region="World"/>
+		<rom name="Another Day in Hell (World) (v1.1) (Aftermarket) (Unl).ngc" size="1494777" crc="73d4c2a4" md5="b66c0335be91d86650e31c5942a69323" sha1="8ede8a19190fb5e74658d06f2d076a9fcf440187"/>
 		<url>https://retroachievements.org/game/23731/hashes</url>
 		<hash>b66c0335be91d86650e31c5942a69323</hash>
 	</game>
 	
-	<game name="Blocks (World) (Aftermarket)">
+	<game name="Blocks (World) (Aftermarket) (Unl)">
 		<category>Homebrew</category>
-		<description>Blocks (World) (Aftermarket)</description>
-		<release name="Blocks (World) (Aftermarket)" region="World"/>
-		<rom name="Blocks (World) (Aftermarket).ngc" size="32768" crc="dfd9d777" md5="e2b6d75c63b17e18cd02411f6ce1d6e4" sha1="8bb44863e9e874d8d78234a406f84e33711fc495"/>
+		<description>Blocks (World) (Aftermarket) (Unl)</description>
+		<release name="Blocks (World) (Aftermarket) (Unl)" region="World"/>
+		<rom name="Blocks (World) (Aftermarket) (Unl).ngc" size="32768" crc="dfd9d777" md5="e2b6d75c63b17e18cd02411f6ce1d6e4" sha1="8bb44863e9e874d8d78234a406f84e33711fc495"/>
 		<url>https://retroachievements.org/game/23744/hashes</url>
 		<hash>e2b6d75c63b17e18cd02411f6ce1d6e4</hash>
 	</game>
 	
-	<game name="Bomberman (World) (v1.1) (Unl) (Aftermarket)">
+	<game name="Bomberman (World) (v1.1) (Aftermarket) (Unl)">
 		<category>Homebrew</category>
-		<description>Bomberman (World) (v1.1) (Unl) (Aftermarket)</description>
-		<release name="Bomberman (World) (v1.1) (Unl) (Aftermarket)" region="World"/>
-		<rom name="Bomberman (World) (v1.1) (Unl) (Aftermarket).ngc" size="1910804" crc="61b14431" md5="3f18507c9aa7e80b9aa75ce9e69de9ed" sha1="18f722428e3033ba631f4f049520577da867731e"/>
+		<description>Bomberman (World) (v1.1) (Aftermarket) (Unl)</description>
+		<release name="Bomberman (World) (v1.1) (Aftermarket) (Unl)" region="World"/>
+		<rom name="Bomberman (World) (v1.1) (Aftermarket) (Unl).ngc" size="1910804" crc="61b14431" md5="3f18507c9aa7e80b9aa75ce9e69de9ed" sha1="18f722428e3033ba631f4f049520577da867731e"/>
 		<url>https://retroachievements.org/game/23735/hashes</url>
 		<hash>3f18507c9aa7e80b9aa75ce9e69de9ed</hash>
 	</game>
 	
-	<game name="Diamond Run (World) (Aftermarket)">
+	<game name="Diamond Run (World) (Aftermarket) (Unl)">
 		<category>Homebrew</category>
-		<description>Diamond Run (World) (Aftermarket)</description>
-		<release name="Diamond Run (World) (Aftermarket)" region="World"/>
-		<rom name="Diamond Run (World) (Aftermarket).ngc" size="32768" crc="97c58fd0" md5="0cd4aa9a72ececf14508de6ae6725ed1" sha1="76f82acc6e5df9c4980a56361966058653cd32f6"/>
+		<description>Diamond Run (World) (Aftermarket) (Unl)</description>
+		<release name="Diamond Run (World) (Aftermarket) (Unl)" region="World"/>
+		<rom name="Diamond Run (World) (Aftermarket) (Unl).ngc" size="32768" crc="97c58fd0" md5="0cd4aa9a72ececf14508de6ae6725ed1" sha1="76f82acc6e5df9c4980a56361966058653cd32f6"/>
 		<url>https://retroachievements.org/game/19896/hashes</url>
 		<hash>0cd4aa9a72ececf14508de6ae6725ed1</hash>
 	</game>
 	
-	<game name="Gears of Fate (World) (v20090508) (Aftermarket)">
+	<game name="Gears of Fate (World) (v20090508) (Aftermarket) (Unl)">
 		<category>Homebrew</category>
-		<description>Gears of Fate (World) (v20090508) (Aftermarket)</description>
-		<release name="Gears of Fate (World) (v20090508) (Aftermarket)" region="World"/>
-		<rom name="Gears of Fate (World) (v20090508) (Aftermarket).ngc" size="1917732" crc="3c75807e" md5="782c7aec693c95de10e05a268c023ce1" sha1="b2356a4c4af8cb40a212a2e29a74084dfda6c53a"/>
+		<description>Gears of Fate (World) (v20090508) (Aftermarket) (Unl)</description>
+		<release name="Gears of Fate (World) (v20090508) (Aftermarket) (Unl)" region="World"/>
+		<rom name="Gears of Fate (World) (v20090508) (Aftermarket) (Unl).ngc" size="1917732" crc="3c75807e" md5="782c7aec693c95de10e05a268c023ce1" sha1="b2356a4c4af8cb40a212a2e29a74084dfda6c53a"/>
 		<url>https://retroachievements.org/game/23737/hashes</url>
 		<hash>782c7aec693c95de10e05a268c023ce1</hash>
 	</game>
 	
-	<game name="Lights! (World) (v1.1) (Aftermarket)">
+	<game name="Lights! (World) (v1.1) (Aftermarket) (Unl)">
 		<category>Homebrew</category>
-		<description>Lights! (World) (v1.1) (Aftermarket)</description>
-		<release name="Lights! (World) (v1.1) (Aftermarket)" region="World"/>
-		<rom name="Lights! (World) (v1.1) (Aftermarket).ngc" size="32768" crc="281de628" md5="1715311acd6bf2717a3b1bf70321d195" sha1="eeac12009e07025e46a188b17b38fdae2c7346a6"/>
+		<description>Lights! (World) (v1.1) (Aftermarket) (Unl)</description>
+		<release name="Lights! (World) (v1.1) (Aftermarket) (Unl)" region="World"/>
+		<rom name="Lights! (World) (v1.1) (Aftermarket) (Unl).ngc" size="32768" crc="281de628" md5="1715311acd6bf2717a3b1bf70321d195" sha1="eeac12009e07025e46a188b17b38fdae2c7346a6"/>
 		<url>https://retroachievements.org/game/23745/hashes</url>
 		<hash>1715311acd6bf2717a3b1bf70321d195</hash>
 	</game>
 	
-	<game name="Mines (World) (Aftermarket)">
+	<game name="Mines (World) (Aftermarket) (Unl)">
 		<category>Homebrew</category>
-		<description>Mines (World) (Aftermarket)</description>
-		<release name="Mines (World) (Aftermarket)" region="World"/>
-		<rom name="Mines (World) (Aftermarket).ngc" size="32768" crc="4b687e99" md5="6594d32d6774b616949a31641799472a" sha1="7aa07c67a6aa8d398370bceea7124f9e2e5b03f8"/>
+		<description>Mines (World) (Aftermarket) (Unl)</description>
+		<release name="Mines (World) (Aftermarket) (Unl)" region="World"/>
+		<rom name="Mines (World) (Aftermarket) (Unl).ngc" size="32768" crc="4b687e99" md5="6594d32d6774b616949a31641799472a" sha1="7aa07c67a6aa8d398370bceea7124f9e2e5b03f8"/>
 		<url>https://retroachievements.org/game/23741/hashes</url>
 		<hash>6594d32d6774b616949a31641799472a</hash>
 	</game>
 	
-	<game name="Mr. Do! (World) (Aftermarket)">
+	<game name="Mr. Do! (World) (Aftermarket) (Unl)">
 		<category>Homebrew</category>
-		<description>Mr. Do! (World) (Aftermarket)</description>
-		<release name="Mr. Do! (World) (Aftermarket)" region="World"/>
-		<rom name="Mr. Do! (World) (Aftermarket).ngc" size="16152" crc="0098c7b5" md5="2ee3331dd1e34020bbafdd91df0ce1bb" sha1="3e0ea487d3647936413a42570d0a1a6565cc6ec9"/>
+		<description>Mr. Do! (World) (Aftermarket) (Unl)</description>
+		<release name="Mr. Do! (World) (Aftermarket) (Unl)" region="World"/>
+		<rom name="Mr. Do! (World) (Aftermarket) (Unl).ngc" size="16152" crc="0098c7b5" md5="2ee3331dd1e34020bbafdd91df0ce1bb" sha1="3e0ea487d3647936413a42570d0a1a6565cc6ec9"/>
 		<url>https://retroachievements.org/game/23747/hashes</url>
 		<hash>2ee3331dd1e34020bbafdd91df0ce1bb</hash>
 	</game>
 	
-	<game name="Puzzle Gems (World) (v1.1) (Aftermarket)">
+	<game name="Puzzle Gems (World) (v1.1) (Aftermarket) (Unl)">
 		<category>Homebrew</category>
-		<description>Puzzle Gems (World) (v1.1) (Aftermarket)</description>
-		<release name="Puzzle Gems (World) (v1.1) (Aftermarket)" region="World"/>
-		<rom name="Puzzle Gems (World) (v1.1) (Aftermarket).ngc" size="39798" crc="ef104269" md5="04a35a8f274479a061b88bdeee8ee6d4" sha1="cf0fc231f7386ffb9fbf5825d03a758fa0236081"/>
+		<description>Puzzle Gems (World) (v1.1) (Aftermarket) (Unl)</description>
+		<release name="Puzzle Gems (World) (v1.1) (Aftermarket) (Unl)" region="World"/>
+		<rom name="Puzzle Gems (World) (v1.1) (Aftermarket) (Unl).ngc" size="39798" crc="ef104269" md5="04a35a8f274479a061b88bdeee8ee6d4" sha1="cf0fc231f7386ffb9fbf5825d03a758fa0236081"/>
 		<url>https://retroachievements.org/game/23733/hashes</url>
 		<hash>04a35a8f274479a061b88bdeee8ee6d4</hash>
 	</game>
 	
-	<game name="Snake (World) (v1.2) (Aftermarket)">
+	<game name="Snake (World) (v1.2) (Aftermarket) (Unl)">
 		<category>Homebrew</category>
-		<description>Snake (World) (v1.2) (Aftermarket)</description>
-		<release name="Snake (World) (v1.2) (Aftermarket)" region="World"/>
-		<rom name="Snake (World) (v1.2) (Aftermarket).ngc" size="524288" crc="82510aa9" md5="62029cf9c8af82f4dd13bd0243693d32" sha1="2ca5b0e26dbb6f399ff89183de17603ea78e87a7"/>
+		<description>Snake (World) (v1.2) (Aftermarket) (Unl)</description>
+		<release name="Snake (World) (v1.2) (Aftermarket) (Unl)" region="World"/>
+		<rom name="Snake (World) (v1.2) (Aftermarket) (Unl).ngc" size="524288" crc="82510aa9" md5="62029cf9c8af82f4dd13bd0243693d32" sha1="2ca5b0e26dbb6f399ff89183de17603ea78e87a7"/>
 		<url>https://retroachievements.org/game/23738/hashes</url>
 		<hash>62029cf9c8af82f4dd13bd0243693d32</hash>
 	</game>
@@ -112,14 +112,13 @@
 		<hash>184dc284995dc20ddce599426b9cac7d</hash>
 	</game>
 	
-	<game name="Biomotor Unitron (USA, Europe)">
+	<game name="Bust-A-Move Pocket (USA)">
 		<category>Retail</category>
-		<description>Biomotor Unitron (USA, Europe)</description>
-		<release name="Biomotor Unitron (USA, Europe)" region="Europe"/>
-		<release name="Biomotor Unitron (USA, Europe)" region="USA"/>
-		<rom name="Biomotor Unitron (USA, Europe).ngc" size="1048576" crc="3807df4f" md5="f4bbe8cf42074b75c8a911bf7b0562d5" sha1="ff74d5877bf58164419710888923e46b9cfb415e"/>
-		<url>https://retroachievements.org/game/11572/hashes</url>
-		<hash>f4bbe8cf42074b75c8a911bf7b0562d5</hash>
+		<description>Bust-A-Move Pocket (USA)</description>
+		<release name="Bust-A-Move Pocket (USA)" region="USA"/>
+		<rom name="Bust-A-Move Pocket (USA).ngc" size="1048576" crc="b073d601" md5="d91fd1c6c941bc2bde4ada3580fe408f" sha1="3b102e32fccf8ff389c508be55517368d56b144f"/>
+		<url>https://retroachievements.org/game/11573/hashes</url>
+		<hash>d91fd1c6c941bc2bde4ada3580fe408f</hash>
 	</game>
 	
 	<game name="Cool Boarders Pocket (Japan, Europe) (En,Ja)">
@@ -175,10 +174,10 @@
 		<url>https://retroachievements.org/game/14396/hashes</url>
 		<hash>64495ddd898f14e9c89e02179ab6f5e0</hash>
 	</game>
-	<game name="Delta Warp (Japan) (En,Ja) (RetroHQ Fixed) " cloneof="Delta Warp (Japan) (En,Ja) (Save Fix) (RetroHQ)">
+	<game name="Delta Warp (Japan) (En,Ja) (RetroHQ Fixed)" cloneof="Delta Warp (Japan) (En,Ja) (Save Fix) (RetroHQ)">
 		<category>Retail</category>
-		<description>Delta Warp (Japan) (En,Ja) (RetroHQ Fixed) </description>
-		<rom name="Delta Warp (Japan) (En,Ja) (RetroHQ Fixed) .ngc" size="1048576" crc="efecb4b8" md5="905a97b0100f8ee7080628bfef815a33" sha1="dccdcd138f9f2413387a9ef5cd879ebf9dc2473e"/>
+		<description>Delta Warp (Japan) (En,Ja) (RetroHQ Fixed)</description>
+		<rom name="Delta Warp (Japan) (En,Ja) (RetroHQ Fixed).ngc" size="1048576" crc="efecb4b8" md5="905a97b0100f8ee7080628bfef815a33" sha1="dccdcd138f9f2413387a9ef5cd879ebf9dc2473e"/>
 		<url>https://retroachievements.org/game/14396/hashes</url>
 		<hash>905a97b0100f8ee7080628bfef815a33</hash>
 	</game>
@@ -473,11 +472,11 @@
 		<url>https://retroachievements.org/game/32107/hashes</url>
 		<hash>362e9c04ec255225eeb0a9dee8fcac1b</hash>
 	</game>
-	<game name="King of Fighters, The - Battle de Paradise (En) (v1.0) (marc_max, xenophile127)" cloneof="King of Fighters, The - Battle de Paradise (Japan)">
+	<game name="King of Fighters, The - Battle de Paradise (Japan) (v1.0) (marc_max, xenophile127)" cloneof="King of Fighters, The - Battle de Paradise (Japan)">
 		<category>Retail</category>
-		<description>King of Fighters, The - Battle de Paradise (En) (v1.0) (marc_max, xenophile127)</description>
-		<release name="King of Fighters, The - Battle de Paradise (En) (v1.0) (marc_max, xenophile127)" region="English"/>
-		<rom name="King of Fighters, The - Battle de Paradise (En) (v1.0) (marc_max, xenophile127).ngc" size="2097152" crc="e08dc918" md5="b16a89f1787c83212b964e7fb570a060" sha1="967b0d1a7074ecbfbd4bf476fcaed3be30e2a7b3"/>
+		<description>King of Fighters, The - Battle de Paradise (Japan) (v1.0) (marc_max, xenophile127)</description>
+		<release name="King of Fighters, The - Battle de Paradise (Japan) (v1.0) (marc_max, xenophile127)" region="English"/>
+		<rom name="King of Fighters, The - Battle de Paradise (Japan) (v1.0) (marc_max, xenophile127).ngc" size="2097152" crc="e08dc918" md5="b16a89f1787c83212b964e7fb570a060" sha1="967b0d1a7074ecbfbd4bf476fcaed3be30e2a7b3"/>
 		<url>https://retroachievements.org/game/32107/hashes</url>
 		<hash>b16a89f1787c83212b964e7fb570a060</hash>
 	</game>

--- a/DATs/RetroAchievements (No Subfolders)/RA - Sega 32X.dat
+++ b/DATs/RetroAchievements (No Subfolders)/RA - Sega 32X.dat
@@ -5,8 +5,8 @@
 		<name>RA - Sega 32X</name>
 		<description>Sega 32X</description>
 		<category>No Subfolders</category>
-		<version>20260227</version>
-		<date>27 February 2026</date>
+		<version>20260427</version>
+		<date>27 April 2026</date>
 		<author>AzgoRAth, NeoRetroGamer (Contributor), Jumphil (Contributor)</author>
 		<homepage>https://retroachievements.org</homepage>
 		<url>https://retroachievements.org/system/10/games</url>
@@ -65,38 +65,38 @@
 		<hash>16a811628cd9245f2101e218581cd594</hash>
 	</game>
 	
-	<game name="Double Symbol (World) (v1.35) (Timur Lyazgiev) (Aftermarket)">
+	<game name="Double Symbol (World) (v1.35) (Aftermarket) (Timur Lyazgiev)">
 		<category>Homebrew</category>
-		<description>Double Symbol (World) (v1.35) (Timur Lyazgiev) (Aftermarket)</description>
-		<release name="Double Symbol (World) (v1.35) (Timur Lyazgiev) (Aftermarket)" region="World"/>
-		<rom name="Double Symbol (World) (v1.35) (Timur Lyazgiev) (Aftermarket).32x" size="484748" crc="2812d4fe" md5="4b14e8c22a97b4fd164e077a4980c582" sha1="54421dcfeecb9d00d1e6deeb191d921baa323a4e"/>
+		<description>Double Symbol (World) (v1.35) (Aftermarket) (Timur Lyazgiev)</description>
+		<release name="Double Symbol (World) (v1.35) (Aftermarket) (Timur Lyazgiev)" region="World"/>
+		<rom name="Double Symbol (World) (v1.35) (Aftermarket) (Timur Lyazgiev).32x" size="484748" crc="2812d4fe" md5="4b14e8c22a97b4fd164e077a4980c582" sha1="54421dcfeecb9d00d1e6deeb191d921baa323a4e"/>
 		<url>https://retroachievements.org/game/33570/hashes</url>
 		<hash>4b14e8c22a97b4fd164e077a4980c582</hash>
 	</game>
 	
-	<game name="xRick (USA) (v2011-04-30) (Chilly Willy) (Aftermarket)">
+	<game name="xRick (World) (Aftermarket) (Unl)">
 		<category>Homebrew</category>
-		<description>xRick (USA) (v2011-04-30) (Chilly Willy) (Aftermarket)</description>
-		<release name="xRick (USA) (v2011-04-30) (Chilly Willy) (Aftermarket)" region="World"/>
-		<rom name="xRick (USA) (v2011-04-30) (Chilly Willy) (Aftermarket).bin" size="4194304" crc="fd07db46" md5="f642e289bfb670022e0ae001786bdf94" sha1="f951890e6cd3cfd5e4cba13be8c8aea4f70d36a5"/>
+		<description>xRick (World) (Aftermarket) (Unl)</description>
+		<release name="xRick (World) (Aftermarket) (Unl)" region="World"/>
+		<rom name="xRick (World) (Aftermarket) (Unl).32x" size="4194304" crc="fd07db46" md5="f642e289bfb670022e0ae001786bdf94" sha1="f951890e6cd3cfd5e4cba13be8c8aea4f70d36a5"/>
 		<url>https://retroachievements.org/game/17682/hashes</url>
 		<hash>f642e289bfb670022e0ae001786bdf94</hash>
 	</game>
 	
-	<game name="ClayFighter 2 (USA) (Proto) (1995-04-28)">
+	<game name="ClayFighter 2 (USA) (Proto)">
 		<category>Prototype</category>
-		<description>ClayFighter 2 (USA) (Proto) (1995-04-28)</description>
-		<release name="ClayFighter 2 (USA) (Proto) (1995-04-28)" region="USA"/>
-		<rom name="ClayFighter 2 (USA) (Proto) (1995-04-28).32x" size="1048576" crc="59701755" md5="dee27ac83240ddebdcaa92e9f58fde4f" sha1="1d3c372b55fa1418556aea1949995f997227b5fa"/>
+		<description>ClayFighter 2 (USA) (Proto)</description>
+		<release name="ClayFighter 2 (USA) (Proto)" region="USA"/>
+		<rom name="ClayFighter 2 (USA) (Proto).32x" size="1048576" crc="59701755" md5="dee27ac83240ddebdcaa92e9f58fde4f" sha1="1d3c372b55fa1418556aea1949995f997227b5fa"/>
 		<url>https://retroachievements.org/game/16794/hashes</url>
 		<hash>dee27ac83240ddebdcaa92e9f58fde4f</hash>
 	</game>
 	
-	<game name="Pinocchio (Europe) (Proto) (1995-12-06)">
+	<game name="Pinocchio (Europe) (Proto)">
 		<category>Prototype</category>
-		<description>Pinocchio (Europe) (Proto) (1995-12-06)</description>
-		<release name="Pinocchio (Europe) (Proto) (1995-12-06)" region="Europe"/>
-		<rom name="Pinocchio (Europe) (Proto) (1995-12-06).32x" size="4194304" crc="390a90f9" md5="406ab3e46797d8459c3d9efbbc044282" sha1="39ccf67e516bdaec879f1e30b23d5f253e82b6c8"/>
+		<description>Pinocchio (Europe) (Proto)</description>
+		<release name="Pinocchio (Europe) (Proto)" region="Europe"/>
+		<rom name="Pinocchio (Europe) (Proto).32x" size="4194304" crc="390a90f9" md5="406ab3e46797d8459c3d9efbbc044282" sha1="39ccf67e516bdaec879f1e30b23d5f253e82b6c8"/>
 		<url>https://retroachievements.org/game/16800/hashes</url>
 		<hash>406ab3e46797d8459c3d9efbbc044282</hash>
 	</game>

--- a/DATs/RetroAchievements (No Subfolders)/RA - Sega Game Gear.dat
+++ b/DATs/RetroAchievements (No Subfolders)/RA - Sega Game Gear.dat
@@ -5,37 +5,46 @@
 		<name>RA - Sega Game Gear</name>
 		<description>Sega Game Gear</description>
 		<category>No Subfolders</category>
-		<version>20260214</version>
-		<date>14 February 2026</date>
+		<version>20260428</version>
+		<date>28 April 2026</date>
 		<author>AzgoRAth, NeoRetroGamer (Contributor), Jumphil (Contributor)</author>
 		<homepage>https://retroachievements.org</homepage>
 		<url>https://retroachievements.org/system/15/games</url>
-		<titlecount>113</titlecount>
-		<hashcount>137/138</hashcount>
+		<titlecount>119</titlecount>
+		<hashcount>143/144</hashcount>
 	</header>
-	<game name="Hamburgers en Route to Switzerland (World) (v0.75) (Proto) (Aftermarket)">
+	<game name="Hamburgers en Route to Switzerland (World) (Proto 2) (Aftermarket) (Unl)">
 		<category>Homebrew</category>
-		<description>Hamburgers en Route to Switzerland (World) (v0.75) (Proto) (Aftermarket)</description>
-		<release name="Hamburgers en Route to Switzerland (World) (v0.75) (Proto) (Aftermarket)" region="World"/>
-		<rom name="Hamburgers en Route to Switzerland (World) (v0.75) (Proto) (Aftermarket).gg" size="131072" crc="f4fad7c2" md5="c91f1bcc0b4ab1abac998ce8a02bbafb" sha1="de7f24f7bcc6b6a225b994c82d4e2ea6aac0f4e7"/>
+		<description>Hamburgers en Route to Switzerland (World) (Proto 2) (Aftermarket) (Unl)</description>
+		<release name="Hamburgers en Route to Switzerland (World) (Proto 2) (Aftermarket) (Unl)" region="World"/>
+		<rom name="Hamburgers en Route to Switzerland (World) (Proto 2) (Aftermarket) (Unl).gg" size="131072" crc="f4fad7c2" md5="c91f1bcc0b4ab1abac998ce8a02bbafb" sha1="de7f24f7bcc6b6a225b994c82d4e2ea6aac0f4e7"/>
 		<url>https://retroachievements.org/game/28834/hashes</url>
 		<hash>c91f1bcc0b4ab1abac998ce8a02bbafb</hash>
 	</game>
 	
-	<game name="Snepzhen Solitaire (World) (v1.0) (Wainstop) (Aftermarket)">
+	<game name="Hopman Mini (World) (Aftermarket) (Unl)">
 		<category>Homebrew</category>
-		<description>Snepzhen Solitaire (World) (v1.0) (Wainstop) (Aftermarket)</description>
-		<release name="Snepzhen Solitaire (World) (v1.0) (Wainstop) (Aftermarket)" region="World"/>
-		<rom name="Snepzhen Solitaire (World) (v1.0) (Wainstop) (Aftermarket).gg" size="32768" crc="fd06798c" md5="aca63448b5d887239fc8821760d36efb" sha1="891811a7b86222b01f9a43664db8186e2f8001b8"/>
+		<description>Hopman Mini (World) (Aftermarket) (Unl)</description>
+		<release name="Hopman Mini (World) (Aftermarket) (Unl)" region="World"/>
+		<rom name="Hopman Mini (World) (Aftermarket) (Unl).gg" size="16368" crc="84fd672d" md5="73cda8d9cf406c5ad1d69747333482e9" sha1="920aa9c3d64073d140280bf0baed64fe2aaa5dfa"/>
+		<url>https://retroachievements.org/game/32992/hashes</url>
+		<hash>73cda8d9cf406c5ad1d69747333482e9</hash>
+	</game>
+	
+	<game name="Snepzhen Solitaire (World) (Aftermarket) (Unl)">
+		<category>Homebrew</category>
+		<description>Snepzhen Solitaire (World) (Aftermarket) (Unl)</description>
+		<release name="Snepzhen Solitaire (World) (Aftermarket) (Unl)" region="World"/>
+		<rom name="Snepzhen Solitaire (World) (Aftermarket) (Unl).gg" size="32768" crc="fd06798c" md5="aca63448b5d887239fc8821760d36efb" sha1="891811a7b86222b01f9a43664db8186e2f8001b8"/>
 		<url>https://retroachievements.org/game/30932/hashes</url>
 		<hash>aca63448b5d887239fc8821760d36efb</hash>
 	</game>
 	
-	<game name="Swabby (World) (v1.11) (Aftermarket)">
+	<game name="Swabby (World) (v1.11) (Aftermarket) (Unl)">
 		<category>Homebrew</category>
-		<description>Swabby (World) (v1.11) (Aftermarket)</description>
-		<release name="Swabby (World) (v1.11) (Aftermarket)" region="World"/>
-		<rom name="Swabby (World) (v1.11) (Aftermarket).gg" size="131072" crc="b814ad3d" md5="db672d52225564b6f520e8a0a4b1a4c7" sha1="64f7350ca2c37c44b679e35f9bfd2766c7259cb9"/>
+		<description>Swabby (World) (v1.11) (Aftermarket) (Unl)</description>
+		<release name="Swabby (World) (v1.11) (Aftermarket) (Unl)" region="World"/>
+		<rom name="Swabby (World) (v1.11) (Aftermarket) (Unl).gg" size="131072" crc="b814ad3d" md5="db672d52225564b6f520e8a0a4b1a4c7" sha1="64f7350ca2c37c44b679e35f9bfd2766c7259cb9"/>
 		<url>https://retroachievements.org/game/26880/hashes</url>
 		<hash>db672d52225564b6f520e8a0a4b1a4c7</hash>
 	</game>
@@ -191,11 +200,11 @@
 		<hash>86a3221d3d74133c84f658939fd6e928</hash>
 	</game>
 	
-	<game name="Sassou Shounen Eiyuuden Coca Cola Kid (Japan) (En) (v1.1) (Filler)" cloneof="Sassou Shounen Eiyuuden - Coca-Cola Kid (Japan)">
+	<game name="Sassou Shounen Eiyuuden - Coca Cola Kid (Japan) (En) (v1.1) (Filler)" cloneof="Sassou Shounen Eiyuuden - Coca-Cola Kid (Japan)">
 		<category>Retail</category>
-		<description>Sassou Shounen Eiyuuden Coca Cola Kid (Japan) (En) (v1.1) (Filler)</description>
-		<release name="Sassou Shounen Eiyuuden Coca Cola Kid (Japan) (En) (v1.1) (Filler)" region="English"/>
-		<rom name="Sassou Shounen Eiyuuden Coca Cola Kid (Japan) (En) (v1.1) (Filler).gg" size="524288" crc="ea32dbc5" md5="d259f6b3a437b7df069abb935553007a" sha1="a584a65d1aa75d62df8162915744a456e499e9a5"/>
+		<description>Sassou Shounen Eiyuuden - Coca Cola Kid (Japan) (En) (v1.1) (Filler)</description>
+		<release name="Sassou Shounen Eiyuuden - Coca Cola Kid (Japan) (En) (v1.1) (Filler)" region="English"/>
+		<rom name="Sassou Shounen Eiyuuden - Coca Cola Kid (Japan) (En) (v1.1) (Filler).gg" size="524288" crc="ea32dbc5" md5="d259f6b3a437b7df069abb935553007a" sha1="a584a65d1aa75d62df8162915744a456e499e9a5"/>
 		<url>https://retroachievements.org/game/11802/hashes</url>
 		<hash>d259f6b3a437b7df069abb935553007a</hash>
 	</game>
@@ -219,11 +228,11 @@
 		<hash>90bd4681e3e4b07445eaf35e83b223db</hash>
 	</game>
 	
-	<game name="Crayon Shin-chan - Taiketsu! Kantam Panic!! (Japan) (En)">
+	<game name="Crayon Shin-chan - Taiketsu! Kantam Panic!! (Japan)">
 		<category>Retail</category>
-		<description>Crayon Shin-chan - Taiketsu! Kantam Panic!! (Japan) (En)</description>
-		<release name="Crayon Shin-chan - Taiketsu! Kantam Panic!! (Japan) (En)" region="English"/>
-		<rom name="Crayon Shin-chan - Taiketsu! Kantam Panic!! (Japan) (En).gg" size="524288" crc="48c18828" md5="3788f49e16ddb70d0af7b2cf63456246" sha1="01aac4e14ae71d3980cf968cc2bd6831e3987ab1"/>
+		<description>Crayon Shin-chan - Taiketsu! Kantam Panic!! (Japan)</description>
+		<release name="Crayon Shin-chan - Taiketsu! Kantam Panic!! (Japan)" region="English"/>
+		<rom name="Crayon Shin-chan - Taiketsu! Kantam Panic!! (Japan).gg" size="524288" crc="48c18828" md5="3788f49e16ddb70d0af7b2cf63456246" sha1="01aac4e14ae71d3980cf968cc2bd6831e3987ab1"/>
 		<url>https://retroachievements.org/game/29324/hashes</url>
 		<hash>3788f49e16ddb70d0af7b2cf63456246</hash>
 	</game>
@@ -315,11 +324,11 @@
 		<url>https://retroachievements.org/game/14297/hashes</url>
 		<hash>c58d6291da8a4919328b8f42be8640a7</hash>
 	</game>
-	<game name="Eternal Legend - Eien no Densetsu (Japan) (En) (No-Encounter) (v1.0) (LIPEMCO!,Searo)" cloneof="Eternal Legend (Japan)">
+	<game name="Eternal Legend (Japan) (En) (No-Encounter) (v1.0) (LIPEMCO!,Searo)" cloneof="Eternal Legend (Japan)">
 		<category>Retail</category>
-		<description>Eternal Legend - Eien no Densetsu (Japan) (En) (No-Encounter) (v1.0) (LIPEMCO!,Searo)</description>
-		<release name="Eternal Legend - Eien no Densetsu (Japan) (En) (No-Encounter) (v1.0) (LIPEMCO!,Searo)" region="English"/>
-		<rom name="Eternal Legend - Eien no Densetsu (Japan) (En) (No-Encounter) (v1.0) (LIPEMCO!,Searo).gg" size="1048576" crc="75988ab3" md5="e8f49ea568e174b50079f725ce29f45d" sha1="5a5cf544317465db0b486e4edc6d1354b693f0a8"/>
+		<description>Eternal Legend (Japan) (En) (No-Encounter) (v1.0) (LIPEMCO!,Searo)</description>
+		<release name="Eternal Legend (Japan) (En) (No-Encounter) (v1.0) (LIPEMCO!,Searo)" region="English"/>
+		<rom name="Eternal Legend (Japan) (En) (No-Encounter) (v1.0) (LIPEMCO!,Searo).gg" size="1048576" crc="75988ab3" md5="e8f49ea568e174b50079f725ce29f45d" sha1="5a5cf544317465db0b486e4edc6d1354b693f0a8"/>
 		<url>https://retroachievements.org/game/14297/hashes</url>
 		<hash>e8f49ea568e174b50079f725ce29f45d</hash>
 	</game>
@@ -352,11 +361,11 @@
 		<hash>43301e7c15fe11f66b29b00e6ec47a52</hash>
 	</game>
 	
-	<game name="GG Aleste 3 (Japan) (En) (Playability Patch)">
+	<game name="GG Aleste 3 (Japan) (En) (Aleste Collection) (Playability Patch)">
 		<category>Retail</category>
-		<description>GG Aleste 3 (Japan) (En) (Playability Patch)</description>
-		<release name="GG Aleste 3 (Japan) (En) (Playability Patch)" region="Japan"/>
-		<rom name="GG Aleste 3 (Japan) (En) (Playability Patch).gg" size="1048576" crc="717fd9e3" md5="41f9b360571a8aae3b01e780e90a9f68" sha1="b2948f2498d3095aebdb5fe4a62590c12c8ea846"/>
+		<description>GG Aleste 3 (Japan) (En) (Aleste Collection) (Playability Patch)</description>
+		<release name="GG Aleste 3 (Japan) (En) (Aleste Collection) (Playability Patch)" region="Japan"/>
+		<rom name="GG Aleste 3 (Japan) (En) (Aleste Collection) (Playability Patch).gg" size="1048576" crc="717fd9e3" md5="41f9b360571a8aae3b01e780e90a9f68" sha1="b2948f2498d3095aebdb5fe4a62590c12c8ea846"/>
 		<url>https://retroachievements.org/game/27591/hashes</url>
 		<hash>41f9b360571a8aae3b01e780e90a9f68</hash>
 	</game>
@@ -387,7 +396,7 @@
 		<url>https://retroachievements.org/game/12624/hashes</url>
 		<hash>c46d46f3ab4873cb1ed7ae8b9b70f2b4</hash>
 	</game>
-
+	
 	<game name="Halley Wars (USA, Europe, Brazil) (En)">
 		<category>Retail</category>
 		<description>Halley Wars (USA, Europe, Brazil) (En)</description>
@@ -453,11 +462,11 @@
 		<url>https://retroachievements.org/game/12896/hashes</url>
 		<hash>ac6ed281ac8e9d71af186602951cfd7a</hash>
 	</game>
-	<game name="Kishin Douji Zenki (Japan) (En) (v1.0) (LIPEMCO Translations)" cloneof="Kishin Douji Zenki (Japan)">
+	<game name="Kishin Douji Zenki (Japan) (En) (v1.0) (LIPEMCO! Translations)" cloneof="Kishin Douji Zenki (Japan)">
 		<category>Retail</category>
-		<description>Kishin Douji Zenki (Japan) (En) (v1.0) (LIPEMCO Translations)</description>
-		<release name="Kishin Douji Zenki (Japan) (En) (v1.0) (LIPEMCO Translations)" region="English"/>
-		<rom name="Kishin Douji Zenki (Japan) (En) (v1.0) (LIPEMCO Translations).gg" size="1048576" crc="dcd63e4c" md5="b0f8f7a3b573468f1d65b660c173dc82" sha1="048e3bddc01f4079d0a6a54efbeca1254d10d1f2"/>
+		<description>Kishin Douji Zenki (Japan) (En) (v1.0) (LIPEMCO! Translations)</description>
+		<release name="Kishin Douji Zenki (Japan) (En) (v1.0) (LIPEMCO! Translations)" region="English"/>
+		<rom name="Kishin Douji Zenki (Japan) (En) (v1.0) (LIPEMCO! Translations).gg" size="1048576" crc="dcd63e4c" md5="b0f8f7a3b573468f1d65b660c173dc82" sha1="048e3bddc01f4079d0a6a54efbeca1254d10d1f2"/>
 		<url>https://retroachievements.org/game/12896/hashes</url>
 		<hash>b0f8f7a3b573468f1d65b660c173dc82</hash>
 	</game>
@@ -719,11 +728,11 @@
 		<hash>4d0d6d25dfef7e1a509d828f157d515f</hash>
 	</game>
 	
-	<game name="Pengo (Japan)" cloneof="Pengo (Europe)">
+	<game name="Pengo (Japan) (En)" cloneof="Pengo (Europe)">
 		<category>Retail</category>
-		<description>Pengo (Japan)</description>
-		<release name="Pengo (Japan)" region="Japan"/>
-		<rom name="Pengo (Japan).gg" size="32768" crc="ce863dba" md5="95cea3a33a3f5915942904b4817b2010" sha1="5883e2d19ab7126d52abc177a97d44bc88c319de"/>
+		<description>Pengo (Japan) (En)</description>
+		<release name="Pengo (Japan) (En)" region="Japan"/>
+		<rom name="Pengo (Japan) (En).gg" size="32768" crc="ce863dba" md5="95cea3a33a3f5915942904b4817b2010" sha1="5883e2d19ab7126d52abc177a97d44bc88c319de"/>
 		<url>https://retroachievements.org/game/12251/hashes</url>
 		<hash>95cea3a33a3f5915942904b4817b2010</hash>
 	</game>
@@ -745,14 +754,6 @@
 		<hash>c069464b6a0f9fa547c22133f143b75c</hash>
 	</game>
 	
-	<game name="Phantasy Star Gaiden (Japan) (En) (v1.012) (Dynamic Designs)" cloneof="Phantasy Star Gaiden (Japan)">
-		<category>Retail</category>
-		<description>Phantasy Star Gaiden (Japan) (En) (v1.012) (Dynamic Designs)</description>
-		<release name="Phantasy Star Gaiden (Japan) (En) (v1.012) (Dynamic Designs)" region="English"/>
-		<rom name="Phantasy Star Gaiden (Japan) (En) (v1.012) (Dynamic Designs).gg" size="262144" crc="17e64f1e" md5="39aa719b13cd1c50c30232cf5ac80059" sha1="adab47ecc3c0d574243205ddd6edbae6c12bce64"/>
-		<url>https://retroachievements.org/game/12884/hashes</url>
-		<hash>39aa719b13cd1c50c30232cf5ac80059</hash>
-	</game>
 	<game name="Phantasy Star Gaiden (Japan)">
 		<category>Retail</category>
 		<description>Phantasy Star Gaiden (Japan)</description>
@@ -760,6 +761,14 @@
 		<rom name="Phantasy Star Gaiden (Japan).gg" size="262144" crc="a942514a" md5="54be96ca21885145108f1c02e4d88eba" sha1="914f1e693f396794a37b5d99acaf5db54fe529c2"/>
 		<url>https://retroachievements.org/game/12884/hashes</url>
 		<hash>54be96ca21885145108f1c02e4d88eba</hash>
+	</game>
+	<game name="Phantasy Star Gaiden (Japan) (En) (v1.012) (Dynamic Designs)" cloneof="Phantasy Star Gaiden (Japan)">
+		<category>Retail</category>
+		<description>Phantasy Star Gaiden (Japan) (En) (v1.012) (Dynamic Designs)</description>
+		<release name="Phantasy Star Gaiden (Japan) (En) (v1.012) (Dynamic Designs)" region="English"/>
+		<rom name="Phantasy Star Gaiden (Japan) (En) (v1.012) (Dynamic Designs).gg" size="262144" crc="17e64f1e" md5="39aa719b13cd1c50c30232cf5ac80059" sha1="adab47ecc3c0d574243205ddd6edbae6c12bce64"/>
+		<url>https://retroachievements.org/game/12884/hashes</url>
+		<hash>39aa719b13cd1c50c30232cf5ac80059</hash>
 	</game>
 	<game name="Phantasy Star Gaiden (Japan) (En) (Wide Font) (v1.012) (Dynamic Designs)" cloneof="Phantasy Star Gaiden (Japan)">
 		<category>Retail</category>
@@ -769,11 +778,11 @@
 		<hash>ba091114cbc5a4b3482e6887094070bb</hash>
 	</game>
 	
-	<game name="Pop Breaker (Japan)">
+	<game name="Pop Breaker (Japan) (En)">
 		<category>Retail</category>
-		<description>Pop Breaker (Japan)</description>
-		<release name="Pop Breaker (Japan)" region="Japan"/>
-		<rom name="Pop Breaker (Japan).gg" size="131072" crc="71deba5a" md5="e0e2fbd5834c04574795c923b0147f39" sha1="9c358504d3c106dd62bd8981132b47cdb95903de"/>
+		<description>Pop Breaker (Japan) (En)</description>
+		<release name="Pop Breaker (Japan) (En)" region="Japan"/>
+		<rom name="Pop Breaker (Japan) (En).gg" size="131072" crc="71deba5a" md5="e0e2fbd5834c04574795c923b0147f39" sha1="9c358504d3c106dd62bd8981132b47cdb95903de"/>
 		<url>https://retroachievements.org/game/14301/hashes</url>
 		<hash>e0e2fbd5834c04574795c923b0147f39</hash>
 	</game>
@@ -817,11 +826,11 @@
 		<url>https://retroachievements.org/game/14059/hashes</url>
 		<hash>52cfddc12af6a3a64030f62ccf6aca83</hash>
 	</game>
-	<game name="Psychic World (Japan) (En)" cloneof="Psychic World (USA, Europe, Brazil) (En) (Rev 1)">
+	<game name="Psychic World (Japan)" cloneof="Psychic World (USA, Europe, Brazil) (En) (Rev 1)">
 		<category>Retail</category>
-		<description>Psychic World (Japan) (En)</description>
-		<release name="Psychic World (Japan) (En)" region="Japan"/>
-		<rom name="Psychic World (Japan) (En).sms" size="131072" crc="afcc7828" md5="a764b44555aadb48c519e7c85bdf7895" sha1="1c0074c811ed4eb369be31c1bc7d851e40ae8797"/>
+		<description>Psychic World (Japan)</description>
+		<release name="Psychic World (Japan)" region="Japan"/>
+		<rom name="Psychic World (Japan).sms" size="131072" crc="afcc7828" md5="a764b44555aadb48c519e7c85bdf7895" sha1="1c0074c811ed4eb369be31c1bc7d851e40ae8797"/>
 		<url>https://retroachievements.org/game/14059/hashes</url>
 		<hash>a764b44555aadb48c519e7c85bdf7895</hash>
 	</game>
@@ -834,12 +843,12 @@
 		<url>https://retroachievements.org/game/26242/hashes</url>
 		<hash>dcec1000aea3882b218b0cc0aed5a5d8</hash>
 	</game>
-
-	<game name="Rastan Saga (Japan)">
+	
+	<game name="Rastan Saga (Japan) (En)">
 		<category>Retail</category>
-		<description>Rastan Saga (Japan)</description>
-		<release name="Rastan Saga (Japan)" region="Japan"/>
-		<rom name="Rastan Saga (Japan).sms" size="262144" crc="9c76fb3a" md5="fd82af26ebbed24f57c4eea8eddf3136" sha1="96bf8a67919218aac91fb74cde80a16f90df77d5"/>
+		<description>Rastan Saga (Japan) (En)</description>
+		<release name="Rastan Saga (Japan) (En)" region="Japan"/>
+		<rom name="Rastan Saga (Japan) (En).sms" size="262144" crc="9c76fb3a" md5="fd82af26ebbed24f57c4eea8eddf3136" sha1="96bf8a67919218aac91fb74cde80a16f90df77d5"/>
 		<url>https://retroachievements.org/game/17698/hashes</url>
 		<hash>fd82af26ebbed24f57c4eea8eddf3136</hash>
 	</game>
@@ -897,11 +906,11 @@
 		<hash>f96d7da86e4f63d66175b1903f976b2c</hash>
 	</game>
 	
-	<game name="Shining Force Gaiden - Final Conflict (Japan) (En) (Debug Patch) (Bartis1989)" cloneof="Shining Force Gaiden - Final Conflict (Japan) (Debug Patch) (Bartis1989)">
+	<game name="Shining Force Gaiden - Final Conflict (Japan) (En) (Debug Patch) (Shining Force Central,Bartis1989)" cloneof="Shining Force Gaiden - Final Conflict (Japan) (Debug Patch) (Bartis1989)">
 		<category>Retail</category>
-		<description>Shining Force Gaiden - Final Conflict (Japan) (En) (Debug Patch) (Bartis1989)</description>
-		<release name="Shining Force Gaiden - Final Conflict (Japan) (En) (Debug Patch) (Bartis1989)" region="English"/>
-		<rom name="Shining Force Gaiden - Final Conflict (Japan) (En) (Debug Patch) (Bartis1989).gg" size="524288" crc="88d26fcd" md5="219b1a3f5e055fce7245d869e1fc9249" sha1="a7f5ee9d8287a32e7d9c18ff8f491555785f5ed1"/>
+		<description>Shining Force Gaiden - Final Conflict (Japan) (En) (Debug Patch) (Shining Force Central,Bartis1989)</description>
+		<release name="Shining Force Gaiden - Final Conflict (Japan) (En) (Debug Patch) (Shining Force Central,Bartis1989)" region="English"/>
+		<rom name="Shining Force Gaiden - Final Conflict (Japan) (En) (Debug Patch) (Shining Force Central,Bartis1989).gg" size="524288" crc="88d26fcd" md5="219b1a3f5e055fce7245d869e1fc9249" sha1="a7f5ee9d8287a32e7d9c18ff8f491555785f5ed1"/>
 		<url>https://retroachievements.org/game/12640/hashes</url>
 		<hash>219b1a3f5e055fce7245d869e1fc9249</hash>
 	</game>
@@ -914,15 +923,15 @@
 		<hash>b7b023b6c716c8c984c3268a962cf99b</hash>
 	</game>
 	
-	<game name="Shining Force - The Sword of Hajya (USA) (Debug Patch) (Bartis 1989)">
+	<game name="Shining Force - The Sword of Hajya (USA) (Debug Patch) (Bartis1989)">
 		<category>Retail</category>
-		<description>Shining Force - The Sword of Hajya (USA) (Debug Patch) (Bartis 1989)</description>
-		<release name="Shining Force - The Sword of Hajya (USA) (Debug Patch) (Bartis 1989)" region="USA"/>
-		<rom name="Shining Force - The Sword of Hajya (USA) (Debug Patch) (Bartis 1989).gg" size="524288" crc="90ac7c6a" md5="4c749140795a0fb69a06574d5187cd25" sha1="c010b70d2ab6dd010bee676da11bf69a90c39a01"/>
+		<description>Shining Force - The Sword of Hajya (USA) (Debug Patch) (Bartis1989)</description>
+		<release name="Shining Force - The Sword of Hajya (USA) (Debug Patch) (Bartis1989)" region="USA"/>
+		<rom name="Shining Force - The Sword of Hajya (USA) (Debug Patch) (Bartis1989).gg" size="524288" crc="90ac7c6a" md5="4c749140795a0fb69a06574d5187cd25" sha1="c010b70d2ab6dd010bee676da11bf69a90c39a01"/>
 		<url>https://retroachievements.org/game/12639/hashes</url>
 		<hash>4c749140795a0fb69a06574d5187cd25</hash>
 	</game>
-	<game name="Shining Force Gaiden II - Jashin no Kakusei (Japan) (Debug Patch) (Bartis1989)" cloneof="Shining Force - The Sword of Hajya (USA) (Debug Patch) (Bartis 1989)">
+	<game name="Shining Force Gaiden II - Jashin no Kakusei (Japan) (Debug Patch) (Bartis1989)" cloneof="Shining Force - The Sword of Hajya (USA) (Debug Patch) (Bartis1989)">
 		<category>Retail</category>
 		<description>Shining Force Gaiden II - Jashin no Kakusei (Japan) (Debug Patch) (Bartis1989)</description>
 		<release name="Shining Force Gaiden II - Jashin no Kakusei (Japan) (Debug Patch) (Bartis1989)" region="Japan"/>
@@ -1285,6 +1294,25 @@
 		<rom name="X-Men (USA).gg" size="524288" crc="567a5ee6" md5="21d75ed09b6f73037544894580933a0b" sha1="215e5f761475ca17a091371e39f636718f213403"/>
 		<url>https://retroachievements.org/game/13394/hashes</url>
 		<hash>21d75ed09b6f73037544894580933a0b</hash>
+	</game>
+	
+	<game name="X-Men - Gamemaster's Legacy (USA, Europe)">
+		<category>Retail</category>
+		<description>X-Men - Gamemaster's Legacy (USA, Europe)</description>
+		<release name="X-Men - Gamemaster's Legacy (USA, Europe)" region="Europe"/>
+		<release name="X-Men - Gamemaster's Legacy (USA, Europe)" region="USA"/>
+		<rom name="X-Men - Gamemaster's Legacy (USA, Europe).gg" size="524288" crc="c169c344" md5="571ac03b80e3075c699cd583bf8651fd" sha1="872596d40aae1755c9dda99180cb165166267904"/>
+		<url>https://retroachievements.org/game/13396/hashes</url>
+		<hash>571ac03b80e3075c699cd583bf8651fd</hash>
+	</game>
+	
+	<game name="X-Men - Mojo World (USA)">
+		<category>Retail</category>
+		<description>X-Men - Mojo World (USA)</description>
+		<release name="X-Men - Mojo World (USA)" region="USA"/>
+		<rom name="X-Men - Mojo World (USA).gg" size="524288" crc="c2cba9d7" md5="ca15f2ba2507ebd836c42d9d10231eb1" sha1="cff15c4a3e555c2868af93c55386b5ab3d3db4e3"/>
+		<url>https://retroachievements.org/game/26255/hashes</url>
+		<hash>ca15f2ba2507ebd836c42d9d10231eb1</hash>
 	</game>
 	
 	<game name="Yu Yu Hakusho II - Gekitou! Nanakyou no Tatakai (Japan)">

--- a/DATs/RetroAchievements (No Subfolders)/RA - Sega SG-1000.dat
+++ b/DATs/RetroAchievements (No Subfolders)/RA - Sega SG-1000.dat
@@ -5,160 +5,160 @@
 		<name>RA - Sega SG-1000</name>
 		<description>Sega SG-1000</description>
 		<category>No Subfolders</category>
-		<version>20251225</version>
-		<date>25 December 2025</date>
+		<version>20260427</version>
+		<date>27 April 2026</date>
 		<author>AzgoRAth, NeoRetroGamer (Contributor), Jumphil (Contributor)</author>
 		<homepage>https://retroachievements.org</homepage>
 		<url>https://retroachievements.org/system/33/games</url>
-		<titlecount>92</titlecount>
-		<hashcount>108/109</hashcount>
+		<titlecount>93</titlecount>
+		<hashcount>109/110</hashcount>
 	</header>
-	<game name="Cheril Perils Classic (World) (NTSC) (Aftermarket)">
+	<game name="Cheril Perils Classic (World) (NTSC) (Aftermarket) (Unl)">
 		<category>Homebrew</category>
-		<description>Cheril Perils Classic (World) (NTSC) (Aftermarket)</description>
-		<release name="Cheril Perils Classic (World) (NTSC) (Aftermarket)" region="USA"/>
-		<rom name="Cheril Perils Classic (World) (NTSC) (Aftermarket).sg" size="49152" crc="60d5c65d" md5="dea9e4e5891fbdcd3e0df16fc840afbe" sha1="877c7f71daf10c451745d68c2c88e5c06abc5c42"/>
+		<description>Cheril Perils Classic (World) (NTSC) (Aftermarket) (Unl)</description>
+		<release name="Cheril Perils Classic (World) (NTSC) (Aftermarket) (Unl)" region="USA"/>
+		<rom name="Cheril Perils Classic (World) (NTSC) (Aftermarket) (Unl).sg" size="49152" crc="60d5c65d" md5="dea9e4e5891fbdcd3e0df16fc840afbe" sha1="877c7f71daf10c451745d68c2c88e5c06abc5c42"/>
 		<url>https://retroachievements.org/game/22685/hashes</url>
 		<hash>dea9e4e5891fbdcd3e0df16fc840afbe</hash>
 	</game>
 	
-	<game name="Earth Attack (USA) (v2021116) (Aftermarket)">
+	<game name="Earth Attack (USA) (v2021116) (Aftermarket) (Unl)">
 		<category>Homebrew</category>
-		<description>Earth Attack (USA) (v2021116) (Aftermarket)</description>
-		<release name="Earth Attack (USA) (v2021116) (Aftermarket)" region="USA"/>
-		<rom name="Earth Attack (USA) (v2021116) (Aftermarket).sg" size="16384" crc="575c7f2a" md5="be7798f9073f9a587ff0a36b646c65b7" sha1="92636a511152051a593976a4651c85c8affea614"/>
+		<description>Earth Attack (USA) (v2021116) (Aftermarket) (Unl)</description>
+		<release name="Earth Attack (USA) (v2021116) (Aftermarket) (Unl)" region="USA"/>
+		<rom name="Earth Attack (USA) (v2021116) (Aftermarket) (Unl).sg" size="16384" crc="575c7f2a" md5="be7798f9073f9a587ff0a36b646c65b7" sha1="92636a511152051a593976a4651c85c8affea614"/>
 		<url>https://retroachievements.org/game/25804/hashes</url>
 		<hash>be7798f9073f9a587ff0a36b646c65b7</hash>
 	</game>
 	
-	<game name="Foryster (USA) (v00.9) (Aftermarket)" cloneof="Foryster (USA) (v00.9 - Level 10 Fix) (Aftermarket)">
+	<game name="Foryster (USA) (v00.9) (Aftermarket) (Unl)" cloneof="Foryster (USA) (v00.9 - Level 10 Fix) (Aftermarket) (Unl)">
 		<category>Homebrew</category>
-		<description>Foryster (USA) (v00.9) (Aftermarket)</description>
-		<rom name="Foryster (USA) (v00.9) (Aftermarket).sg" size="32768" crc="f8d7fa2c" md5="7aeb05029bdb9a571b1b72482daad5eb" sha1="6d9ed7208032ad3ec9011bbc999cea426aca46d3"/>
+		<description>Foryster (USA) (v00.9) (Aftermarket) (Unl)</description>
+		<rom name="Foryster (USA) (v00.9) (Aftermarket) (Unl).sg" size="32768" crc="f8d7fa2c" md5="7aeb05029bdb9a571b1b72482daad5eb" sha1="6d9ed7208032ad3ec9011bbc999cea426aca46d3"/>
 		<url>https://retroachievements.org/game/25010/hashes</url>
 		<hash>7aeb05029bdb9a571b1b72482daad5eb</hash>
 	</game>
-	<game name="Foryster (USA) (v00.9 - Level 10 Fix) (Aftermarket)">
+	<game name="Foryster (USA) (v00.9 - Level 10 Fix) (Aftermarket) (Unl)">
 		<category>Homebrew</category>
-		<description>Foryster (USA) (v00.9 - Level 10 Fix) (Aftermarket)</description>
-		<release name="Foryster (USA) (v00.9 - Level 10 Fix) (Aftermarket)" region="USA"/>
-		<rom name="Foryster (USA) (v00.9 - Level 10 Fix) (Aftermarket).sg" size="32768" crc="c3bdd92c" md5="1065ae51e06b8a07ce99998a37c7db79" sha1="f59be1768fbab79d1bffb886f4074d1e06498f9f"/>
+		<description>Foryster (USA) (v00.9 - Level 10 Fix) (Aftermarket) (Unl)</description>
+		<release name="Foryster (USA) (v00.9 - Level 10 Fix) (Aftermarket) (Unl)" region="USA"/>
+		<rom name="Foryster (USA) (v00.9 - Level 10 Fix) (Aftermarket) (Unl).sg" size="32768" crc="c3bdd92c" md5="1065ae51e06b8a07ce99998a37c7db79" sha1="f59be1768fbab79d1bffb886f4074d1e06498f9f"/>
 		<url>https://retroachievements.org/game/25010/hashes</url>
 		<hash>1065ae51e06b8a07ce99998a37c7db79</hash>
 	</game>
 	
-	<game name="H7N9 (USA) (v20161024) (Aftermarket)">
+	<game name="H7N9 (USA) (v20161024) (Aftermarket) (Unl)">
 		<category>Homebrew</category>
-		<description>H7N9 (USA) (v20161024) (Aftermarket)</description>
-		<release name="H7N9 (USA) (v20161024) (Aftermarket)" region="USA"/>
-		<rom name="H7N9 (USA) (v20161024) (Aftermarket).sg" size="8192" crc="8643027f" md5="784f9220a864953323b42aef566d667e" sha1="5848cc4a8116ce428caa8b775829ed4ffee8fb52"/>
+		<description>H7N9 (USA) (v20161024) (Aftermarket) (Unl)</description>
+		<release name="H7N9 (USA) (v20161024) (Aftermarket) (Unl)" region="USA"/>
+		<rom name="H7N9 (USA) (v20161024) (Aftermarket) (Unl).sg" size="8192" crc="8643027f" md5="784f9220a864953323b42aef566d667e" sha1="5848cc4a8116ce428caa8b775829ed4ffee8fb52"/>
 		<url>https://retroachievements.org/game/25825/hashes</url>
 		<hash>784f9220a864953323b42aef566d667e</hash>
 	</game>
 	
-	<game name="Hopman (USA) (v1.0) (Aftermarket)">
+	<game name="Hopman (USA) (v1.0) (Aftermarket) (Unl)">
 		<category>Homebrew</category>
-		<description>Hopman (USA) (v1.0) (Aftermarket)</description>
-		<release name="Hopman (USA) (v1.0) (Aftermarket)" region="USA"/>
-		<rom name="Hopman (USA) (v1.0) (Aftermarket).sg" size="9958" crc="8bc01dd6" md5="ed86987c468fbdcf6255a22536c3bac1" sha1="b9ca846d0dbdbd32ed00fa106fb162a0aceda259"/>
+		<description>Hopman (USA) (v1.0) (Aftermarket) (Unl)</description>
+		<release name="Hopman (USA) (v1.0) (Aftermarket) (Unl)" region="USA"/>
+		<rom name="Hopman (USA) (v1.0) (Aftermarket) (Unl).sg" size="9958" crc="8bc01dd6" md5="ed86987c468fbdcf6255a22536c3bac1" sha1="b9ca846d0dbdbd32ed00fa106fb162a0aceda259"/>
 		<url>https://retroachievements.org/game/25826/hashes</url>
 		<hash>ed86987c468fbdcf6255a22536c3bac1</hash>
 	</game>
 	
-	<game name="Jet Paco and Jet Puri (USA) (v1.0) (Aftermarket)">
+	<game name="Jet Paco and Jet Puri (USA) (v1.0) (Aftermarket) (Unl)">
 		<category>Homebrew</category>
-		<description>Jet Paco and Jet Puri (USA) (v1.0) (Aftermarket)</description>
-		<release name="Jet Paco and Jet Puri (USA) (v1.0) (Aftermarket)" region="USA"/>
-		<rom name="Jet Paco and Jet Puri (USA) (v1.0) (Aftermarket).sg" size="49152" crc="d31c6b3b" md5="c07672a810c23e269a65a02e3893172a" sha1="e2dbe48a9a4490857ae7d51e306f6afba5aac3fa"/>
+		<description>Jet Paco and Jet Puri (USA) (v1.0) (Aftermarket) (Unl)</description>
+		<release name="Jet Paco and Jet Puri (USA) (v1.0) (Aftermarket) (Unl)" region="USA"/>
+		<rom name="Jet Paco and Jet Puri (USA) (v1.0) (Aftermarket) (Unl).sg" size="49152" crc="d31c6b3b" md5="c07672a810c23e269a65a02e3893172a" sha1="e2dbe48a9a4490857ae7d51e306f6afba5aac3fa"/>
 		<url>https://retroachievements.org/game/25011/hashes</url>
 		<hash>c07672a810c23e269a65a02e3893172a</hash>
 	</game>
-	<game name="Jet Paco and Jet Puri (Europe) (v1.0) (Aftermarket)" cloneof="Jet Paco and Jet Puri (USA) (v1.0) (Aftermarket)">
+	<game name="Jet Paco and Jet Puri (Europe) (v1.0) (Aftermarket) (Unl)" cloneof="Jet Paco and Jet Puri (USA) (v1.0) (Aftermarket) (Unl)">
 		<category>Homebrew</category>
-		<description>Jet Paco and Jet Puri (Europe) (v1.0) (Aftermarket)</description>
-		<release name="Jet Paco and Jet Puri (Europe) (v1.0) (Aftermarket)" region="Europe"/>
-		<rom name="Jet Paco and Jet Puri (Europe) (v1.0) (Aftermarket).sg" size="49152" crc="3246adab" md5="e13c66c69904b94459fa46da26aca87e" sha1="4b36acfb4faacdbcce56baf3ddba5cd8d72ce047"/>
+		<description>Jet Paco and Jet Puri (Europe) (v1.0) (Aftermarket) (Unl)</description>
+		<release name="Jet Paco and Jet Puri (Europe) (v1.0) (Aftermarket) (Unl)" region="Europe"/>
+		<rom name="Jet Paco and Jet Puri (Europe) (v1.0) (Aftermarket) (Unl).sg" size="49152" crc="3246adab" md5="e13c66c69904b94459fa46da26aca87e" sha1="4b36acfb4faacdbcce56baf3ddba5cd8d72ce047"/>
 		<url>https://retroachievements.org/game/25011/hashes</url>
 		<hash>e13c66c69904b94459fa46da26aca87e</hash>
 	</game>
 	
-	<game name="Klondike Solitaire (USA) (v1.04b) (Aftermarket)">
+	<game name="Klondike Solitaire (USA) (v1.04b) (Aftermarket) (Unl)">
 		<category>Homebrew</category>
-		<description>Klondike Solitaire (USA) (v1.04b) (Aftermarket)</description>
-		<release name="Klondike Solitaire (USA) (v1.04b) (Aftermarket)" region="USA"/>
-		<rom name="Klondike Solitaire (USA) (v1.04b) (Aftermarket).sg" size="32768" crc="5f9f8b15" md5="9ced5749ab0db9d67b5446381a0182f7" sha1="c52e3ff244bc55802b2856054fb01aba7f747620"/>
+		<description>Klondike Solitaire (USA) (v1.04b) (Aftermarket) (Unl)</description>
+		<release name="Klondike Solitaire (USA) (v1.04b) (Aftermarket) (Unl)" region="USA"/>
+		<rom name="Klondike Solitaire (USA) (v1.04b) (Aftermarket) (Unl).sg" size="32768" crc="5f9f8b15" md5="9ced5749ab0db9d67b5446381a0182f7" sha1="c52e3ff244bc55802b2856054fb01aba7f747620"/>
 		<url>https://retroachievements.org/game/25013/hashes</url>
 		<hash>9ced5749ab0db9d67b5446381a0182f7</hash>
 	</game>
 	
-	<game name="Mahjong Solitaire (World) (v1.16) (under4mhz) (Aftermarket)">
+	<game name="Mahjong Solitaire (World) (v1.16) (Aftermarket) (Unl) (under4mhz)">
 		<category>Homebrew</category>
-		<description>Mahjong Solitaire (World) (v1.16) (under4mhz) (Aftermarket)</description>
-		<release name="Mahjong Solitaire (World) (v1.16) (under4mhz) (Aftermarket)" region="World"/>
-		<rom name="Mahjong Solitaire (World) (v1.16) (under4mhz) (Aftermarket).sg" size="32768" crc="d07afa95" md5="894cb6837dc67fd4ada3be7126c1cbd4" sha1="7524486ce0fa3c7a21c5231cce35133ef2f20a57"/>
+		<description>Mahjong Solitaire (World) (v1.16) (Aftermarket) (Unl) (under4mhz)</description>
+		<release name="Mahjong Solitaire (World) (v1.16) (Aftermarket) (Unl) (under4mhz)" region="World"/>
+		<rom name="Mahjong Solitaire (World) (v1.16) (Aftermarket) (Unl) (under4mhz).sg" size="32768" crc="d07afa95" md5="894cb6837dc67fd4ada3be7126c1cbd4" sha1="7524486ce0fa3c7a21c5231cce35133ef2f20a57"/>
 		<url>https://retroachievements.org/game/25012/hashes</url>
 		<hash>894cb6837dc67fd4ada3be7126c1cbd4</hash>
 	</game>
 	
-	<game name="Palikat (USA) (v1.0) (Aftermarket)">
+	<game name="Palikat (USA) (v1.0) (Aftermarket) (Unl)">
 		<category>Homebrew</category>
-		<description>Palikat (USA) (v1.0) (Aftermarket)</description>
-		<release name="Palikat (USA) (v1.0) (Aftermarket)" region="USA"/>
-		<rom name="Palikat (USA) (v1.0) (Aftermarket).sg" size="32768" crc="ec169914" md5="a90090e446b4e86ce3cadc451530c0ad" sha1="77493202ba6e5eec599c054e96fe8f86b84b0c96"/>
+		<description>Palikat (USA) (v1.0) (Aftermarket) (Unl)</description>
+		<release name="Palikat (USA) (v1.0) (Aftermarket) (Unl)" region="USA"/>
+		<rom name="Palikat (USA) (v1.0) (Aftermarket) (Unl).sg" size="32768" crc="ec169914" md5="a90090e446b4e86ce3cadc451530c0ad" sha1="77493202ba6e5eec599c054e96fe8f86b84b0c96"/>
 		<url>https://retroachievements.org/game/25009/hashes</url>
 		<hash>a90090e446b4e86ce3cadc451530c0ad</hash>
 	</game>
 	
-	<game name="Pegged (World) (v1.02) (under4mhz) (Aftermarket)">
+	<game name="Pegged (World) (v1.02) (Aftermarket) (Unl) (under4mhz)">
 		<category>Homebrew</category>
-		<description>Pegged (World) (v1.02) (under4mhz) (Aftermarket)</description>
-		<release name="Pegged (World) (v1.02) (under4mhz) (Aftermarket)" region="World"/>
-		<rom name="Pegged (World) (v1.02) (under4mhz) (Aftermarket).sg" size="32768" crc="f6c2547d" md5="54be39abfa98f34f9cfeeeaa75aee054" sha1="c524f5f682e3b39608f4a04f4a29f80b923dce1b"/>
+		<description>Pegged (World) (v1.02) (Aftermarket) (Unl) (under4mhz)</description>
+		<release name="Pegged (World) (v1.02) (Aftermarket) (Unl) (under4mhz)" region="World"/>
+		<rom name="Pegged (World) (v1.02) (Aftermarket) (Unl) (under4mhz).sg" size="32768" crc="f6c2547d" md5="54be39abfa98f34f9cfeeeaa75aee054" sha1="c524f5f682e3b39608f4a04f4a29f80b923dce1b"/>
 		<url>https://retroachievements.org/game/25602/hashes</url>
 		<hash>54be39abfa98f34f9cfeeeaa75aee054</hash>
 	</game>
 	
-	<game name="Pitman (World) (v1.03) (under4mhz) (Aftermarket)">
+	<game name="Pitman (World) (v1.03) (Aftermarket) (Unl) (under4mhz)">
 		<category>Homebrew</category>
-		<description>Pitman (World) (v1.03) (under4mhz) (Aftermarket)</description>
-		<release name="Pitman (World) (v1.03) (under4mhz) (Aftermarket)" region="World"/>
-		<rom name="Pitman (World) (v1.03) (under4mhz) (Aftermarket).sg" size="32768" crc="e325f022" md5="f8d0df42b3143c16d3730a37ff1190b9" sha1="22b6c05f186bc87bfbeb734e8ef107d314f6825d"/>
+		<description>Pitman (World) (v1.03) (Aftermarket) (Unl) (under4mhz)</description>
+		<release name="Pitman (World) (v1.03) (Aftermarket) (Unl) (under4mhz)" region="World"/>
+		<rom name="Pitman (World) (v1.03) (Aftermarket) (Unl) (under4mhz).sg" size="32768" crc="e325f022" md5="f8d0df42b3143c16d3730a37ff1190b9" sha1="22b6c05f186bc87bfbeb734e8ef107d314f6825d"/>
 		<url>https://retroachievements.org/game/22087/hashes</url>
 		<hash>f8d0df42b3143c16d3730a37ff1190b9</hash>
 	</game>
 	
-	<game name="Snake (Rick Skrbina) (USA) (v1.0) (Aftermarket)">
+	<game name="Snake (Rick Skrbina) (USA) (v1.0) (Aftermarket) (Unl)">
 		<category>Homebrew</category>
-		<description>Snake (Rick Skrbina) (USA) (v1.0) (Aftermarket)</description>
-		<release name="Snake (Rick Skrbina) (USA) (v1.0) (Aftermarket)" region="USA"/>
-		<rom name="Snake (Rick Skrbina) (USA) (v1.0) (Aftermarket).sg" size="32768" crc="af29bba8" md5="3bec2aa3d11a1d1e9b1de9dbef6b513c" sha1="4984dbeab2f7f04bd05b1e357583e005677709d4"/>
+		<description>Snake (Rick Skrbina) (USA) (v1.0) (Aftermarket) (Unl)</description>
+		<release name="Snake (Rick Skrbina) (USA) (v1.0) (Aftermarket) (Unl)" region="USA"/>
+		<rom name="Snake (Rick Skrbina) (USA) (v1.0) (Aftermarket) (Unl).sg" size="32768" crc="af29bba8" md5="3bec2aa3d11a1d1e9b1de9dbef6b513c" sha1="4984dbeab2f7f04bd05b1e357583e005677709d4"/>
 		<url>https://retroachievements.org/game/14474/hashes</url>
 		<hash>3bec2aa3d11a1d1e9b1de9dbef6b513c</hash>
 	</game>
 	
-	<game name="Snake (under4mhz) (USA) (v1.0) (Aftermarket)">
+	<game name="Snake (under4mhz) (USA) (v1.0) (Aftermarket) (Unl)">
 		<category>Homebrew</category>
-		<description>Snake (under4mhz) (USA) (v1.0) (Aftermarket)</description>
-		<release name="Snake (under4mhz) (USA) (v1.0) (Aftermarket)" region="USA"/>
-		<rom name="Snake (under4mhz) (USA) (v1.0) (Aftermarket).sg" size="32768" crc="c885db61" md5="bb91e8818fdd78c9e6cd2b94bbe552ff" sha1="47829d776889e2f4cf48d41ce07a374d14c521a2"/>
+		<description>Snake (under4mhz) (USA) (v1.0) (Aftermarket) (Unl)</description>
+		<release name="Snake (under4mhz) (USA) (v1.0) (Aftermarket) (Unl)" region="USA"/>
+		<rom name="Snake (under4mhz) (USA) (v1.0) (Aftermarket) (Unl).sg" size="32768" crc="c885db61" md5="bb91e8818fdd78c9e6cd2b94bbe552ff" sha1="47829d776889e2f4cf48d41ce07a374d14c521a2"/>
 		<url>https://retroachievements.org/game/22345/hashes</url>
 		<hash>bb91e8818fdd78c9e6cd2b94bbe552ff</hash>
 	</game>
 	
-	<game name="Super Uwol (World) (v2016-11-19) (Mojon Twins) (Aftermarket)">
+	<game name="Super Uwol (World) (v2016-11-19) (Aftermarket) (Unl) (Mojon Twins)">
 		<category>Homebrew</category>
-		<description>Super Uwol (World) (v2016-11-19) (Mojon Twins) (Aftermarket)</description>
-		<release name="Super Uwol (World) (v2016-11-19) (Mojon Twins) (Aftermarket)" region="World"/>
-		<rom name="Super Uwol (World) (v2016-11-19) (Mojon Twins) (Aftermarket).sg" size="49152" crc="aa8ea6eb" md5="44a7e8eaf9187835f3fb6c6ddda45327" sha1="ffd3c645662d8926965d4e334f68764648db851f"/>
+		<description>Super Uwol (World) (v2016-11-19) (Aftermarket) (Unl) (Mojon Twins)</description>
+		<release name="Super Uwol (World) (v2016-11-19) (Aftermarket) (Unl) (Mojon Twins)" region="World"/>
+		<rom name="Super Uwol (World) (v2016-11-19) (Aftermarket) (Unl) (Mojon Twins).sg" size="49152" crc="aa8ea6eb" md5="44a7e8eaf9187835f3fb6c6ddda45327" sha1="ffd3c645662d8926965d4e334f68764648db851f"/>
 		<url>https://retroachievements.org/game/19716/hashes</url>
 		<hash>44a7e8eaf9187835f3fb6c6ddda45327</hash>
 	</game>
 	
-	<game name="Vexed (World) (v1.03) (Aftermarket)">
+	<game name="Vexed (World) (v1.03) (Aftermarket) (Unl)">
 		<category>Homebrew</category>
-		<description>Vexed (World) (v1.03) (Aftermarket)</description>
-		<release name="Vexed (World) (v1.03) (Aftermarket)" region="World"/>
-		<rom name="Vexed (World) (v1.03) (Aftermarket).sg" size="32768" crc="6159a842" md5="7cd478e059987105eaf4f2780be137c9" sha1="aff1f34dab6f92685348d850db28048c43760a6a"/>
+		<description>Vexed (World) (v1.03) (Aftermarket) (Unl)</description>
+		<release name="Vexed (World) (v1.03) (Aftermarket) (Unl)" region="World"/>
+		<rom name="Vexed (World) (v1.03) (Aftermarket) (Unl).sg" size="32768" crc="6159a842" md5="7cd478e059987105eaf4f2780be137c9" sha1="aff1f34dab6f92685348d850db28048c43760a6a"/>
 		<url>https://retroachievements.org/game/22072/hashes</url>
 		<hash>7cd478e059987105eaf4f2780be137c9</hash>
 	</game>
@@ -179,6 +179,15 @@
 		<rom name="Cabbage Patch Kids (Taiwan) (Unl).sg" size="32768" crc="9d91ab78" md5="1c2c5851deb0e9142b5ff19e8dcd8442" sha1="5c011f37f4fcbaa72167293a9917bb6af0e30b55"/>
 		<url>https://retroachievements.org/game/24311/hashes</url>
 		<hash>1c2c5851deb0e9142b5ff19e8dcd8442</hash>
+	</game>
+	
+	<game name="King's Valley (Taiwan) (Unl)">
+		<category>Unlicensed</category>
+		<description>King's Valley (Taiwan) (Unl)</description>
+		<release name="King's Valley (Taiwan) (Unl)" region="Taiwan"/>
+		<rom name="King's Valley (Taiwan) (Unl).sg" size="32768" crc="223397A1" md5="ff28e684eb3952ae3f7cf3e3d1c507ef" sha1="922d23895c12707b2fc382ea5cb769c5cb9b5755"/>
+		<url>https://retroachievements.org/game/24546/hashes</url>
+		<hash>ff28e684eb3952ae3f7cf3e3d1c507ef</hash>
 	</game>
 	
 	<game name="Knightmare (Taiwan) (Unl)">
@@ -302,11 +311,11 @@
 		<hash>25c742e43bc9f1329f3f26502fefb10a</hash>
 	</game>
 	
-	<game name="C So! (Japan)">
+	<game name="C_So! (Japan)">
 		<category>Retail</category>
-		<description>C So! (Japan)</description>
-		<release name="C So! (Japan)" region="Japan"/>
-		<rom name="C So! (Japan).sg" size="32768" crc="be7ed0eb" md5="d87daad7de33105d703b613052ccc2dd" sha1="d45a230b3cbf2d2dcfe7b94691fc7f1a5d747625"/>
+		<description>C_So! (Japan)</description>
+		<release name="C_So! (Japan)" region="Japan"/>
+		<rom name="C_So! (Japan).sg" size="32768" crc="be7ed0eb" md5="d87daad7de33105d703b613052ccc2dd" sha1="d45a230b3cbf2d2dcfe7b94691fc7f1a5d747625"/>
 		<url>https://retroachievements.org/game/24528/hashes</url>
 		<hash>d87daad7de33105d703b613052ccc2dd</hash>
 	</game>

--- a/DATs/RetroAchievements (No Subfolders)/RA - Uzebox.dat
+++ b/DATs/RetroAchievements (No Subfolders)/RA - Uzebox.dat
@@ -5,42 +5,42 @@
 		<name>RA - Uzebox</name>
 		<description>Uzebox</description>
 		<category>No Subfolders</category>
-		<version>20260208</version>
-		<date>08 February 2026</date>
+		<version>20260428</version>
+		<date>28 April 2026</date>
 		<author>AzgoRAth, NeoRetroGamer (Contributor), Jumphil (Contributor)</author>
 		<homepage>https://retroachievements.org</homepage>
 		<url>https://retroachievements.org/system/80/games</url>
-		<titlecount>41</titlecount>
-		<hashcount>41</hashcount>
+		<titlecount>45</titlecount>
+		<hashcount>45</hashcount>
 	</header>
-	<game name="Megatris (Arcade Edition) (World) (v1.03) (clymax) (Hack)">
+	<game name="Megatris - Arcade Edition (World) (v1.03) (clymax)">
 		<category>Hack</category>
-		<description>Megatris (Arcade Edition) (World) (v1.03) (clymax) (Hack)</description>
-		<rom name="Megatris (Arcade Edition) (World) (v1.03) (clymax) (Hack).uze" size="59296" crc="a61161dc" md5="4cf318df04117de0067e876db7faaf5b" sha1="67684e18092c86d75c6d9f0a80a1e1e19743b4e8"/>
+		<description>Megatris - Arcade Edition (World) (v1.03) (clymax)</description>
+		<rom name="Megatris - Arcade Edition (World) (v1.03) (clymax).uze" size="59296" crc="a61161dc" md5="4cf318df04117de0067e876db7faaf5b" sha1="67684e18092c86d75c6d9f0a80a1e1e19743b4e8"/>
 		<url>https://retroachievements.org/game/24755/hashes</url>
 		<hash>4cf318df04117de0067e876db7faaf5b</hash>
 	</game>
 	
-	<game name="Megatris (Arcade Edition) (World) (v1.03) (clymax) (Hack) (Subset - Bonus)">
+	<game name="Megatris - Arcade Edition (World) (v1.03-Bonus) (clymax)">
 		<category>Subset</category>
-		<description>Megatris (Arcade Edition) (World) (v1.03) (clymax) (Hack) (Subset - Bonus)</description>
-		<rom name="Megatris (Arcade Edition) (World) (v1.03) (clymax) (Hack) (Subset - Bonus).uze" size="59296" crc="57b9284c" md5="8e765bd046b2dee4e6876eb043d6a532" sha1="74971496fafd62139df3969c9c26c2331c18f993"/>
+		<description>Megatris - Arcade Edition (World) (v1.03-Bonus) (clymax)</description>
+		<rom name="Megatris - Arcade Edition (World) (v1.03-Bonus) (clymax).uze" size="59296" crc="57b9284c" md5="8e765bd046b2dee4e6876eb043d6a532" sha1="74971496fafd62139df3969c9c26c2331c18f993"/>
 		<url>https://retroachievements.org/game/28806/hashes</url>
 		<hash>8e765bd046b2dee4e6876eb043d6a532</hash>
 	</game>
 	
-	<game name="Space Age (World) (Pitfall Jones) - Director's Cut (v1.01) (clymax) (Hack)">
+	<game name="Space Age (World) (Pitfall Jones) - Director's Cut (v1.01) (clymax)">
 		<category>Hack</category>
-		<description>Space Age (World) (Pitfall Jones) - Director's Cut (v1.01) (clymax) (Hack)</description>
-		<rom name="Space Age (World) (Pitfall Jones) - Director's Cut (v1.01) (clymax) (Hack).uze" size="56668" crc="ecf33e30" md5="b899ca234f713f920cde11a01fd857d0" sha1="a12a30e239ca210a3a74936772de512afc6003d4"/>
+		<description>Space Age (World) (Pitfall Jones) - Director's Cut (v1.01) (clymax)</description>
+		<rom name="Space Age (World) (Pitfall Jones) - Director's Cut (v1.01) (clymax).uze" size="56668" crc="ecf33e30" md5="b899ca234f713f920cde11a01fd857d0" sha1="a12a30e239ca210a3a74936772de512afc6003d4"/>
 		<url>https://retroachievements.org/game/28940/hashes</url>
 		<hash>b899ca234f713f920cde11a01fd857d0</hash>
 	</game>
 	
-	<game name="UzeMaze - UzeMaze RA (World) (pinguupinguu) (Hack)">
+	<game name="UzeMaze - UzeMaze RA (pinguupinguu)">
 		<category>Hack</category>
-		<description>UzeMaze - UzeMaze RA (World) (pinguupinguu) (Hack)</description>
-		<rom name="UzeMaze - UzeMaze RA (World) (pinguupinguu) (Hack).uze" size="19604" crc="d7094b70" md5="ae053a9a71680a22a59518544ab7c70b" sha1="80d57ad82286e193cf0ea89ff9242ae9054a3545"/>
+		<description>UzeMaze - UzeMaze RA (pinguupinguu)</description>
+		<rom name="UzeMaze - UzeMaze RA (pinguupinguu).uze" size="19604" crc="d7094b70" md5="ae053a9a71680a22a59518544ab7c70b" sha1="80d57ad82286e193cf0ea89ff9242ae9054a3545"/>
 		<url>https://retroachievements.org/game/25084/hashes</url>
 		<hash>ae053a9a71680a22a59518544ab7c70b</hash>
 	</game>
@@ -93,10 +93,10 @@
 		<hash>b62117e7c6448e266ce9f7f8d46def5a</hash>
 	</game>
 	
-	<game name="Chickens In Choppers (World) (CunningFellow)">
+	<game name="Chicken in Choppers (World) (CunningFellow)">
 		<category>Retail</category>
-		<description>Chickens In Choppers (World) (CunningFellow)</description>
-		<rom name="Chickens In Choppers (World) (CunningFellow).uze" size="61952" crc="dbbaa9ea" md5="d781bdc469c322270bb7b6f177435e8a" sha1="e9ae022e3a1daa3f51b80f5373ca03435995f233"/>
+		<description>Chicken in Choppers (World) (CunningFellow)</description>
+		<rom name="Chicken in Choppers (World) (CunningFellow).uze" size="61952" crc="dbbaa9ea" md5="d781bdc469c322270bb7b6f177435e8a" sha1="e9ae022e3a1daa3f51b80f5373ca03435995f233"/>
 		<url>https://retroachievements.org/game/24725/hashes</url>
 		<hash>d781bdc469c322270bb7b6f177435e8a</hash>
 	</game>
@@ -195,6 +195,14 @@
 		<rom name="Joyrider (World) (jhhoward).uze" size="59310" crc="18820af6" md5="7f353ceb0bb15f87917355cf62a3c909" sha1="602c649b52dc784e1db0df2f023c4820f9dcf63d"/>
 		<url>https://retroachievements.org/game/24744/hashes</url>
 		<hash>7f353ceb0bb15f87917355cf62a3c909</hash>
+	</game>
+	
+	<game name="Lander (World) (Harty123)">
+		<category>Retail</category>
+		<description>Lander (World) (Harty123)</description>
+		<rom name="Lander (World) (Harty123).uze" size="48246" crc="53d00c16" md5="187bc5fd6d073047cf0f06df8d5465bc" sha1="607ee737870fb13820771532d1b5b0a4c31c6cb3"/>
+		<url>https://retroachievements.org/game/24745/hashes</url>
+		<hash>187bc5fd6d073047cf0f06df8d5465bc</hash>
 	</game>
 	
 	<game name="Laser Puzzle (World) (Artcfox)">

--- a/DATs/RetroAchievements (No Subfolders)/RA - WASM-4.dat
+++ b/DATs/RetroAchievements (No Subfolders)/RA - WASM-4.dat
@@ -5,13 +5,13 @@
 		<name>RA - WASM-4</name>
 		<description>WASM-4</description>
 		<category>No Subfolders</category>
-		<version>20251225</version>
-		<date>25 December 2025</date>
+		<version>20260428</version>
+		<date>28 April 2026</date>
 		<author>AzgoRAth, NeoRetroGamer (Contributor), Jumphil (Contributor)</author>
 		<homepage>https://retroachievements.org</homepage>
 		<url>https://retroachievements.org/system/72/games</url>
-		<titlecount>60</titlecount>
-		<hashcount>64</hashcount>
+		<titlecount>64</titlecount>
+		<hashcount>69</hashcount>
 	</header>
 	<game name="2048 (World) (Peter Hellberg)">
 		<category>Retail</category>
@@ -121,6 +121,15 @@
 		<hash>892b0811bb4c21ad276f97ab8895de4f</hash>
 	</game>
 	
+	<game name="Floppy Fish (World) (Chris Breece) (RA Compatibility) (PS2Hagrid)">
+		<category>Retail</category>
+		<description>Floppy Fish (World) (Chris Breece) (RA Compatibility) (PS2Hagrid)</description>
+		<release name="Floppy Fish (World) (Chris Breece) (RA Compatibility) (PS2Hagrid)" region="World"/>
+		<rom name="Floppy Fish (World) (Chris Breece) (RA Compatibility) (PS2Hagrid).wasm" size="15219" crc="0476ce67" md5="a9493e58653da70d06e229355db94ce5" sha1="8de0315a6ad332a6835dc657c1854f679fa29268"/>
+		<url>https://retroachievements.org/game/27641/hashes</url>
+		<hash>a9493e58653da70d06e229355db94ce5</hash>
+	</game>
+	
 	<game name="Formula 1 (World) (Davy Willems)">
 		<category>Retail</category>
 		<description>Formula 1 (World) (Davy Willems)</description>
@@ -155,6 +164,15 @@
 		<rom name="GALDR (World) (jonathand).wasm" size="46169" crc="f6a9a241" md5="00e3c7577b124f20dbf667e5c2bc3d11" sha1="95b6fe1a3e2c1ca01be294f5ecc2b9011f4cfe08"/>
 		<url>https://retroachievements.org/game/27651/hashes</url>
 		<hash>00e3c7577b124f20dbf667e5c2bc3d11</hash>
+	</game>
+	
+	<game name="Glitch Dungeon (World) (Wormi)">
+		<category>Retail</category>
+		<description>Glitch Dungeon (World) (Wormi)</description>
+		<release name="Glitch Dungeon (World) (Wormi)" region="World"/>
+		<rom name="Glitch Dungeon (World) (Wormi).wasm" size="62135" crc="551dd101" md5="3340d9ca43ad3c11f4e6732f084e299b" sha1="7729764f196dd25de49e5b855280d116e16af8b3"/>
+		<url>https://retroachievements.org/game/37988/hashes</url>
+		<hash>3340d9ca43ad3c11f4e6732f084e299b</hash>
 	</game>
 	
 	<game name="Hammer Joe (World) (Proto) (MFauzan26)">
@@ -279,11 +297,11 @@
 		<hash>d7b509d435d9699f12744e615254a2c4</hash>
 	</game>
 	
-	<game name="Ninja vs Knights (World) (v1.0.1) (Mr.Rafael)">
+	<game name="Ninja vs Knights (World) (v1.0.1) (World) (Mr.Rafael)">
 		<category>Retail</category>
-		<description>Ninja vs Knights (World) (v1.0.1) (Mr.Rafael)</description>
-		<release name="Ninja vs Knights (World) (v1.0.1) (Mr.Rafael)" region="World"/>
-		<rom name="Ninja vs Knights (World) (v1.0.1) (Mr.Rafael).wasm" size="59424" crc="9de9b738" md5="5921f8b9bb63024bd3145172806d2498" sha1="8a6e1b3375415f09874e149b20891603b31f4701"/>
+		<description>Ninja vs Knights (World) (v1.0.1) (World) (Mr.Rafael)</description>
+		<release name="Ninja vs Knights (World) (v1.0.1) (World) (Mr.Rafael)" region="World"/>
+		<rom name="Ninja vs Knights (World) (v1.0.1) (World) (Mr.Rafael).wasm" size="59424" crc="9de9b738" md5="5921f8b9bb63024bd3145172806d2498" sha1="8a6e1b3375415f09874e149b20891603b31f4701"/>
 		<url>https://retroachievements.org/game/21393/hashes</url>
 		<hash>5921f8b9bb63024bd3145172806d2498</hash>
 	</game>
@@ -324,11 +342,11 @@
 		<hash>973c5e969ba18229376ebe6e8420fe56</hash>
 	</game>
 	
-	<game name="Plctfarmer (World) (Proto) (pfg)">
+	<game name="Plctformer (World) (Proto) (pfg)">
 		<category>Retail</category>
-		<description>Plctfarmer (World) (Proto) (pfg)</description>
-		<release name="Plctfarmer (World) (Proto) (pfg)" region="World"/>
-		<rom name="Plctfarmer (World) (Proto) (pfg).wasm" size="55938" crc="9b7d48bb" md5="9280d1d157f0eb4eeda9e1dacedcf4b6" sha1="a81b96e2048040d3926fef00c8d5b1b42c609df6"/>
+		<description>Plctformer (World) (Proto) (pfg)</description>
+		<release name="Plctformer (World) (Proto) (pfg)" region="World"/>
+		<rom name="Plctformer (World) (Proto) (pfg).wasm" size="55938" crc="9b7d48bb" md5="9280d1d157f0eb4eeda9e1dacedcf4b6" sha1="a81b96e2048040d3926fef00c8d5b1b42c609df6"/>
 		<url>https://retroachievements.org/game/19309/hashes</url>
 		<hash>9280d1d157f0eb4eeda9e1dacedcf4b6</hash>
 	</game>
@@ -351,11 +369,11 @@
 		<hash>b5653249e28bd05cbb28d7483de29ab3</hash>
 	</game>
 	
-	<game name="Punch-Em-Up (World) (Louis Pearson)">
+	<game name="Punch'Em Up (World) (Louis Pearson)">
 		<category>Retail</category>
-		<description>Punch-Em-Up (World) (Louis Pearson)</description>
-		<release name="Punch-Em-Up (World) (Louis Pearson)" region="World"/>
-		<rom name="Punch-Em-Up (World) (Louis Pearson).wasm" size="34671" crc="3b73f50d" md5="053d4b372253533561f51573564472af" sha1="1c51036909740344221b877350d5740eb467fe51"/>
+		<description>Punch'Em Up (World) (Louis Pearson)</description>
+		<release name="Punch'Em Up (World) (Louis Pearson)" region="World"/>
+		<rom name="Punch'Em Up (World) (Louis Pearson).wasm" size="34671" crc="3b73f50d" md5="053d4b372253533561f51573564472af" sha1="1c51036909740344221b877350d5740eb467fe51"/>
 		<url>https://retroachievements.org/game/25680/hashes</url>
 		<hash>053d4b372253533561f51573564472af</hash>
 	</game>
@@ -592,15 +610,15 @@
 		<hash>8df88405a112173638e7d6f0d95fb67a</hash>
 	</game>
 	
-	<game name="ZxZ (World) (Rev 1)">
+	<game name="ZxZ (World) (Rev 1) (Scislaw Dercz)">
 		<category>Retail</category>
-		<description>ZxZ (World) (Rev 1)</description>
-		<release name="ZxZ (World) (Rev 1)" region="World"/>
-		<rom name="ZxZ (World) (Rev 1).wasm" size="18711" crc="e3cbe9f4" md5="88f0a50bf711bdc9fae8f1ee91395cb1" sha1="5cc971fa63389d51131eb2c094f4481e39082169"/>
+		<description>ZxZ (World) (Rev 1) (Scislaw Dercz)</description>
+		<release name="ZxZ (World) (Rev 1) (Scislaw Dercz)" region="World"/>
+		<rom name="ZxZ (World) (Rev 1) (Scislaw Dercz).wasm" size="18711" crc="e3cbe9f4" md5="88f0a50bf711bdc9fae8f1ee91395cb1" sha1="5cc971fa63389d51131eb2c094f4481e39082169"/>
 		<url>https://retroachievements.org/game/19298/hashes</url>
 		<hash>88f0a50bf711bdc9fae8f1ee91395cb1</hash>
 	</game>
-	<game name="ZxZ (World) (Scislaw Dercz)" cloneof="ZxZ (World) (Rev 1)">
+	<game name="ZxZ (World) (Scislaw Dercz)" cloneof="ZxZ (World) (Rev 1) (Scislaw Dercz)">
 		<category>Retail</category>
 		<description>ZxZ (World) (Scislaw Dercz)</description>
 		<rom name="ZxZ (World) (Scislaw Dercz).wasm" size="18701" crc="b787b38c" md5="9967ddb877ad4d0332e129a1db67beee" sha1="9e994d8223bdb1a50e82a343ef7f7b8abd5a9955"/>

--- a/DATs/RetroAchievements (No Subfolders)/RA - Watara Supervision.dat
+++ b/DATs/RetroAchievements (No Subfolders)/RA - Watara Supervision.dat
@@ -5,109 +5,109 @@
 		<name>RA - Watara Supervision</name>
 		<description>Watara Supervision</description>
 		<category>No Subfolders</category>
-		<version>20251225</version>
-		<date>25 December 2025</date>
+		<version>20260428</version>
+		<date>28 April 2026</date>
 		<author>AzgoRAth, NeoRetroGamer (Contributor), Jumphil (Contributor)</author>
 		<homepage>https://retroachievements.org</homepage>
 		<url>https://retroachievements.org/system/63/games</url>
 		<titlecount>75</titlecount>
-		<hashcount>81</hashcount>
+		<hashcount>82</hashcount>
 	</header>
-	<game name="AntiAir Mini (World) (v20240422) (Inufuto) (Aftermarket)">
+	<game name="AntiAir Mini (World) (v20240422) (Aftermarket) (Inufuto)">
 		<category>Homebrew</category>
-		<description>AntiAir Mini (World) (v20240422) (Inufuto) (Aftermarket)</description>
-		<release name="AntiAir Mini (World) (v20240422) (Inufuto) (Aftermarket)" region="World"/>
-		<rom name="AntiAir Mini (World) (v20240422) (Inufuto) (Aftermarket).sv" size="16384" crc="b10634c0" md5="8b5071a6648aecbf86fe6e44a5a2e3c7" sha1="e9c3e4763ca6a80ddfff9c26c7c2012667d889bd"/>
+		<description>AntiAir Mini (World) (v20240422) (Aftermarket) (Inufuto)</description>
+		<release name="AntiAir Mini (World) (v20240422) (Aftermarket) (Inufuto)" region="World"/>
+		<rom name="AntiAir Mini (World) (v20240422) (Aftermarket) (Inufuto).sv" size="16384" crc="b10634c0" md5="8b5071a6648aecbf86fe6e44a5a2e3c7" sha1="e9c3e4763ca6a80ddfff9c26c7c2012667d889bd"/>
 		<url>https://retroachievements.org/game/33069/hashes</url>
 		<hash>8b5071a6648aecbf86fe6e44a5a2e3c7</hash>
 	</game>
 	
-	<game name="Assembloids (World) (Aftermarket)">
+	<game name="Assembloids (World) (Digital) (Aftermarket) (Unl)">
 		<category>Homebrew</category>
-		<description>Assembloids (World) (Aftermarket)</description>
-		<release name="Assembloids (World) (Aftermarket)" region="World"/>
-		<rom name="Assembloids (World) (Aftermarket).sv" size="65536" crc="c71131e4" md5="6dd574473abfe47583c81a2fe33d3d02" sha1="79831275a6a30064d400b21c7eff709403ebcecc"/>
+		<description>Assembloids (World) (Digital) (Aftermarket) (Unl)</description>
+		<release name="Assembloids (World) (Digital) (Aftermarket) (Unl)" region="World"/>
+		<rom name="Assembloids (World) (Digital) (Aftermarket) (Unl).sv" size="65536" crc="c71131e4" md5="6dd574473abfe47583c81a2fe33d3d02" sha1="79831275a6a30064d400b21c7eff709403ebcecc"/>
 		<url>https://retroachievements.org/game/17660/hashes</url>
 		<hash>6dd574473abfe47583c81a2fe33d3d02</hash>
 	</game>
 	
-	<game name="Cross Bomber (World) (Aftermarket)">
+	<game name="Cross Bomber (World) (Aftermarket) (Unl)">
 		<category>Homebrew</category>
-		<description>Cross Bomber (World) (Aftermarket)</description>
-		<release name="Cross Bomber (World) (Aftermarket)" region="World"/>
-		<rom name="Cross Bomber (World) (Aftermarket).sv" size="32768" crc="5fac2aa3" md5="7a905b02571bfd0a7fdbb03b0637af4f" sha1="d579049862297d05ad8fbf318cf21f5423ed9b64"/>
+		<description>Cross Bomber (World) (Aftermarket) (Unl)</description>
+		<release name="Cross Bomber (World) (Aftermarket) (Unl)" region="World"/>
+		<rom name="Cross Bomber (World) (Aftermarket) (Unl).sv" size="32768" crc="5fac2aa3" md5="7a905b02571bfd0a7fdbb03b0637af4f" sha1="d579049862297d05ad8fbf318cf21f5423ed9b64"/>
 		<url>https://retroachievements.org/game/23775/hashes</url>
 		<hash>7a905b02571bfd0a7fdbb03b0637af4f</hash>
 	</game>
 	
-	<game name="Cross Chase (World) (Aftermarket)">
+	<game name="Cross Chase (World) (Aftermarket) (Unl)">
 		<category>Homebrew</category>
-		<description>Cross Chase (World) (Aftermarket)</description>
-		<release name="Cross Chase (World) (Aftermarket)" region="World"/>
-		<rom name="Cross Chase (World) (Aftermarket).sv" size="32768" crc="346a7bba" md5="c077ce97c8d134230a68006ccc788b60" sha1="6564e4644e66005d8fb9fe23018b514503e0c869"/>
+		<description>Cross Chase (World) (Aftermarket) (Unl)</description>
+		<release name="Cross Chase (World) (Aftermarket) (Unl)" region="World"/>
+		<rom name="Cross Chase (World) (Aftermarket) (Unl).sv" size="32768" crc="346a7bba" md5="c077ce97c8d134230a68006ccc788b60" sha1="6564e4644e66005d8fb9fe23018b514503e0c869"/>
 		<url>https://retroachievements.org/game/23771/hashes</url>
 		<hash>c077ce97c8d134230a68006ccc788b60</hash>
 	</game>
 	
-	<game name="Cross Horde (World) (Aftermarket)">
+	<game name="Cross Horde (World) (Aftermarket) (Unl)">
 		<category>Homebrew</category>
-		<description>Cross Horde (World) (Aftermarket)</description>
-		<release name="Cross Horde (World) (Aftermarket)" region="World"/>
-		<rom name="Cross Horde (World) (Aftermarket).sv" size="32768" crc="7885ce58" md5="4048c11b1be067483fa948724fbb9869" sha1="a09c3c83ea7e8f610611be852a4f51262d94e280"/>
+		<description>Cross Horde (World) (Aftermarket) (Unl)</description>
+		<release name="Cross Horde (World) (Aftermarket) (Unl)" region="World"/>
+		<rom name="Cross Horde (World) (Aftermarket) (Unl).sv" size="32768" crc="7885ce58" md5="4048c11b1be067483fa948724fbb9869" sha1="a09c3c83ea7e8f610611be852a4f51262d94e280"/>
 		<url>https://retroachievements.org/game/23770/hashes</url>
 		<hash>4048c11b1be067483fa948724fbb9869</hash>
 	</game>
 	
-	<game name="Cross Shoot (World) (Aftermarket)">
+	<game name="Cross Shoot (World) (Aftermarket) (Unl)">
 		<category>Homebrew</category>
-		<description>Cross Shoot (World) (Aftermarket)</description>
-		<release name="Cross Shoot (World) (Aftermarket)" region="World"/>
-		<rom name="Cross Shoot (World) (Aftermarket).sv" size="32768" crc="017f75af" md5="19b3812f3a3ffbf3eff501521078c5a2" sha1="8b734d620eb8d28f4ab932fe686fc884b9299910"/>
+		<description>Cross Shoot (World) (Aftermarket) (Unl)</description>
+		<release name="Cross Shoot (World) (Aftermarket) (Unl)" region="World"/>
+		<rom name="Cross Shoot (World) (Aftermarket) (Unl).sv" size="32768" crc="017f75af" md5="19b3812f3a3ffbf3eff501521078c5a2" sha1="8b734d620eb8d28f4ab932fe686fc884b9299910"/>
 		<url>https://retroachievements.org/game/23772/hashes</url>
 		<hash>19b3812f3a3ffbf3eff501521078c5a2</hash>
 	</game>
 	
-	<game name="Cross Shuriken (World) (Aftermarket)">
+	<game name="Cross Shuriken (World) (Aftermarket) (Unl)">
 		<category>Homebrew</category>
-		<description>Cross Shuriken (World) (Aftermarket)</description>
-		<release name="Cross Shuriken (World) (Aftermarket)" region="World"/>
-		<rom name="Cross Shuriken (World) (Aftermarket).sv" size="32768" crc="36a6a62b" md5="6f4938e6ea4b8e62479a0081c4ab3ab5" sha1="c244b0075a81e1175e359f5e7bf56d8f26269a1b"/>
+		<description>Cross Shuriken (World) (Aftermarket) (Unl)</description>
+		<release name="Cross Shuriken (World) (Aftermarket) (Unl)" region="World"/>
+		<rom name="Cross Shuriken (World) (Aftermarket) (Unl).sv" size="32768" crc="36a6a62b" md5="6f4938e6ea4b8e62479a0081c4ab3ab5" sha1="c244b0075a81e1175e359f5e7bf56d8f26269a1b"/>
 		<url>https://retroachievements.org/game/29755/hashes</url>
 		<hash>6f4938e6ea4b8e62479a0081c4ab3ab5</hash>
 	</game>
 	
-	<game name="Cross Snake (World) (Aftermarket)">
+	<game name="Cross Snake (World) (Aftermarket) (Unl)">
 		<category>Homebrew</category>
-		<description>Cross Snake (World) (Aftermarket)</description>
-		<release name="Cross Snake (World) (Aftermarket)" region="World"/>
-		<rom name="Cross Snake (World) (Aftermarket).sv" size="32768" crc="24b141f7" md5="a7055f5cd9a3101e26ce62dd022c3635" sha1="50d811b555e4471765121a36173f4356d971363a"/>
+		<description>Cross Snake (World) (Aftermarket) (Unl)</description>
+		<release name="Cross Snake (World) (Aftermarket) (Unl)" region="World"/>
+		<rom name="Cross Snake (World) (Aftermarket) (Unl).sv" size="32768" crc="24b141f7" md5="a7055f5cd9a3101e26ce62dd022c3635" sha1="50d811b555e4471765121a36173f4356d971363a"/>
 		<url>https://retroachievements.org/game/23773/hashes</url>
 		<hash>a7055f5cd9a3101e26ce62dd022c3635</hash>
 	</game>
 	
-	<game name="Cross Stinger (World) (Aftermarket)">
+	<game name="Cross Stinger (World) (Aftermarket) (Unl)">
 		<category>Homebrew</category>
-		<description>Cross Stinger (World) (Aftermarket)</description>
-		<release name="Cross Stinger (World) (Aftermarket)" region="World"/>
-		<rom name="Cross Stinger (World) (Aftermarket).sv" size="32768" crc="b79492ae" md5="6cfe4c52ddc5afca426889a210eb1e99" sha1="93dffde8ccd6c13e7cbb8a1c5ea830b07980ab52"/>
+		<description>Cross Stinger (World) (Aftermarket) (Unl)</description>
+		<release name="Cross Stinger (World) (Aftermarket) (Unl)" region="World"/>
+		<rom name="Cross Stinger (World) (Aftermarket) (Unl).sv" size="32768" crc="b79492ae" md5="6cfe4c52ddc5afca426889a210eb1e99" sha1="93dffde8ccd6c13e7cbb8a1c5ea830b07980ab52"/>
 		<url>https://retroachievements.org/game/29756/hashes</url>
 		<hash>6cfe4c52ddc5afca426889a210eb1e99</hash>
 	</game>
 	
-	<game name="Cross Verbix (World) (Aftermarket)">
+	<game name="Cross Verbix (World) (Aftermarket) (Unl)">
 		<category>Homebrew</category>
-		<description>Cross Verbix (World) (Aftermarket)</description>
-		<release name="Cross Verbix (World) (Aftermarket)" region="World"/>
-		<rom name="Cross Verbix (World) (Aftermarket).sv" size="32768" crc="2606a717" md5="a989076fdf62db8e63b5604d579a1e72" sha1="0aa4e96ea1c6c76a7f6639adbc4d1ef7e5e1303f"/>
+		<description>Cross Verbix (World) (Aftermarket) (Unl)</description>
+		<release name="Cross Verbix (World) (Aftermarket) (Unl)" region="World"/>
+		<rom name="Cross Verbix (World) (Aftermarket) (Unl).sv" size="32768" crc="2606a717" md5="a989076fdf62db8e63b5604d579a1e72" sha1="0aa4e96ea1c6c76a7f6639adbc4d1ef7e5e1303f"/>
 		<url>https://retroachievements.org/game/23774/hashes</url>
 		<hash>a989076fdf62db8e63b5604d579a1e72</hash>
 	</game>
 	
-	<game name="Mazy Mini (World) (v20240311) (Inufuto) (Aftermarket)">
+	<game name="Mazy Mini (World) (v20240311) (Aftermarket) (Inufuto)">
 		<category>Homebrew</category>
-		<description>Mazy Mini (World) (v20240311) (Inufuto) (Aftermarket)</description>
-		<release name="Mazy Mini (World) (v20240311) (Inufuto) (Aftermarket)" region="World"/>
-		<rom name="Mazy Mini (World) (v20240311) (Inufuto) (Aftermarket).sv" size="16384" crc="0d236cba" md5="646dfa79b64831f3b32b8b7b4b209ac4" sha1="3806f6b6ac4307e9362632f74c7d7280d40028bf"/>
+		<description>Mazy Mini (World) (v20240311) (Aftermarket) (Inufuto)</description>
+		<release name="Mazy Mini (World) (v20240311) (Aftermarket) (Inufuto)" region="World"/>
+		<rom name="Mazy Mini (World) (v20240311) (Aftermarket) (Inufuto).sv" size="16384" crc="0d236cba" md5="646dfa79b64831f3b32b8b7b4b209ac4" sha1="3806f6b6ac4307e9362632f74c7d7280d40028bf"/>
 		<url>https://retroachievements.org/game/31767/hashes</url>
 		<hash>646dfa79b64831f3b32b8b7b4b209ac4</hash>
 	</game>
@@ -602,6 +602,13 @@
 		<hash>504d378933cb037f9d047279306ed520</hash>
 	</game>
 	
+	<game name="Police Bust (USA, Europe)" cloneof="Police Bust (USA, Europe) (Level 11 Fix) (PixieGlow)">
+		<category>Retail</category>
+		<description>Police Bust (USA, Europe)</description>
+		<rom name="Police Bust (USA, Europe).sv" size="65536" crc="531f0b51" md5="427488cb0f3251a46e923f9e8608ff80" sha1="9fa06b4d171d9ade2f9e4a639e80feba15c963f9"/>
+		<url>https://retroachievements.org/game/17621/hashes</url>
+		<hash>427488cb0f3251a46e923f9e8608ff80</hash>
+	</game>
 	<game name="Police Bust (USA, Europe) (Level 11 Fix) (PixieGlow)">
 		<category>Retail</category>
 		<description>Police Bust (USA, Europe) (Level 11 Fix) (PixieGlow)</description>
@@ -610,13 +617,6 @@
 		<rom name="Police Bust (USA, Europe) (Level 11 Fix) (PixieGlow).sv" size="65536" crc="a37ae594" md5="3abc347ec03fe567dacfb851bec308f8" sha1="da89b0143886d5c78429eec47138336a2750b7fe"/>
 		<url>https://retroachievements.org/game/17621/hashes</url>
 		<hash>3abc347ec03fe567dacfb851bec308f8</hash>
-	</game>
-	<game name="Police Bust (USA, Europe)" cloneof="Police Bust (USA, Europe) (Level 11 Fix) (PixieGlow)">
-		<category>Retail</category>
-		<description>Police Bust (USA, Europe)</description>
-		<rom name="Police Bust (USA, Europe).sv" size="65536" crc="531f0b51" md5="427488cb0f3251a46e923f9e8608ff80" sha1="9fa06b4d171d9ade2f9e4a639e80feba15c963f9"/>
-		<url>https://retroachievements.org/game/17621/hashes</url>
-		<hash>427488cb0f3251a46e923f9e8608ff80</hash>
 	</game>
 	
 	<game name="Popo Team (USA, Europe)">
@@ -649,21 +649,21 @@
 		<hash>0a07c444324d0b41546e2363679360da</hash>
 	</game>
 	
-	<game name="Scaffolder (USA, Europe) (Level Fix by Hotscrock)">
-		<category>Retail</category>
-		<description>Scaffolder (USA, Europe) (Level Fix by Hotscrock)</description>
-		<release name="Scaffolder (USA, Europe) (Level Fix by Hotscrock)" region="Europe"/>
-		<release name="Scaffolder (USA, Europe) (Level Fix by Hotscrock)" region="USA"/>
-		<rom name="Scaffolder (USA, Europe) (Level Fix by Hotscrock).sv" size="65536" crc="4d5f6666" md5="7816deddb48c44df99c6bb3535c1dc88" sha1="88bddc446c3e761750b1ec9736cf47d7e1830f8c"/>
-		<url>https://retroachievements.org/game/17599/hashes</url>
-		<hash>7816deddb48c44df99c6bb3535c1dc88</hash>
-	</game>
-	<game name="Scaffolder (USA, Europe)" cloneof="Scaffolder (USA, Europe) (Level Fix by Hotscrock)">
+	<game name="Scaffolder (USA, Europe)" cloneof="Scaffolder (USA, Europe) (Level Fix) (Hotscrock)">
 		<category>Retail</category>
 		<description>Scaffolder (USA, Europe)</description>
 		<rom name="Scaffolder (USA, Europe).sv" size="65536" crc="46fb22c5" md5="c07638809b49f2c922c4d4d7519e6f9c" sha1="4fd487ce62c8b7a6f3d4000fcd72f2a269d32fc2"/>
 		<url>https://retroachievements.org/game/17599/hashes</url>
 		<hash>c07638809b49f2c922c4d4d7519e6f9c</hash>
+	</game>
+	<game name="Scaffolder (USA, Europe) (Level Fix) (Hotscrock)">
+		<category>Retail</category>
+		<description>Scaffolder (USA, Europe) (Level Fix) (Hotscrock)</description>
+		<release name="Scaffolder (USA, Europe) (Level Fix) (Hotscrock)" region="Europe"/>
+		<release name="Scaffolder (USA, Europe) (Level Fix) (Hotscrock)" region="USA"/>
+		<rom name="Scaffolder (USA, Europe) (Level Fix) (Hotscrock).sv" size="65536" crc="4d5f6666" md5="7816deddb48c44df99c6bb3535c1dc88" sha1="88bddc446c3e761750b1ec9736cf47d7e1830f8c"/>
+		<url>https://retroachievements.org/game/17599/hashes</url>
+		<hash>7816deddb48c44df99c6bb3535c1dc88</hash>
 	</game>
 	
 	<game name="Soccer Champion (USA, Europe)">

--- a/DATs/RetroAchievements (No Subfolders)/RA - WonderSwan.dat
+++ b/DATs/RetroAchievements (No Subfolders)/RA - WonderSwan.dat
@@ -5,46 +5,46 @@
 		<name>RA - WonderSwan</name>
 		<description>WonderSwan</description>
 		<category>No Subfolders</category>
-		<version>20260208</version>
-		<date>08 February 2026</date>
+		<version>20260427</version>
+		<date>27 April 2026</date>
 		<author>AzgoRAth, NeoRetroGamer (Contributor), Jumphil (Contributor)</author>
 		<homepage>https://retroachievements.org</homepage>
 		<url>https://retroachievements.org/system/53/games</url>
-		<titlecount>48</titlecount>
-		<hashcount>65</hashcount>
+		<titlecount>49</titlecount>
+		<hashcount>66</hashcount>
 	</header>
-	<game name="Atop the Witch's Tower (World) (v1.1) (Aftermarket)">
+	<game name="Atop the Witch's Tower (World) (v1.1) (Aftermarket) (Unl)">
 		<category>Homebrew</category>
-		<description>Atop the Witch's Tower (World) (v1.1) (Aftermarket)</description>
-		<release name="Atop the Witch's Tower (World) (v1.1) (Aftermarket)" region="World"/>
-		<rom name="Atop the Witch's Tower (World) (v1.1) (Aftermarket).wsc" size="131072" crc="23e814cc" md5="db3569afdb8d8f553da626970f1804e7" sha1="1487a981e576bf8248818b1f1a12c947760be511"/>
+		<description>Atop the Witch's Tower (World) (v1.1) (Aftermarket) (Unl)</description>
+		<release name="Atop the Witch's Tower (World) (v1.1) (Aftermarket) (Unl)" region="World"/>
+		<rom name="Atop the Witch's Tower (World) (v1.1) (Aftermarket) (Unl).wsc" size="131072" crc="23e814cc" md5="db3569afdb8d8f553da626970f1804e7" sha1="1487a981e576bf8248818b1f1a12c947760be511"/>
 		<url>https://retroachievements.org/game/26483/hashes</url>
 		<hash>db3569afdb8d8f553da626970f1804e7</hash>
 	</game>
 	
-	<game name="Cracky Mini (World) (v20240612) (Aftermarket)">
+	<game name="Cracky Mini (World) (v20240612) (Aftermarket) (Unl)">
 		<category>Homebrew</category>
-		<description>Cracky Mini (World) (v20240612) (Aftermarket)</description>
-		<release name="Cracky Mini (World) (v20240612) (Aftermarket)" region="World"/>
-		<rom name="Cracky Mini (World) (v20240612) (Aftermarket).wsc" size="65536" crc="3071302b" md5="2ad72633b07f623b6eb0a641ec44dfd3" sha1="0323adb8a740466f7d2b6f29dc55acaee357be48"/>
+		<description>Cracky Mini (World) (v20240612) (Aftermarket) (Unl)</description>
+		<release name="Cracky Mini (World) (v20240612) (Aftermarket) (Unl)" region="World"/>
+		<rom name="Cracky Mini (World) (v20240612) (Aftermarket) (Unl).wsc" size="65536" crc="3071302b" md5="2ad72633b07f623b6eb0a641ec44dfd3" sha1="0323adb8a740466f7d2b6f29dc55acaee357be48"/>
 		<url>https://retroachievements.org/game/32532/hashes</url>
 		<hash>2ad72633b07f623b6eb0a641ec44dfd3</hash>
 	</game>
 	
-	<game name="Mazy Mini (World) (v20230618) (Aftermarket)">
+	<game name="Mazy (World) (v20230618) (Aftermarket) (Unl)">
 		<category>Homebrew</category>
-		<description>Mazy Mini (World) (v20230618) (Aftermarket)</description>
-		<release name="Mazy Mini (World) (v20230618) (Aftermarket)" region="World"/>
-		<rom name="Mazy Mini (World) (v20230618) (Aftermarket).wsc" size="65536" crc="2620c258" md5="4ea83a19867a3e32749b1c9d898583ca" sha1="d7dd04a77d8c0edee79df61a3cd7f308fdde611d"/>
+		<description>Mazy (World) (v20230618) (Aftermarket) (Unl)</description>
+		<release name="Mazy (World) (v20230618) (Aftermarket) (Unl)" region="World"/>
+		<rom name="Mazy (World) (v20230618) (Aftermarket) (Unl).wsc" size="65536" crc="2620c258" md5="4ea83a19867a3e32749b1c9d898583ca" sha1="d7dd04a77d8c0edee79df61a3cd7f308fdde611d"/>
 		<url>https://retroachievements.org/game/32952/hashes</url>
 		<hash>4ea83a19867a3e32749b1c9d898583ca</hash>
 	</game>
 	
-	<game name="Wondersnake (World) (Aftermarket)">
+	<game name="Wondersnake (World) (Aftermarket) (Unl)">
 		<category>Homebrew</category>
-		<description>Wondersnake (World) (Aftermarket)</description>
-		<release name="Wondersnake (World) (Aftermarket)" region="World"/>
-		<rom name="Wondersnake (World) (Aftermarket).wsc" size="524288" crc="a0591f00" md5="f8706cc921099ce84b2dd154b3cbbac6" sha1="fec915b4993f2d84ea30bd0fa4d8575e9074d292"/>
+		<description>Wondersnake (World) (Aftermarket) (Unl)</description>
+		<release name="Wondersnake (World) (Aftermarket) (Unl)" region="World"/>
+		<rom name="Wondersnake (World) (Aftermarket) (Unl).wsc" size="524288" crc="a0591f00" md5="f8706cc921099ce84b2dd154b3cbbac6" sha1="fec915b4993f2d84ea30bd0fa4d8575e9074d292"/>
 		<url>https://retroachievements.org/game/19897/hashes</url>
 		<hash>f8706cc921099ce84b2dd154b3cbbac6</hash>
 	</game>
@@ -67,11 +67,11 @@
 		<hash>b814e71eb1d079466a9535566d605280</hash>
 	</game>
 	
-	<game name="Cardinal Sins - Recycle Edition (World) (Ja) (v1.02) (WonderWitch) (Aftermarket)">
+	<game name="Cardinal Sins - Recycle Edition (World) (Ja) (v1.02) (WonderWitch) (Aftermarket) (Unl)">
 		<category>Unlicensed</category>
-		<description>Cardinal Sins - Recycle Edition (World) (Ja) (v1.02) (WonderWitch) (Aftermarket)</description>
-		<release name="Cardinal Sins - Recycle Edition (World) (Ja) (v1.02) (WonderWitch) (Aftermarket)" region="World"/>
-		<rom name="Cardinal Sins - Recycle Edition (World) (Ja) (v1.02) (WonderWitch) (Aftermarket).wsc" size="524288" crc="deaec59b" md5="50425331b91ee4273df1d56d7dcd519f" sha1="0a250a6e7d09787ea2062347a69f0452412c6b8d"/>
+		<description>Cardinal Sins - Recycle Edition (World) (Ja) (v1.02) (WonderWitch) (Aftermarket) (Unl)</description>
+		<release name="Cardinal Sins - Recycle Edition (World) (Ja) (v1.02) (WonderWitch) (Aftermarket) (Unl)" region="World"/>
+		<rom name="Cardinal Sins - Recycle Edition (World) (Ja) (v1.02) (WonderWitch) (Aftermarket) (Unl).wsc" size="524288" crc="deaec59b" md5="50425331b91ee4273df1d56d7dcd519f" sha1="0a250a6e7d09787ea2062347a69f0452412c6b8d"/>
 		<url>https://retroachievements.org/game/22100/hashes</url>
 		<hash>50425331b91ee4273df1d56d7dcd519f</hash>
 	</game>
@@ -101,11 +101,11 @@
 		<url>https://retroachievements.org/game/14874/hashes</url>
 		<hash>8f0ba3401662a40e8da5ebcfe7b85e81</hash>
 	</game>
-	<game name="Clock Tower for WonderSwan (Japan) (En) (v1.1) (Team C.U.T.S.)" cloneof="Clock Tower for WonderSwan (Japan) (Rev 1)">
+	<game name="Clock Tower for WonderSwan (Japan) (Rev 1) (En) (v1.1) (Team C.U.T.S.)" cloneof="Clock Tower for WonderSwan (Japan) (Rev 1)">
 		<category>Retail</category>
-		<description>Clock Tower for WonderSwan (Japan) (En) (v1.1) (Team C.U.T.S.)</description>
-		<release name="Clock Tower for WonderSwan (Japan) (En) (v1.1) (Team C.U.T.S.)" region="English"/>
-		<rom name="Clock Tower for WonderSwan (Japan) (En) (v1.1) (Team C.U.T.S.).ws" size="2097152" crc="d536a070" md5="bdaacc5193951ca7fff2845b1664d451" sha1="245b722f978bbe0ea301a14d41afbf6a2040b903"/>
+		<description>Clock Tower for WonderSwan (Japan) (Rev 1) (En) (v1.1) (Team C.U.T.S.)</description>
+		<release name="Clock Tower for WonderSwan (Japan) (Rev 1) (En) (v1.1) (Team C.U.T.S.)" region="English"/>
+		<rom name="Clock Tower for WonderSwan (Japan) (Rev 1) (En) (v1.1) (Team C.U.T.S.).ws" size="2097152" crc="d536a070" md5="bdaacc5193951ca7fff2845b1664d451" sha1="245b722f978bbe0ea301a14d41afbf6a2040b903"/>
 		<url>https://retroachievements.org/game/14874/hashes</url>
 		<hash>bdaacc5193951ca7fff2845b1664d451</hash>
 	</game>
@@ -136,6 +136,15 @@
 		<hash>d5f7fbf06c57aa50f08c14e64d2e02a2</hash>
 	</game>
 	
+	<game name="Digimon Adventure 02 - D1 Tamers (Japan) (En) (v0.97) (USC)">
+		<category>Retail</category>
+		<description>Digimon Adventure 02 - D1 Tamers (Japan) (En) (v0.97) (USC)</description>
+		<release name="Digimon Adventure 02 - D1 Tamers (Japan) (En) (v0.97) (USC)" region="English"/>
+		<rom name="Digimon Adventure 02 - D1 Tamers (Japan) (En) (v0.97) (USC).wsc" size="4194304" crc="74A1AE86" md5="0b4973f8406e90f325198b6747b4e632" sha1="4ad4642abc8b97fd9291b90f98f610bc1462d2d6"/>
+		<url>https://retroachievements.org/game/16142/hashes</url>
+		<hash>0b4973f8406e90f325198b6747b4e632</hash>
+	</game>
+	
 	<game name="Digimon Adventure 02 - Tag Tamers (Japan) (Rev 1)">
 		<category>Retail</category>
 		<description>Digimon Adventure 02 - Tag Tamers (Japan) (Rev 1)</description>
@@ -144,11 +153,11 @@
 		<url>https://retroachievements.org/game/16143/hashes</url>
 		<hash>2cb264ba76b88452d7576992f2b90dbf</hash>
 	</game>
-	<game name="Digimon Adventure 02 - Tag Tamers (Japan) (En) (v1.4.5) (USC)" cloneof="Digimon Adventure 02 - Tag Tamers (Japan) (Rev 1)">
+	<game name="Digimon Adventure 02 - Tag Tamers (Japan) (Rev 1) (En) (v1.4.5) (USC)" cloneof="Digimon Adventure 02 - Tag Tamers (Japan) (Rev 1)">
 		<category>Retail</category>
-		<description>Digimon Adventure 02 - Tag Tamers (Japan) (En) (v1.4.5) (USC)</description>
-		<release name="Digimon Adventure 02 - Tag Tamers (Japan) (En) (v1.4.5) (USC)" region="English"/>
-		<rom name="Digimon Adventure 02 - Tag Tamers (Japan) (En) (v1.4.5) (USC).ws" size="2097152" crc="885058a9" md5="521dee8107ef14ffc0e0b3795207d9fd" sha1="5dd7f045071c15451ee5828154566a0c6be24cc2"/>
+		<description>Digimon Adventure 02 - Tag Tamers (Japan) (Rev 1) (En) (v1.4.5) (USC)</description>
+		<release name="Digimon Adventure 02 - Tag Tamers (Japan) (Rev 1) (En) (v1.4.5) (USC)" region="English"/>
+		<rom name="Digimon Adventure 02 - Tag Tamers (Japan) (Rev 1) (En) (v1.4.5) (USC).ws" size="2097152" crc="885058a9" md5="521dee8107ef14ffc0e0b3795207d9fd" sha1="5dd7f045071c15451ee5828154566a0c6be24cc2"/>
 		<url>https://retroachievements.org/game/16143/hashes</url>
 		<hash>521dee8107ef14ffc0e0b3795207d9fd</hash>
 	</game>
@@ -188,14 +197,6 @@
 		<hash>bfafb9bc64fc88bb71f5936172c2abcd</hash>
 	</game>
 	
-	<game name="Final Fantasy (Japan) (En) (v0.91) (Kalas)" cloneof="Final Fantasy (Japan)">
-		<category>Retail</category>
-		<description>Final Fantasy (Japan) (En) (v0.91) (Kalas)</description>
-		<release name="Final Fantasy (Japan) (En) (v0.91) (Kalas)" region="English"/>
-		<rom name="Final Fantasy (Japan) (En) (v0.91) (Kalas).wsc" size="4194304" crc="df94a149" md5="0d5c239eb1b99b4ab756acda11992ce3" sha1="08e70b98918df5e5cf2fe057908ce5e8a69e05fe"/>
-		<url>https://retroachievements.org/game/15580/hashes</url>
-		<hash>0d5c239eb1b99b4ab756acda11992ce3</hash>
-	</game>
 	<game name="Final Fantasy (Japan)">
 		<category>Retail</category>
 		<description>Final Fantasy (Japan)</description>
@@ -203,6 +204,14 @@
 		<rom name="Final Fantasy (Japan).wsc" size="4194304" crc="b7243e88" md5="e36650ac50df69d1832a0d496c165db2" sha1="26628eb76c16880b6faf2e706778d91a60144078"/>
 		<url>https://retroachievements.org/game/15580/hashes</url>
 		<hash>e36650ac50df69d1832a0d496c165db2</hash>
+	</game>
+	<game name="Final Fantasy (Japan) (En) (v0.91) (Kalas)" cloneof="Final Fantasy (Japan)">
+		<category>Retail</category>
+		<description>Final Fantasy (Japan) (En) (v0.91) (Kalas)</description>
+		<release name="Final Fantasy (Japan) (En) (v0.91) (Kalas)" region="English"/>
+		<rom name="Final Fantasy (Japan) (En) (v0.91) (Kalas).wsc" size="4194304" crc="df94a149" md5="0d5c239eb1b99b4ab756acda11992ce3" sha1="08e70b98918df5e5cf2fe057908ce5e8a69e05fe"/>
+		<url>https://retroachievements.org/game/15580/hashes</url>
+		<hash>0d5c239eb1b99b4ab756acda11992ce3</hash>
 	</game>
 	
 	<game name="Final Fantasy II (Japan)">
@@ -293,14 +302,6 @@
 		<hash>816c81b156146be62a45edd7d7d49fc6</hash>
 	</game>
 	
-	<game name="Hataraku Chocobo (Japan) (En) (v1.01) (Specialagentape)" cloneof="Hataraku Chocobo (Japan)">
-		<category>Retail</category>
-		<description>Hataraku Chocobo (Japan) (En) (v1.01) (Specialagentape)</description>
-		<release name="Hataraku Chocobo (Japan) (En) (v1.01) (Specialagentape)" region="English"/>
-		<rom name="Hataraku Chocobo (Japan) (En) (v1.01) (Specialagentape).wsc" size="1048576" crc="b6528093" md5="907ed96e5e12c55212bb15265d59801b" sha1="580be88475d0fe5acc0629b42278df9e97d9a98f"/>
-		<url>https://retroachievements.org/game/17766/hashes</url>
-		<hash>907ed96e5e12c55212bb15265d59801b</hash>
-	</game>
 	<game name="Hataraku Chocobo (Japan)">
 		<category>Retail</category>
 		<description>Hataraku Chocobo (Japan)</description>
@@ -308,6 +309,14 @@
 		<rom name="Hataraku Chocobo (Japan).wsc" size="1048576" crc="7a29e9a6" md5="ebab0f1f4148d54437834971d9756431" sha1="9bd63ed48926b27be70333fbe07da2ceed56328a"/>
 		<url>https://retroachievements.org/game/17766/hashes</url>
 		<hash>ebab0f1f4148d54437834971d9756431</hash>
+	</game>
+	<game name="Hataraku Chocobo (Japan) (En) (v1.01) (Specialagentape)" cloneof="Hataraku Chocobo (Japan)">
+		<category>Retail</category>
+		<description>Hataraku Chocobo (Japan) (En) (v1.01) (Specialagentape)</description>
+		<release name="Hataraku Chocobo (Japan) (En) (v1.01) (Specialagentape)" region="English"/>
+		<rom name="Hataraku Chocobo (Japan) (En) (v1.01) (Specialagentape).wsc" size="1048576" crc="b6528093" md5="907ed96e5e12c55212bb15265d59801b" sha1="580be88475d0fe5acc0629b42278df9e97d9a98f"/>
+		<url>https://retroachievements.org/game/17766/hashes</url>
+		<hash>907ed96e5e12c55212bb15265d59801b</hash>
 	</game>
 	
 	<game name="Judgement Silversword - Rebirth Edition (Japan) (Rev 5C21)">
@@ -482,14 +491,6 @@
 		<hash>cadd7d9a54d7debffc52a02ff127a5b7</hash>
 	</game>
 	
-	<game name="Rockman EXE WS (Japan) (En) (v1.0) (Greiga Master)" cloneof="Rockman EXE WS (Japan)">
-		<category>Retail</category>
-		<description>Rockman EXE WS (Japan) (En) (v1.0) (Greiga Master)</description>
-		<release name="Rockman EXE WS (Japan) (En) (v1.0) (Greiga Master)" region="English"/>
-		<rom name="Rockman EXE WS (Japan) (En) (v1.0) (Greiga Master).wsc" size="4194304" crc="a8c02e74" md5="20379c41873b0d99a2baaf2ef959e1e6" sha1="79f7821791d99a4e6a912ff60bb10eb8ccb0bcd0"/>
-		<url>https://retroachievements.org/game/14596/hashes</url>
-		<hash>20379c41873b0d99a2baaf2ef959e1e6</hash>
-	</game>
 	<game name="Rockman EXE WS (Japan)">
 		<category>Retail</category>
 		<description>Rockman EXE WS (Japan)</description>
@@ -497,6 +498,14 @@
 		<rom name="Rockman EXE WS (Japan).wsc" size="4194304" crc="658c4b98" md5="a66390da2c2defcf092eb107edaf4fa0" sha1="b4a3ff3b72639f27d1a6f449b0335074aeb9e603"/>
 		<url>https://retroachievements.org/game/14596/hashes</url>
 		<hash>a66390da2c2defcf092eb107edaf4fa0</hash>
+	</game>
+	<game name="Rockman EXE WS (Japan) (En) (v1.0) (Greiga Master)" cloneof="Rockman EXE WS (Japan)">
+		<category>Retail</category>
+		<description>Rockman EXE WS (Japan) (En) (v1.0) (Greiga Master)</description>
+		<release name="Rockman EXE WS (Japan) (En) (v1.0) (Greiga Master)" region="English"/>
+		<rom name="Rockman EXE WS (Japan) (En) (v1.0) (Greiga Master).wsc" size="4194304" crc="a8c02e74" md5="20379c41873b0d99a2baaf2ef959e1e6" sha1="79f7821791d99a4e6a912ff60bb10eb8ccb0bcd0"/>
+		<url>https://retroachievements.org/game/14596/hashes</url>
+		<hash>20379c41873b0d99a2baaf2ef959e1e6</hash>
 	</game>
 	
 	<game name="Rockman EXE - N1 Battle (Japan) (Rev 1)">
@@ -598,14 +607,6 @@
 		<hash>144b29a9997c016fb4b2bb05e3965cfe</hash>
 	</game>
 	
-	<game name="Wizardry Scenario 1 - Proving Grounds of the Mad Overlord (Japan) (En) (v1.1) (Hengki Kusuma Adi)" cloneof="Wizardry Scenario 1 - Proving Grounds of the Mad Overlord (Japan)">
-		<category>Retail</category>
-		<description>Wizardry Scenario 1 - Proving Grounds of the Mad Overlord (Japan) (En) (v1.1) (Hengki Kusuma Adi)</description>
-		<release name="Wizardry Scenario 1 - Proving Grounds of the Mad Overlord (Japan) (En) (v1.1) (Hengki Kusuma Adi)" region="English"/>
-		<rom name="Wizardry Scenario 1 - Proving Grounds of the Mad Overlord (Japan) (En) (v1.1) (Hengki Kusuma Adi).wsc" size="2097152" crc="2c055c98" md5="a9eca898b6014e7ce23b9493b2d12efe" sha1="22fca73a28893a213f3760f54d3d61a81c95753c"/>
-		<url>https://retroachievements.org/game/14595/hashes</url>
-		<hash>a9eca898b6014e7ce23b9493b2d12efe</hash>
-	</game>
 	<game name="Wizardry Scenario 1 - Proving Grounds of the Mad Overlord (Japan)">
 		<category>Retail</category>
 		<description>Wizardry Scenario 1 - Proving Grounds of the Mad Overlord (Japan)</description>
@@ -613,6 +614,14 @@
 		<rom name="Wizardry Scenario 1 - Proving Grounds of the Mad Overlord (Japan).wsc" size="2097152" crc="15e55706" md5="f0ba64cd7b88eab7add0f7af02080072" sha1="c1ad383d337dba8a63295cfb8c7ca8470c893c67"/>
 		<url>https://retroachievements.org/game/14595/hashes</url>
 		<hash>f0ba64cd7b88eab7add0f7af02080072</hash>
+	</game>
+	<game name="Wizardry Scenario 1 - Proving Grounds of the Mad Overlord (Japan) (En) (v1.1) (Hengki Kusuma Adi)" cloneof="Wizardry Scenario 1 - Proving Grounds of the Mad Overlord (Japan)">
+		<category>Retail</category>
+		<description>Wizardry Scenario 1 - Proving Grounds of the Mad Overlord (Japan) (En) (v1.1) (Hengki Kusuma Adi)</description>
+		<release name="Wizardry Scenario 1 - Proving Grounds of the Mad Overlord (Japan) (En) (v1.1) (Hengki Kusuma Adi)" region="English"/>
+		<rom name="Wizardry Scenario 1 - Proving Grounds of the Mad Overlord (Japan) (En) (v1.1) (Hengki Kusuma Adi).wsc" size="2097152" crc="2c055c98" md5="a9eca898b6014e7ce23b9493b2d12efe" sha1="22fca73a28893a213f3760f54d3d61a81c95753c"/>
+		<url>https://retroachievements.org/game/14595/hashes</url>
+		<hash>a9eca898b6014e7ce23b9493b2d12efe</hash>
 	</game>
 	<game name="Wizardry Scenario 1 - Proving Grounds of the Mad Overlord (Japan) (En) (v1.1) (WonderGate Unlock) (v1.0) (Justin Gibbins)" cloneof="Wizardry Scenario 1 - Proving Grounds of the Mad Overlord (Japan)">
 		<category>Retail</category>

--- a/DATs/RetroAchievements (Subfolders)/RA - 3DO Interactive Multiplayer.dat
+++ b/DATs/RetroAchievements (Subfolders)/RA - 3DO Interactive Multiplayer.dat
@@ -15,10 +15,10 @@
 		<clrmamepro forcepacking="unzip"/>
 		<romvault forcepacking="unzip"/>
 	</header>
-	<machine name="Homebrew/Wreckman (World) (v1.0.0) (retroloveletter) (Aftermarket)">
+	<machine name="Homebrew/Wreckman (World) (v1.0.0) (Aftermarket) (retroloveletter)">
 		<category></category>
-		<description>Wreckman (World) (v1.0.0) (retroloveletter) (Aftermarket)</description>
-		<disk name="Wreckman (World) (v1.0.0) (retroloveletter) (Aftermarket).chd" sha1="3f0b20fa82db7cd8778b386b3c1485aa8b535e23"/>
+		<description>Wreckman (World) (v1.0.0) (Aftermarket) (retroloveletter)</description>
+		<disk name="Wreckman (World) (v1.0.0) (Aftermarket) (retroloveletter).chd" sha1="3f0b20fa82db7cd8778b386b3c1485aa8b535e23"/>
 		<url>https://retroachievements.org/game/24160/hashes</url>
 		<hash>33031a9305cab3eb38af9f163fafe307</hash>
 	</machine>

--- a/DATs/RetroAchievements (Subfolders)/RA - 3DO Interactive Multiplayer.dat
+++ b/DATs/RetroAchievements (Subfolders)/RA - 3DO Interactive Multiplayer.dat
@@ -5,8 +5,8 @@
 		<name>RA - 3DO Interactive Multiplayer</name>
 		<description>3DO Interactive Multiplayer</description>
 		<category>Subfolders</category>
-		<version>20260227</version>
-		<date>27 February 2026</date>
+		<version>20260417</version>
+		<date>17 April 2026</date>
 		<author>AzgoRAth, NeoRetroGamer (Contributor), Jumphil (Contributor)</author>
 		<homepage>https://retroachievements.org</homepage>
 		<url>https://retroachievements.org/system/43/games</url>

--- a/DATs/RetroAchievements (Subfolders)/RA - Atari 2600.dat
+++ b/DATs/RetroAchievements (Subfolders)/RA - Atari 2600.dat
@@ -5,13 +5,13 @@
 		<name>RA - Atari 2600</name>
 		<description>Atari 2600</description>
 		<category>Subfolders</category>
-		<version>20260405</version>
-		<date>5 April 2026</date>
+		<version>20260428</version>
+		<date>28 April 2026</date>
 		<author>AzgoRAth, NeoRetroGamer (Contributor), Jumphil (Contributor)</author>
 		<homepage>https://retroachievements.org</homepage>
 		<url>https://retroachievements.org/system/25/games</url>
-		<titlecount>188</titlecount>
-		<hashcount>201</hashcount>
+		<titlecount>198</titlecount>
+		<hashcount>212</hashcount>
 	</header>
 	<game name="Demo/Pepsi Invaders - Coke Wins (NTSC) (Prototype)">
 		<category></category>
@@ -1112,6 +1112,14 @@
 		<rom name="Mario Bros. (USA).a26" size="8192" crc="8fbf7e90" md5="e908611d99890733be31733a979c62d8" sha1="49425ff154b92ca048abb4ce5e8d485c24935035"/>
 		<url>https://retroachievements.org/game/11465/hashes</url>
 		<hash>e908611d99890733be31733a979c62d8</hash>
+	</game>
+	
+	<game name="Retail/Masters of the Universe - The Power of He-Man (USA)">
+		<category></category>
+		<description>Masters of the Universe - The Power of He-Man (USA)</description>
+		<rom name="Masters of the Universe - The Power of He-Man (USA).a26" size="16384" crc="0603e177" md5="3b76242691730b2dd22ec0ceab351bc6" sha1="6db8fa65755db86438ada3d90f4c39cc288dcf84"/>
+		<url>https://retroachievements.org/game/25343/hashes</url>
+		<hash>3b76242691730b2dd22ec0ceab351bc6</hash>
 	</game>
 	
 	<game name="Retail/Math Gran Prix (USA)">

--- a/DATs/RetroAchievements (Subfolders)/RA - Atari 2600.dat
+++ b/DATs/RetroAchievements (Subfolders)/RA - Atari 2600.dat
@@ -5,34 +5,34 @@
 		<name>RA - Atari 2600</name>
 		<description>Atari 2600</description>
 		<category>Subfolders</category>
-		<version>20260227</version>
-		<date>27 February 2026</date>
+		<version>20260405</version>
+		<date>5 April 2026</date>
 		<author>AzgoRAth, NeoRetroGamer (Contributor), Jumphil (Contributor)</author>
 		<homepage>https://retroachievements.org</homepage>
 		<url>https://retroachievements.org/system/25/games</url>
 		<titlecount>188</titlecount>
 		<hashcount>201</hashcount>
 	</header>
-	<game name="Demo/Pepsi Invaders - Coke Wins (NTSC) (Demo)">
+	<game name="Demo/Pepsi Invaders - Coke Wins (NTSC) (Prototype)">
 		<category></category>
-		<description>Pepsi Invaders - Coke Wins (NTSC) (Demo)</description>
-		<rom name="Pepsi Invaders - Coke Wins (NTSC) (Demo).a26" size="4096" crc="7ac99b5c" md5="212d0b200ed8b45d8795ad899734d7d7" sha1="c5317035e73f60e959c123d89600c81b7c45701f"/>
+		<description>Pepsi Invaders - Coke Wins (NTSC) (Prototype)</description>
+		<rom name="Pepsi Invaders - Coke Wins (NTSC) (Prototype).a26" size="4096" crc="7ac99b5c" md5="212d0b200ed8b45d8795ad899734d7d7" sha1="c5317035e73f60e959c123d89600c81b7c45701f"/>
 		<url>https://retroachievements.org/game/11697/hashes</url>
 		<hash>212d0b200ed8b45d8795ad899734d7d7</hash>
 	</game>
 	
-	<game name="Demo/Venetian Blinds (USA) (Demo)">
+	<game name="Demo/Venetian Blinds Demo (USA) (Demo)">
 		<category></category>
-		<description>Venetian Blinds (USA) (Demo)</description>
-		<rom name="Venetian Blinds (USA) (Demo).a26" size="2048" crc="1f0d3562" md5="d08fccfbebaa531c4a4fa7359393a0a9" sha1="81f485b545445080e009adf0f2e93dd4f16b92ce"/>
+		<description>Venetian Blinds Demo (USA) (Demo)</description>
+		<rom name="Venetian Blinds Demo (USA) (Demo).a26" size="2048" crc="1f0d3562" md5="d08fccfbebaa531c4a4fa7359393a0a9" sha1="81f485b545445080e009adf0f2e93dd4f16b92ce"/>
 		<url>https://retroachievements.org/game/11715/hashes</url>
 		<hash>d08fccfbebaa531c4a4fa7359393a0a9</hash>
 	</game>
 	
-	<game name="Homebrew/Mega Man (NTSC) (David Galloway) (Demo) (Aftermarket)">
+	<game name="Homebrew/Mega Man (NTSC) (Demo) (Aftermarket) (David Galloway)">
 		<category></category>
-		<description>Mega Man (NTSC) (David Galloway) (Demo) (Aftermarket)</description>
-		<rom name="Mega Man (NTSC) (David Galloway) (Demo) (Aftermarket).a26" size="32768" crc="9158b4ed" md5="c74ddb744209a92382616e2fa38d1378" sha1="c2fd4bf592d2c1948d4cba02da7980f1df8751f4"/>
+		<description>Mega Man (NTSC) (Demo) (Aftermarket) (David Galloway)</description>
+		<rom name="Mega Man (NTSC) (Demo) (Aftermarket) (David Galloway).a26" size="32768" crc="9158b4ed" md5="c74ddb744209a92382616e2fa38d1378" sha1="c2fd4bf592d2c1948d4cba02da7980f1df8751f4"/>
 		<url>https://retroachievements.org/game/17048/hashes</url>
 		<hash>c74ddb744209a92382616e2fa38d1378</hash>
 	</game>
@@ -45,33 +45,33 @@
 		<hash>76b970b1497e9ec92ee9209895f4d682</hash>
 	</game>
 	
-	<game name="Homebrew/Touhou (USA) (Demo) (Aftermarket)">
+	<game name="Homebrew/Touhou (NTSC) (Demo) (Aftermarket) (Unl)">
 		<category></category>
-		<description>Touhou (USA) (Demo) (Aftermarket)</description>
-		<rom name="Touhou (USA) (Demo) (Aftermarket).a26" size="4096" crc="0c0a6fbc" md5="494af1350a71d7de6661dac265dbbd82" sha1="39cd9520a140ff9f58098dd9ac2cfcae294f30b4"/>
+		<description>Touhou (NTSC) (Demo) (Aftermarket) (Unl)</description>
+		<rom name="Touhou (NTSC) (Demo) (Aftermarket) (Unl).a26" size="4096" crc="0c0a6fbc" md5="494af1350a71d7de6661dac265dbbd82" sha1="39cd9520a140ff9f58098dd9ac2cfcae294f30b4"/>
 		<url>https://retroachievements.org/game/29062/hashes</url>
 		<hash>494af1350a71d7de6661dac265dbbd82</hash>
 	</game>
 	
-	<game name="Homebrew/Alien Force (NTSC) (Nova32) (Aftermarket)">
+	<game name="Homebrew/Alien Force (NTSC) (Aftermarket) (Nova32)">
 		<category></category>
-		<description>Alien Force (NTSC) (Nova32) (Aftermarket)</description>
-		<rom name="Alien Force (NTSC) (Nova32) (Aftermarket).a26" size="8192" crc="7c5ceba6" md5="e204a6b63a8e6e1400fde46bbd054722" sha1="9b9ed3cc635203a6f917032ed741e2c1fdcc1af3"/>
+		<description>Alien Force (NTSC) (Aftermarket) (Nova32)</description>
+		<rom name="Alien Force (NTSC) (Aftermarket) (Nova32).a26" size="8192" crc="7c5ceba6" md5="e204a6b63a8e6e1400fde46bbd054722" sha1="9b9ed3cc635203a6f917032ed741e2c1fdcc1af3"/>
 		<url>https://retroachievements.org/game/26007/hashes</url>
 		<hash>e204a6b63a8e6e1400fde46bbd054722</hash>
 	</game>
 	
-	<game name="Homebrew/Amoeba Jump/Amoeba Jump (World) (v1.3) (PAL) (Aftermarket)">
+	<game name="Homebrew/Amoeba Jump/Amoeba Jump (World) (v1.3) (PAL) (Aftermarket) (Unl)">
 		<category></category>
-		<description>Amoeba Jump (World) (v1.3) (PAL) (Aftermarket)</description>
-		<rom name="Amoeba Jump (World) (v1.3) (PAL) (Aftermarket).a26" size="4096" crc="77112941" md5="0c72cc3a6658c1abd4b735ef55fa72e4" sha1="b04b1181950e2bb898ea23ff11de93c9b56fdc65"/>
+		<description>Amoeba Jump (World) (v1.3) (PAL) (Aftermarket) (Unl)</description>
+		<rom name="Amoeba Jump (World) (v1.3) (PAL) (Aftermarket) (Unl).a26" size="4096" crc="77112941" md5="0c72cc3a6658c1abd4b735ef55fa72e4" sha1="b04b1181950e2bb898ea23ff11de93c9b56fdc65"/>
 		<url>https://retroachievements.org/game/13457/hashes</url>
 		<hash>0c72cc3a6658c1abd4b735ef55fa72e4</hash>
 	</game>
-	<game name="Homebrew/Amoeba Jump/Amoeba Jump (World) (v1.3) (NTSC) (Aftermarket)">
+	<game name="Homebrew/Amoeba Jump/Amoeba Jump (World) (v1.3) (NTSC) (Aftermarket) (Unl)">
 		<category></category>
-		<description>Amoeba Jump (World) (v1.3) (NTSC) (Aftermarket)</description>
-		<rom name="Amoeba Jump (World) (v1.3) (NTSC) (Aftermarket).a26" size="4096" crc="e4349cef" md5="539f3c42c4e15f450ed93cb96ce93af5" sha1="dccbfb28358ca8339920b584cf64465905ce1354"/>
+		<description>Amoeba Jump (World) (v1.3) (NTSC) (Aftermarket) (Unl)</description>
+		<rom name="Amoeba Jump (World) (v1.3) (NTSC) (Aftermarket) (Unl).a26" size="4096" crc="e4349cef" md5="539f3c42c4e15f450ed93cb96ce93af5" sha1="dccbfb28358ca8339920b584cf64465905ce1354"/>
 		<url>https://retroachievements.org/game/13457/hashes</url>
 		<hash>539f3c42c4e15f450ed93cb96ce93af5</hash>
 	</game>
@@ -84,10 +84,10 @@
 		<hash>597af15cc043c11f60f1e5cc6f091380</hash>
 	</game>
 	
-	<game name="Homebrew/Birds and Beans (NTSC) (v2.2) (Bluswimmer) (Aftermarket)">
+	<game name="Homebrew/Birds and Beans (NTSC) (v2.2) (Aftermarket) (Bluswimmer)">
 		<category></category>
-		<description>Birds and Beans (NTSC) (v2.2) (Bluswimmer) (Aftermarket)</description>
-		<rom name="Birds and Beans (NTSC) (v2.2) (Bluswimmer) (Aftermarket).a26" size="4096" crc="9cdedf59" md5="41e0953e9e8810ce67bc7995b37bbf8b" sha1="d5565849199b206466c6f65f66489ed60a53faa8"/>
+		<description>Birds and Beans (NTSC) (v2.2) (Aftermarket) (Bluswimmer)</description>
+		<rom name="Birds and Beans (NTSC) (v2.2) (Aftermarket) (Bluswimmer).a26" size="4096" crc="9cdedf59" md5="41e0953e9e8810ce67bc7995b37bbf8b" sha1="d5565849199b206466c6f65f66489ed60a53faa8"/>
 		<url>https://retroachievements.org/game/26027/hashes</url>
 		<hash>41e0953e9e8810ce67bc7995b37bbf8b</hash>
 	</game>
@@ -100,112 +100,112 @@
 		<hash>e60ddaf73ee51ecba7dd22219faede50</hash>
 	</game>
 	
-	<game name="Homebrew/Dark Mage (NTSC) (Greg Troutman) (Aftermarket)">
+	<game name="Homebrew/Dark Mage (NTSC) (Aftermarket) (Greg Troutman)">
 		<category></category>
-		<description>Dark Mage (NTSC) (Greg Troutman) (Aftermarket)</description>
-		<rom name="Dark Mage (NTSC) (Greg Troutman) (Aftermarket).a26" size="8192" crc="2b38b9de" md5="6333ef5b5cbb77acd47f558c8b7a95d3" sha1="c5af53c4b64c3db552d4717b8583d6fe8d3e7952"/>
+		<description>Dark Mage (NTSC) (Aftermarket) (Greg Troutman)</description>
+		<rom name="Dark Mage (NTSC) (Aftermarket) (Greg Troutman).a26" size="8192" crc="2b38b9de" md5="6333ef5b5cbb77acd47f558c8b7a95d3" sha1="c5af53c4b64c3db552d4717b8583d6fe8d3e7952"/>
 		<url>https://retroachievements.org/game/13321/hashes</url>
 		<hash>6333ef5b5cbb77acd47f558c8b7a95d3</hash>
 	</game>
 	
-	<game name="Homebrew/Fix-It Felix Sr/Fix-It Felix Sr. (Europe) (PAL 60) (Aftermarket)">
+	<game name="Homebrew/Fix-It Felix Sr/Fix-It Felix Sr. (Europe) (PAL 60) (Aftermarket) (Unl)">
 		<category></category>
-		<description>Fix-It Felix Sr. (Europe) (PAL 60) (Aftermarket)</description>
-		<rom name="Fix-It Felix Sr. (Europe) (PAL 60) (Aftermarket).a26" size="4096" crc="b0677067" md5="c7490861ebf74ff1722362aaa146029f" sha1="5a258bdfdf1c72c7b74d1a90f7fb8f7a4d3f7cc7"/>
+		<description>Fix-It Felix Sr. (Europe) (PAL 60) (Aftermarket) (Unl)</description>
+		<rom name="Fix-It Felix Sr. (Europe) (PAL 60) (Aftermarket) (Unl).a26" size="4096" crc="b0677067" md5="c7490861ebf74ff1722362aaa146029f" sha1="5a258bdfdf1c72c7b74d1a90f7fb8f7a4d3f7cc7"/>
 		<url>https://retroachievements.org/game/14710/hashes</url>
 		<hash>c7490861ebf74ff1722362aaa146029f</hash>
 	</game>
-	<game name="Homebrew/Fix-It Felix Sr/Fix-It Felix Sr. (USA) (Aftermarket)">
+	<game name="Homebrew/Fix-It Felix Sr/Fix-It Felix Sr. (NTSC) (Aftermarket) (Unl)">
 		<category></category>
-		<description>Fix-It Felix Sr. (USA) (Aftermarket)</description>
-		<rom name="Fix-It Felix Sr. (USA) (Aftermarket).a26" size="4096" crc="4f066bc9" md5="db112399ab6d6402cc2b34f18ef449da" sha1="296d9c1ef7b214b863516822c7a38009559f3a2a"/>
+		<description>Fix-It Felix Sr. (NTSC) (Aftermarket) (Unl)</description>
+		<rom name="Fix-It Felix Sr. (NTSC) (Aftermarket) (Unl).a26" size="4096" crc="4f066bc9" md5="db112399ab6d6402cc2b34f18ef449da" sha1="296d9c1ef7b214b863516822c7a38009559f3a2a"/>
 		<url>https://retroachievements.org/game/14710/hashes</url>
 		<hash>db112399ab6d6402cc2b34f18ef449da</hash>
 	</game>
 	
-	<game name="Homebrew/Flappy (USA) (RC2) (Aftermarket)">
+	<game name="Homebrew/Flappy (NTSC) (RC2) (Aftermarket) (Unl)">
 		<category></category>
-		<description>Flappy (USA) (RC2) (Aftermarket)</description>
-		<rom name="Flappy (USA) (RC2) (Aftermarket).a26" size="4096" crc="1a7ec0c2" md5="2d33a44e82f88d05f6c50577218c0cae" sha1="14e043587ac67ed5792b4937ddf0e045adeb653a"/>
+		<description>Flappy (NTSC) (RC2) (Aftermarket) (Unl)</description>
+		<rom name="Flappy (NTSC) (RC2) (Aftermarket) (Unl).a26" size="4096" crc="1a7ec0c2" md5="2d33a44e82f88d05f6c50577218c0cae" sha1="14e043587ac67ed5792b4937ddf0e045adeb653a"/>
 		<url>https://retroachievements.org/game/12795/hashes</url>
 		<hash>2d33a44e82f88d05f6c50577218c0cae</hash>
 	</game>
 	
-	<game name="Homebrew/Go Fish/Go Fish! (World) (PAL) (Aftermarket)">
+	<game name="Homebrew/Go Fish/Go Fish! (World) (PAL) (Aftermarket) (Unl)">
     	<category></category>
-		<description>Go Fish! (World) (PAL) (Aftermarket)</description>
-    	<rom name="Go Fish! (World) (PAL) (Aftermarket).a26" size="8192" crc="9a08fc7c" md5="1b64dbaba6bbc1d428e59f088e8018e7" sha1="f286f2e862ca8361c67d815afd9d4e7b27094557"/>
+		<description>Go Fish! (World) (PAL) (Aftermarket) (Unl)</description>
+    	<rom name="Go Fish! (World) (PAL) (Aftermarket) (Unl).a26" size="8192" crc="9a08fc7c" md5="1b64dbaba6bbc1d428e59f088e8018e7" sha1="f286f2e862ca8361c67d815afd9d4e7b27094557"/>
     	<url>https://retroachievements.org/game/13140/hashes</url>
 		<hash>1b64dbaba6bbc1d428e59f088e8018e7</hash>
 	</game>
-	<game name="Homebrew/Go Fish/Go Fish! (World) (NTSC) (Aftermarket)">
+	<game name="Homebrew/Go Fish/Go Fish! (World) (NTSC) (Aftermarket) (Unl)">
     	<category></category>
-		<description>Go Fish! (World) (NTSC) (Aftermarket)</description>
-    	<rom name="Go Fish! (World) (NTSC) (Aftermarket).a26" size="8192" crc="b99fc2bf" md5="787a2faebadc670a887a0e2483b8f034" sha1="c8094b18ea8d7dd0e1824a5fff2c26dd5f99a520"/>
+		<description>Go Fish! (World) (NTSC) (Aftermarket) (Unl)</description>
+    	<rom name="Go Fish! (World) (NTSC) (Aftermarket) (Unl).a26" size="8192" crc="b99fc2bf" md5="787a2faebadc670a887a0e2483b8f034" sha1="c8094b18ea8d7dd0e1824a5fff2c26dd5f99a520"/>
     	<url>https://retroachievements.org/game/13140/hashes</url>
 		<hash>787a2faebadc670a887a0e2483b8f034</hash>
 	</game>
 	
-    <game name="Homebrew/Halo 2600 (World) (Aftermarket)">
+    <game name="Homebrew/Halo 2600 (World) (Aftermarket) (Unl)">
     	<category></category>
-		<description>Halo 2600 (World) (Aftermarket)</description>
-    	<rom name="Halo 2600 (World) (Aftermarket).a26" size="4096" crc="3978a823" md5="4afa7f377eae1cafb4265c68f73f2718" sha1="2a9647e27ab27e6cf82b3bf122edf212fa34ae86"/>
+		<description>Halo 2600 (World) (Aftermarket) (Unl)</description>
+    	<rom name="Halo 2600 (World) (Aftermarket) (Unl).a26" size="4096" crc="3978a823" md5="4afa7f377eae1cafb4265c68f73f2718" sha1="2a9647e27ab27e6cf82b3bf122edf212fa34ae86"/>
     	<url>https://retroachievements.org/game/11776/hashes</url>
 		<hash>4afa7f377eae1cafb4265c68f73f2718</hash>
 	</game>
 	
-	<game name="Homebrew/INV+ (World) (Aftermarket)">
+	<game name="Homebrew/INV+ (World) (Aftermarket) (Unl)">
     	<category></category>
-		<description>INV+ (World) (Aftermarket)</description>
-   		<rom name="INV+ (World) (Aftermarket).a26" size="4096" crc="8ebde037" md5="9ea8ed9dec03082973244a080941e58a" sha1="74dc0247a9c9e4ecec1c173e01274e2391643a60"/>
+		<description>INV+ (World) (Aftermarket) (Unl)</description>
+   		<rom name="INV+ (World) (Aftermarket) (Unl).a26" size="4096" crc="8ebde037" md5="9ea8ed9dec03082973244a080941e58a" sha1="74dc0247a9c9e4ecec1c173e01274e2391643a60"/>
    		<url>https://retroachievements.org/game/13154/hashes</url>
 		<hash>9ea8ed9dec03082973244a080941e58a</hash>
 	</game>
 	
-	<game name="Homebrew/Katamari (NTSC) (v1.3) (Rabbit2600) (Aftermarket)">
+	<game name="Homebrew/Katamari (NTSC) (v1.3) (Aftermarket) (Rabbit2600)">
     	<category></category>
-		<description>Katamari (NTSC) (v1.3) (Rabbit2600) (Aftermarket)</description>
-   		<rom name="Katamari (NTSC) (v1.3) (Rabbit2600) (Aftermarket).a26" size="8192" crc="20f6c442" md5="b467c468a17b82372244893d767f55e2" sha1="0097c3a56b3d92b3192182d2b47937c7579c528d"/>
+		<description>Katamari (NTSC) (v1.3) (Aftermarket) (Rabbit2600)</description>
+   		<rom name="Katamari (NTSC) (v1.3) (Aftermarket) (Rabbit2600).a26" size="8192" crc="20f6c442" md5="b467c468a17b82372244893d767f55e2" sha1="0097c3a56b3d92b3192182d2b47937c7579c528d"/>
    		<url>https://retroachievements.org/game/26087/hashes</url>
 		<hash>b467c468a17b82372244893d767f55e2</hash>
 	</game>
 	
-	<game name="Homebrew/Kelly Kangaroo (USA) (v0.6) (Aftermarket)">
+	<game name="Homebrew/Kelly Kangaroo (NTSC) (v0.6) (Aftermarket) (Unl)">
     	<category></category>
-		<description>Kelly Kangaroo (USA) (v0.6) (Aftermarket)</description>
-   		<rom name="Kelly Kangaroo (USA) (v0.6) (Aftermarket).a26" size="32768" crc="fcb219c6" md5="c411ec2fed53fa14c1fde93a8a975345" sha1="7ebb5e591f0d9b4349d16ee8da50a8fab7c9c30f"/>
+		<description>Kelly Kangaroo (NTSC) (v0.6) (Aftermarket) (Unl)</description>
+   		<rom name="Kelly Kangaroo (NTSC) (v0.6) (Aftermarket) (Unl).a26" size="32768" crc="fcb219c6" md5="c411ec2fed53fa14c1fde93a8a975345" sha1="7ebb5e591f0d9b4349d16ee8da50a8fab7c9c30f"/>
    		<url>https://retroachievements.org/game/33061/hashes</url>
 		<hash>c411ec2fed53fa14c1fde93a8a975345</hash>
 	</game>
 	
-	 <game name="Homebrew/Oystron (World) (Aftermarket)">
+	 <game name="Homebrew/Oystron (World) (Aftermarket) (Unl)">
 		<category></category>
-		<description>Oystron (World) (Aftermarket)</description>
-   		<rom name="Oystron (World) (Aftermarket).a26" size="4096" crc="8155dccf" md5="91f0a708eeb93c133e9672ad2c8e0429" sha1="412e8a2438379878ee4de5c6bf4e5a9ee2707c8b"/>
+		<description>Oystron (World) (Aftermarket) (Unl)</description>
+   		<rom name="Oystron (World) (Aftermarket) (Unl).a26" size="4096" crc="8155dccf" md5="91f0a708eeb93c133e9672ad2c8e0429" sha1="412e8a2438379878ee4de5c6bf4e5a9ee2707c8b"/>
    		<url>https://retroachievements.org/game/14693/hashes</url>
 		<hash>91f0a708eeb93c133e9672ad2c8e0429</hash>
 	</game>
 	
-	<game name="Homebrew/Pac-Man 4K (NTSC) (v2008-05-24) (Dennis Debro) (Aftermarket)">
+	<game name="Homebrew/Pac-Man 4K (NTSC) (v2008-05-24) (Aftermarket) (Dennis Debro)">
 		<category></category>
-		<description>Pac-Man 4K (NTSC) (v2008-05-24) (Dennis Debro) (Aftermarket)</description>
-		<rom name="Pac-Man 4K (NTSC) (v2008-05-24) (Dennis Debro) (Aftermarket).a26" size="4096" crc="4db1f88a" md5="6e88da2b704916eb04a998fed9e23a3e" sha1="f6b59b338f205e2e1e593592d04512d40d8a9bdf"/>
+		<description>Pac-Man 4K (NTSC) (v2008-05-24) (Aftermarket) (Dennis Debro)</description>
+		<rom name="Pac-Man 4K (NTSC) (v2008-05-24) (Aftermarket) (Dennis Debro).a26" size="4096" crc="4db1f88a" md5="6e88da2b704916eb04a998fed9e23a3e" sha1="f6b59b338f205e2e1e593592d04512d40d8a9bdf"/>
 		<url>https://retroachievements.org/game/13151/hashes</url>
 		<hash>6e88da2b704916eb04a998fed9e23a3e</hash>
 	</game>
 	
-	<game name="Homebrew/Princess Rescue (NTSC) (v2013-07-31) (Chris Spry) (Aftermarket)">
+	<game name="Homebrew/Princess Rescue (NTSC) (v2013-07-31) (Chris Spry)">
 		<category></category>
-		<description>Princess Rescue (NTSC) (v2013-07-31) (Chris Spry) (Aftermarket)</description>
-		<rom name="Princess Rescue (NTSC) (v2013-07-31) (Chris Spry) (Aftermarket).a26" size="32768" crc="560dac0c" md5="104468e44898b8e9fa4a1500fde8d4cb" sha1="58aa6bba1d0d26c1287135fc9237b684a984b6be"/>
+		<description>Princess Rescue (NTSC) (v2013-07-31) (Chris Spry)</description>
+		<rom name="Princess Rescue (NTSC) (v2013-07-31) (Chris Spry).a26" size="32768" crc="560dac0c" md5="104468e44898b8e9fa4a1500fde8d4cb" sha1="58aa6bba1d0d26c1287135fc9237b684a984b6be"/>
 		<url>https://retroachievements.org/game/11695/hashes</url>
 		<hash>104468e44898b8e9fa4a1500fde8d4cb</hash>
 	</game>
 	
-	<game name="Homebrew/Punch Out (NTSC) (Demake) (MathanGames) (Aftermarket)">
+	<game name="Homebrew/Punch Out (Demake) (NTSC) (Aftermarket) (MathanGames)">
 		<category></category>
-		<description>Punch Out (NTSC) (Demake) (MathanGames) (Aftermarket)</description>
-		<rom name="Punch Out (NTSC) (Demake) (MathanGames) (Aftermarket).a26" size="32768" crc="780db785" md5="ea6a1cdd1b14eac02759ea6372cfc1f5" sha1="b9d93a04b7fe83ef6782c1145819de24cc4c0f0f"/>
+		<description>Punch Out (Demake) (NTSC) (Aftermarket) (MathanGames)</description>
+		<rom name="Punch Out (Demake) (NTSC) (Aftermarket) (MathanGames).a26" size="32768" crc="780db785" md5="ea6a1cdd1b14eac02759ea6372cfc1f5" sha1="b9d93a04b7fe83ef6782c1145819de24cc4c0f0f"/>
 		<url>https://retroachievements.org/game/25021/hashes</url>
 		<hash>ea6a1cdd1b14eac02759ea6372cfc1f5</hash>
 	</game>
@@ -225,88 +225,88 @@
 		<hash>e2bd71a61584da41ac7c55b90deab543</hash>
 	</game>
 	
-	<game name="Homebrew/Rock Shot (NTSC) (Vivian Video) (Aftermarket)">
+	<game name="Homebrew/Rock Shot (NTSC) (Aftermarket) (Vivian Video)">
 		<category></category>
-		<description>Rock Shot (NTSC) (Vivian Video) (Aftermarket)</description>
-		<rom name="Rock Shot (NTSC) (Vivian Video) (Aftermarket).a26" size="4096" crc="654c7274" md5="d92c1ebe55807fab5921d960130d6925" sha1="25c1338cc954bf903136258cf162f5a584f97b89"/>
+		<description>Rock Shot (NTSC) (Aftermarket) (Vivian Video)</description>
+		<rom name="Rock Shot (NTSC) (Aftermarket) (Vivian Video).a26" size="4096" crc="654c7274" md5="d92c1ebe55807fab5921d960130d6925" sha1="25c1338cc954bf903136258cf162f5a584f97b89"/>
 		<url>https://retroachievements.org/game/36536/hashes</url>
 		<hash>d92c1ebe55807fab5921d960130d6925</hash>
 	</game>
 	
-	<game name="Homebrew/Sheep It Up/Sheep It Up! (World) (PAL) (Aftermarket)">
+	<game name="Homebrew/Sheep It Up/Sheep It Up! - PAL (World) (Aftermarket) (Unl)">
 		<category></category>
-		<description>Sheep It Up! (World) (PAL) (Aftermarket)</description>
-   		<rom name="Sheep It Up! (World) (PAL) (Aftermarket).a26" size="4096" crc="13de1052" md5="1f6267db16ffeb90ba48890d5f84ac9e" sha1="b2d070404738c771e7c5bd3139858f7f8822d423"/>
+		<description>Sheep It Up! - PAL (World) (Aftermarket) (Unl)</description>
+   		<rom name="Sheep It Up! - PAL (World) (Aftermarket) (Unl).a26" size="4096" crc="13de1052" md5="1f6267db16ffeb90ba48890d5f84ac9e" sha1="b2d070404738c771e7c5bd3139858f7f8822d423"/>
     	<url>https://retroachievements.org/game/13456/hashes</url>
 		<hash>1f6267db16ffeb90ba48890d5f84ac9e</hash>
 	</game>
-	<game name="Homebrew/Sheep It Up/Sheep It Up! (World) (NTSC) (Aftermarket)">
+	<game name="Homebrew/Sheep It Up/Sheep It Up! - NTSC (World) (Aftermarket) (Unl)">
     	<category></category>
-		<description>Sheep It Up! (World) (NTSC) (Aftermarket)</description>
-   		<rom name="Sheep It Up! (World) (NTSC) (Aftermarket).a26" size="4096" crc="5be003ad" md5="8debebc61916692e2d66f2edf4bed29c" sha1="d22009a4c4e92e0533bf4379d743f80f53064fde"/>
+		<description>Sheep It Up! - NTSC (World) (Aftermarket) (Unl)</description>
+   		<rom name="Sheep It Up! - NTSC (World) (Aftermarket) (Unl).a26" size="4096" crc="5be003ad" md5="8debebc61916692e2d66f2edf4bed29c" sha1="d22009a4c4e92e0533bf4379d743f80f53064fde"/>
    		<url>https://retroachievements.org/game/13456/hashes</url>
 		<hash>8debebc61916692e2d66f2edf4bed29c</hash>
 	</game>
-	<game name="Homebrew/Sheep It Up/Sheep It Up! (World) (SECAM) (Aftermarket)">
+	<game name="Homebrew/Sheep It Up/Sheep It Up! - SECAM (World) (Aftermarket) (Unl)">
 		<category></category>
-		<description>Sheep It Up! (World) (SECAM) (Aftermarket)</description>
-   		<rom name="Sheep It Up! (World) (SECAM) (Aftermarket).a26" size="4096" crc="f915ad29" md5="da3f54e89b54b0a2391d0513ab8c9861" sha1="566249fc4b955fe7baab05e4818724d3387674b3"/>
+		<description>Sheep It Up! - SECAM (World) (Aftermarket) (Unl)</description>
+   		<rom name="Sheep It Up! - SECAM (World) (Aftermarket) (Unl).a26" size="4096" crc="f915ad29" md5="da3f54e89b54b0a2391d0513ab8c9861" sha1="566249fc4b955fe7baab05e4818724d3387674b3"/>
    		<url>https://retroachievements.org/game/13456/hashes</url>
 		<hash>da3f54e89b54b0a2391d0513ab8c9861</hash>
 	</game>
 	
-	<game name="Homebrew/Skeleton+ (NTSC) (Eric Ball) (Aftermarket)">
+	<game name="Homebrew/Skeleton+ (NTSC) (Aftermarket) (Eric Ball)">
 		<category></category>
-		<description>Skeleton+ (NTSC) (Eric Ball) (Aftermarket)</description>
-		<rom name="Skeleton+ (NTSC) (Eric Ball) (Aftermarket).a26" size="4096" crc="69666409" md5="eafe8b40313a65792e88ff9f2fe2655c" sha1="71e757f92788794632e48a8104e715cb9eb6b217"/>
+		<description>Skeleton+ (NTSC) (Aftermarket) (Eric Ball)</description>
+		<rom name="Skeleton+ (NTSC) (Aftermarket) (Eric Ball).a26" size="4096" crc="69666409" md5="eafe8b40313a65792e88ff9f2fe2655c" sha1="71e757f92788794632e48a8104e715cb9eb6b217"/>
 		<url>https://retroachievements.org/game/13382/hashes</url>
 		<hash>eafe8b40313a65792e88ff9f2fe2655c</hash>
 	</game>
 	
-	<game name="Homebrew/Slide Boy in Maze Land (USA) (Final) (Aftermarket)">
+	<game name="Homebrew/Slide Boy in Maze Land (NTSC) (Final) (Aftermarket) (Unl)">
 		<category></category>
-		<description>Slide Boy in Maze Land (USA) (Final) (Aftermarket)</description>
-		<rom name="Slide Boy in Maze Land (USA) (Final) (Aftermarket).a26" size="32768" crc="1a7388ca" md5="024e97dabc0b083c31ea52a83cca4e01" sha1="744882a4a5a9122e902e5dca743e5b2e42abee32"/>
+		<description>Slide Boy in Maze Land (NTSC) (Final) (Aftermarket) (Unl)</description>
+		<rom name="Slide Boy in Maze Land (NTSC) (Final) (Aftermarket) (Unl).a26" size="32768" crc="1a7388ca" md5="024e97dabc0b083c31ea52a83cca4e01" sha1="744882a4a5a9122e902e5dca743e5b2e42abee32"/>
 		<url>https://retroachievements.org/game/26387/hashes</url>
 		<hash>024e97dabc0b083c31ea52a83cca4e01</hash>
 	</game>
 	
-	<game name="Homebrew/Snake (Rick Skrbina) (USA) (Aftermarket)">
+	<game name="Homebrew/Snake (Rick Skrbina) (NTSC) (Aftermarket) (Unl)">
 		<category></category>
-		<description>Snake (Rick Skrbina) (USA) (Aftermarket)</description>
-		<rom name="Snake (Rick Skrbina) (USA) (Aftermarket).a26" size="4096" crc="5c0b7e5f" md5="bd81069d0945f26d7ff753767208c305" sha1="5c41c48869aa4b64111a24011589be33e7f73ade"/>
+		<description>Snake (Rick Skrbina) (NTSC) (Aftermarket) (Unl)</description>
+		<rom name="Snake (Rick Skrbina) (NTSC) (Aftermarket) (Unl).a26" size="4096" crc="5c0b7e5f" md5="bd81069d0945f26d7ff753767208c305" sha1="5c41c48869aa4b64111a24011589be33e7f73ade"/>
 		<url>https://retroachievements.org/game/14725/hashes</url>
 		<hash>bd81069d0945f26d7ff753767208c305</hash>
 	</game>
 	
-	<game name="Homebrew/Spies in the Night (NTSC) (Jared Gray West) (Aftermarket)">
+	<game name="Homebrew/Spies in the Night (NTSC) (Aftermarket) (Jared Gray West)">
 		<category></category>
-		<description>Spies in the Night (NTSC) (Jared Gray West) (Aftermarket)</description>
-		<rom name="Spies in the Night (NTSC) (Jared Gray West) (Aftermarket).a26" size="8192" crc="6209531c" md5="aecdc8da1d67ad5fd520582750e19938" sha1="934b652be776f37b597e94675b9609fd9b711960"/>
+		<description>Spies in the Night (NTSC) (Aftermarket) (Jared Gray West)</description>
+		<rom name="Spies in the Night (NTSC) (Aftermarket) (Jared Gray West).a26" size="8192" crc="6209531c" md5="aecdc8da1d67ad5fd520582750e19938" sha1="934b652be776f37b597e94675b9609fd9b711960"/>
 		<url>https://retroachievements.org/game/22548/hashes</url>
 		<hash>aecdc8da1d67ad5fd520582750e19938</hash>
 	</game>
 	
-	<game name="Homebrew/Tetris26 (NTSC) (Colin Hughes) (Aftermarket)">
+	<game name="Homebrew/Tetris26 (NTSC) (Aftermarket) (Colin Hughes)">
 		<category></category>
-		<description>Tetris26 (NTSC) (Colin Hughes) (Aftermarket)</description>
-		<rom name="Tetris26 (NTSC) (Colin Hughes) (Aftermarket).a26" size="2048" crc="ebe8d2a9" md5="0279a63d922163da5a4fde76397f3fe0" sha1="c512f2f770d0e8fad29c0ab9e56fd875bc8d1b55"/>
+		<description>Tetris26 (NTSC) (Aftermarket) (Colin Hughes)</description>
+		<rom name="Tetris26 (NTSC) (Aftermarket) (Colin Hughes).a26" size="2048" crc="ebe8d2a9" md5="0279a63d922163da5a4fde76397f3fe0" sha1="c512f2f770d0e8fad29c0ab9e56fd875bc8d1b55"/>
 		<url>https://retroachievements.org/game/13141/hashes</url>
 		<hash>0279a63d922163da5a4fde76397f3fe0</hash>
 	</game>
 	
-	<game name="Homebrew/Angry Video Game Nerd K.O. Boxing (World) (NTSC) (Aftermarket)">
+	<game name="Homebrew/Angry Video Game Nerd K.O. Boxing (World) (NTSC) (Aftermarket) (Unl)">
 		<category></category>
-		<description>Angry Video Game Nerd K.O. Boxing (World) (NTSC) (Aftermarket)</description>
-		<rom name="Angry Video Game Nerd K.O. Boxing (World) (NTSC) (Aftermarket).a26" size="32768" crc="53f02c00" md5="6a7e6fc102bf7459f89419c548a79e2c" sha1="bbcac5c5b2384ab6aa83574e6b9486c4b60822d4"/>
+		<description>Angry Video Game Nerd K.O. Boxing (World) (NTSC) (Aftermarket) (Unl)</description>
+		<rom name="Angry Video Game Nerd K.O. Boxing (World) (NTSC) (Aftermarket) (Unl).a26" size="32768" crc="53f02c00" md5="6a7e6fc102bf7459f89419c548a79e2c" sha1="bbcac5c5b2384ab6aa83574e6b9486c4b60822d4"/>
 		<url>https://retroachievements.org/game/14686/hashes</url>
 		<hash>6a7e6fc102bf7459f89419c548a79e2c</hash>
 	</game>
 	
-	<game name="Homebrew/Video Simon (NTSC) (Mark De Smet) (Aftermarket)">
+	<game name="Homebrew/Video Simon (NTSC) (Aftermarket) (Mark De Smet)">
 		<category></category>
-		<description>Video Simon (NTSC) (Mark De Smet) (Aftermarket)</description>
-		<rom name="Video Simon (NTSC) (Mark De Smet) (Aftermarket).a26" size="4096" crc="c3a4bd27" md5="16f494f20af5dc803bc35939ef924020" sha1="a345a5696f1d63a879e7bb7e3a74c825e97ef7c3"/>
+		<description>Video Simon (NTSC) (Aftermarket) (Mark De Smet)</description>
+		<rom name="Video Simon (NTSC) (Aftermarket) (Mark De Smet).a26" size="4096" crc="c3a4bd27" md5="16f494f20af5dc803bc35939ef924020" sha1="a345a5696f1d63a879e7bb7e3a74c825e97ef7c3"/>
 		<url>https://retroachievements.org/game/13152/hashes</url>
 		<hash>16f494f20af5dc803bc35939ef924020</hash>
 	</game>
@@ -318,57 +318,57 @@
 		<url>https://retroachievements.org/game/11536/hashes</url>
 		<hash>2489359c38551a1d96cbaa4e52d8bb30</hash>
 	</game>
-	<game name="Homebrew/Wall Jump Ninja/Wall Jump Ninja (World) (2015-01-15) (NTSC) (Aftermarket)">
+	<game name="Homebrew/Wall Jump Ninja/Wall Jump Ninja (World) (2015-01-15) (NTSC) (Aftermarket) (Unl)">
 		<category></category>
-		<description>Wall Jump Ninja (World) (2015-01-15) (NTSC) (Aftermarket)</description>
-		<rom name="Wall Jump Ninja (World) (2015-01-15) (NTSC) (Aftermarket).a26" size="4096" crc="353215e0" md5="3c56c0c5f6f97850ed0aa7bcc2a4e30e" sha1="a06fb0c60fff651b0be270e926f220706e86a5b4"/>
+		<description>Wall Jump Ninja (World) (2015-01-15) (NTSC) (Aftermarket) (Unl)</description>
+		<rom name="Wall Jump Ninja (World) (2015-01-15) (NTSC) (Aftermarket) (Unl).a26" size="4096" crc="353215e0" md5="3c56c0c5f6f97850ed0aa7bcc2a4e30e" sha1="a06fb0c60fff651b0be270e926f220706e86a5b4"/>
 		<url>https://retroachievements.org/game/11536/hashes</url>
 		<hash>3c56c0c5f6f97850ed0aa7bcc2a4e30e</hash>
 	</game>
 	
-	<game name="Homebrew/Wall-E (USA) (v20130624) (Aftermarket)">
+	<game name="Homebrew/Wall-E (NTSC) (v20130624) (Aftermarket) (Unl)">
 		<category></category>
-		<description>Wall-E (USA) (v20130624) (Aftermarket)</description>
-		<rom name="Wall-E (USA) (v20130624) (Aftermarket).a26" size="4096" crc="5d278aa5" md5="8c304722f73b9c91d3b68db6eaad690d" sha1="8d02cae15084a804e45bb012cd0681f87ffa2d3b"/>
+		<description>Wall-E (NTSC) (v20130624) (Aftermarket) (Unl)</description>
+		<rom name="Wall-E (NTSC) (v20130624) (Aftermarket) (Unl).a26" size="4096" crc="5d278aa5" md5="8c304722f73b9c91d3b68db6eaad690d" sha1="8d02cae15084a804e45bb012cd0681f87ffa2d3b"/>
 		<url>https://retroachievements.org/game/26911/hashes</url>
 		<hash>8c304722f73b9c91d3b68db6eaad690d</hash>
 	</game>
 	
-	<game name="Homebrew/Wipeout 2600/Wipeout 2600 (USA) (Aftermarket)">
+	<game name="Homebrew/Wipeout 2600/Wipeout 2600 (NTSC) (Aftermarket) (Unl)">
 		<category></category>
-		<description>Wipeout 2600 (USA) (Aftermarket)</description>
-		<rom name="Wipeout 2600 (USA) (Aftermarket).a26" size="4096" crc="613a1389" md5="7088177126d7257472986b65690ce88a" sha1="dbc0e0032c4573a19790fbc551346362adff97b6"/>
+		<description>Wipeout 2600 (NTSC) (Aftermarket) (Unl)</description>
+		<rom name="Wipeout 2600 (NTSC) (Aftermarket) (Unl).a26" size="4096" crc="613a1389" md5="7088177126d7257472986b65690ce88a" sha1="dbc0e0032c4573a19790fbc551346362adff97b6"/>
 		<url>https://retroachievements.org/game/26910/hashes</url>
 		<hash>7088177126d7257472986b65690ce88a</hash>
 	</game>
-	<game name="Homebrew/Wipeout 2600/Wipeout 2600 (USA) (Faster Missiles) (Aftermarket)">
+	<game name="Homebrew/Wipeout 2600/Wipeout 2600 (NTSC) (Faster Missiles) (Aftermarket) (Unl)">
 		<category></category>
-		<description>Wipeout 2600 (USA) (Faster Missiles) (Aftermarket)</description>
-		<rom name="Wipeout 2600 (USA) (Faster Missiles) (Aftermarket).a26" size="4096" crc="b12c3419" md5="f3bb1153e493d740bf41d4e75131001b" sha1="8f3d7abeac8d4b339c6d1b145cdd09e93041bb91"/>
+		<description>Wipeout 2600 (NTSC) (Faster Missiles) (Aftermarket) (Unl)</description>
+		<rom name="Wipeout 2600 (NTSC) (Faster Missiles) (Aftermarket) (Unl).a26" size="4096" crc="b12c3419" md5="f3bb1153e493d740bf41d4e75131001b" sha1="8f3d7abeac8d4b339c6d1b145cdd09e93041bb91"/>
 		<url>https://retroachievements.org/game/26910/hashes</url>
 		<hash>f3bb1153e493d740bf41d4e75131001b</hash>
 	</game>
 	
-	<game name="Homebrew/Xanthiom (NTSC) (v6.0) (MathanGames) (Aftermarket)">
+	<game name="Homebrew/Xanthiom (NTSC) (v6.0) (Aftermarket) (MathanGames)">
 		<category></category>
-		<description>Xanthiom (NTSC) (v6.0) (MathanGames) (Aftermarket)</description>
-		<rom name="Xanthiom (NTSC) (v6.0) (MathanGames) (Aftermarket).a26" size="65536" crc="82738d98" md5="bdda231978da7e14757920094693248a" sha1="bbc0d8e79d4d9a519f68abf2223eeff851c3fec9"/>
+		<description>Xanthiom (NTSC) (v6.0) (Aftermarket) (MathanGames)</description>
+		<rom name="Xanthiom (NTSC) (v6.0) (Aftermarket) (MathanGames).a26" size="65536" crc="82738d98" md5="bdda231978da7e14757920094693248a" sha1="bbc0d8e79d4d9a519f68abf2223eeff851c3fec9"/>
 		<url>https://retroachievements.org/game/25027/hashes</url>
 		<hash>bdda231978da7e14757920094693248a</hash>
 	</game>
 	
-	<game name="Homebrew/Yahtzee (NTSC) (Russell Babylon) (Aftermarket)">
+	<game name="Homebrew/Yahtzee (NTSC) (Aftermarket) (Russell Babylon)">
 		<category></category>
-		<description>Yahtzee (NTSC) (Russell Babylon) (Aftermarket)</description>
-		<rom name="Yahtzee (NTSC) (Russell Babylon) (Aftermarket).a26" size="4096" crc="5c93f4d0" md5="d090836f0a4ea8db9ac7abb7d6adf61e" sha1="6a1e0142c6886a6589a58e029e5aec6b72f7d27f"/>
+		<description>Yahtzee (NTSC) (Aftermarket) (Russell Babylon)</description>
+		<rom name="Yahtzee (NTSC) (Aftermarket) (Russell Babylon).a26" size="4096" crc="5c93f4d0" md5="d090836f0a4ea8db9ac7abb7d6adf61e" sha1="6a1e0142c6886a6589a58e029e5aec6b72f7d27f"/>
 		<url>https://retroachievements.org/game/13024/hashes</url>
 		<hash>d090836f0a4ea8db9ac7abb7d6adf61e</hash>
 	</game>
 	
-	<game name="Homebrew/Zippy the Porcupine (NTSC) (v2) (Chris Spry) (Aftermarket)">
+	<game name="Homebrew/Zippy the Porcupine (NTSC) (v2) (Aftermarket) (Chris Spry)">
 		<category></category>
-		<description>Zippy the Porcupine (NTSC) (v2) (Chris Spry) (Aftermarket)</description>
-		<rom name="Zippy the Porcupine (NTSC) (v2) (Chris Spry) (Aftermarket).a26" size="65536" crc="d57d3189" md5="457b03cd48ff6d895795ef043c6b0f1e" sha1="cbe88e316b471a6476f284df8634d5b646b4bdc5"/>
+		<description>Zippy the Porcupine (NTSC) (v2) (Aftermarket) (Chris Spry)</description>
+		<rom name="Zippy the Porcupine (NTSC) (v2) (Aftermarket) (Chris Spry).a26" size="65536" crc="d57d3189" md5="457b03cd48ff6d895795ef043c6b0f1e" sha1="cbe88e316b471a6476f284df8634d5b646b4bdc5"/>
 		<url>https://retroachievements.org/game/11803/hashes</url>
 		<hash>457b03cd48ff6d895795ef043c6b0f1e</hash>
 	</game>
@@ -491,10 +491,10 @@
 		<hash>16cb43492987d2f32b423817cdaaf7c4</hash>
 	</game>
 	
-	<game name="Retail/Alpha Beam with Ernie (USA) (Joystick Patch) (v2011.01.10)">
+	<game name="Retail/Alpha Beam with Ernie (Japan, USA) (En) (Joystick Patch) (v2011.01.10)">
 		<category></category>
-		<description>Alpha Beam with Ernie (USA) (Joystick Patch) (v2011.01.10)</description>
-		<rom name="Alpha Beam with Ernie (USA) (Joystick Patch) (v2011.01.10).a26" size="8192" crc="bbeeb804" md5="a5d82e469a499a41cfb6e459eba89ad0" sha1="e8519ca4397a4adeb6332017d9a5de63df045362"/>
+		<description>Alpha Beam with Ernie (Japan, USA) (En) (Joystick Patch) (v2011.01.10)</description>
+		<rom name="Alpha Beam with Ernie (Japan, USA) (En) (Joystick Patch) (v2011.01.10).a26" size="8192" crc="bbeeb804" md5="a5d82e469a499a41cfb6e459eba89ad0" sha1="e8519ca4397a4adeb6332017d9a5de63df045362"/>
 		<url>https://retroachievements.org/game/13207/hashes</url>
 		<hash>a5d82e469a499a41cfb6e459eba89ad0</hash>
 	</game>
@@ -595,10 +595,10 @@
 		<hash>136f75c4dd02c29283752b7e5799f978</hash>
 	</game>
 	
-	<game name="Retail/Big Bird's Egg Catch (USA) (Joystick Patch)">
+	<game name="Retail/Big Bird's Egg Catch (Japan, USA) (En) (Joystick Patch)">
 		<category></category>
-		<description>Big Bird's Egg Catch (USA) (Joystick Patch)</description>
-		<rom name="Big Bird's Egg Catch (USA) (Joystick Patch).a26" size="8192" crc="4c343277" md5="d22a401f0b20808196f538cc43786459" sha1="418db57875e69a7dc5e535d71a7953bf74c30798"/>
+		<description>Big Bird's Egg Catch (Japan, USA) (En) (Joystick Patch)</description>
+		<rom name="Big Bird's Egg Catch (Japan, USA) (En) (Joystick Patch).a26" size="8192" crc="4c343277" md5="d22a401f0b20808196f538cc43786459" sha1="418db57875e69a7dc5e535d71a7953bf74c30798"/>
 		<url>https://retroachievements.org/game/14499/hashes</url>
 		<hash>d22a401f0b20808196f538cc43786459</hash>
 	</game>
@@ -1203,10 +1203,10 @@
 		<hash>0164f26f6b38a34208cd4a2d0212afc3</hash>
 	</game>
 	
-	<game name="Retail/Mr. Run and Jump (World) (Aftermarket)">
+	<game name="Retail/Mr. Run and Jump (World) (Aftermarket) (Unl)">
 		<category></category>
-		<description>Mr. Run and Jump (World) (Aftermarket)</description>
-		<rom name="Mr. Run and Jump (World) (Aftermarket).a26" size="16384" crc="9cdb0360" md5="a18c31f680d1adeb541e89508b7a5e3b" sha1="5363ff31b2719ab8114c6d5ac226deb0fb3c1d1f"/>
+		<description>Mr. Run and Jump (World) (Aftermarket) (Unl)</description>
+		<rom name="Mr. Run and Jump (World) (Aftermarket) (Unl).a26" size="16384" crc="9cdb0360" md5="a18c31f680d1adeb541e89508b7a5e3b" sha1="5363ff31b2719ab8114c6d5ac226deb0fb3c1d1f"/>
 		<url>https://retroachievements.org/game/30131/hashes</url>
 		<hash>a18c31f680d1adeb541e89508b7a5e3b</hash>
 	</game>
@@ -1323,10 +1323,10 @@
 		<hash>f724d3dd2471ed4cf5f191dbb724b69f</hash>
 	</game>
 	
-	<game name="Retail/RealSports Volleyball (USA)">
+	<game name="Retail/RealSports Volleyball (USA, Europe) (En,Fr,De,Es,It)">
 		<category></category>
-		<description>RealSports Volleyball (USA)</description>
-		<rom name="RealSports Volleyball (USA).a26" size="4096" crc="54fc9eb2" md5="aed0b7bd64cc384f85fdea33e28daf3b" sha1="2025e1d868595fad36e5d9e7384ffd24c206208d"/>
+		<description>RealSports Volleyball (USA, Europe) (En,Fr,De,Es,It)</description>
+		<rom name="RealSports Volleyball (USA, Europe) (En,Fr,De,Es,It).a26" size="4096" crc="54fc9eb2" md5="aed0b7bd64cc384f85fdea33e28daf3b" sha1="2025e1d868595fad36e5d9e7384ffd24c206208d"/>
 		<url>https://retroachievements.org/game/16350/hashes</url>
 		<hash>aed0b7bd64cc384f85fdea33e28daf3b</hash>
 	</game>

--- a/DATs/RetroAchievements (Subfolders)/RA - Atari 7800.dat
+++ b/DATs/RetroAchievements (Subfolders)/RA - Atari 7800.dat
@@ -5,90 +5,90 @@
 		<name>RA - Atari 7800</name>
 		<description>Atari 7800</description>
 		<category>Subfolders</category>
-		<version>20260227</version>
-		<date>27 February 2026</date>
+		<version>20260405</version>
+		<date>5 April 2026</date>
 		<author>AzgoRAth, NeoRetroGamer (Contributor), Jumphil (Contributor)</author>
 		<homepage>https://retroachievements.org</homepage>
 		<url>https://retroachievements.org/system/51/games</url>
 		<titlecount>39</titlecount>
 		<hashcount>40</hashcount>
 	</header>
-	<game name="Homebrew/2048 (World) (Aftermarket)">
+	<game name="Homebrew/2048 (World) (Aftermarket) (Unl)">
 		<category></category>
-		<description>2048 (World) (Aftermarket)</description>
-		<rom name="2048 (World) (Aftermarket).a78" size="49280" crc="118ea84d" md5="a43ae0a26441ff804a9fbaf094a3533d" sha1="99ed61f87bad6e119c1ef69099e4c348b3bbf143"/>
+		<description>2048 (World) (Aftermarket) (Unl)</description>
+		<rom name="2048 (World) (Aftermarket) (Unl).a78" size="49280" crc="118ea84d" md5="a43ae0a26441ff804a9fbaf094a3533d" sha1="99ed61f87bad6e119c1ef69099e4c348b3bbf143"/>
 		<url>https://retroachievements.org/game/24465/hashes</url>
 		<hash>6f157f421c7ed5d952b393122d37915e</hash>
 	</game>
 	
-	<game name="Homebrew/Bentley Bear's Crystal Quest (World) (NTSC) (Aftermarket)">
+	<game name="Homebrew/Bentley Bear's Crystal Quest (World) (NTSC) (Aftermarket) (Unl)">
 		<category></category>
-		<description>Bentley Bear's Crystal Quest (World) (NTSC) (Aftermarket)</description>
-		<rom name="Bentley Bear's Crystal Quest (World) (NTSC) (Aftermarket).a78" size="147456" crc="d44622b3" md5="34483432b92f565f4ced82a141119164" sha1="4a850d4b97bea621e9b6df142afeec8b398d6d6c"/>
+		<description>Bentley Bear's Crystal Quest (World) (NTSC) (Aftermarket) (Unl)</description>
+		<rom name="Bentley Bear's Crystal Quest (World) (NTSC) (Aftermarket) (Unl).a78" size="147456" crc="d44622b3" md5="34483432b92f565f4ced82a141119164" sha1="4a850d4b97bea621e9b6df142afeec8b398d6d6c"/>
 		<url>https://retroachievements.org/game/31170/hashes</url>
 		<hash>34483432b92f565f4ced82a141119164</hash>
 	</game>
 	
-	<game name="Homebrew/DeathMerchant (World) (v1.30) (Digital) (Aftermarket)">
+	<game name="Homebrew/DeathMerchant (World) (v1.30) (Digital) (Aftermarket) (Unl)">
 		<category></category>
-		<description>DeathMerchant (World) (v1.30) (Digital) (Aftermarket)</description>
-		<rom name="DeathMerchant (World) (v1.30) (Digital) (Aftermarket).a78" size="49280" crc="57adcd6b" md5="596297af60645bf3db97e4c78a21f526" sha1="e01c232f1c51ad1a7f15b0ec5ecc1a47271bc232"/>
+		<description>DeathMerchant (World) (v1.30) (Digital) (Aftermarket) (Unl)</description>
+		<rom name="DeathMerchant (World) (v1.30) (Digital) (Aftermarket) (Unl).a78" size="49280" crc="57adcd6b" md5="596297af60645bf3db97e4c78a21f526" sha1="e01c232f1c51ad1a7f15b0ec5ecc1a47271bc232"/>
 		<url>https://retroachievements.org/game/28950/hashes</url>
 		<hash>fab7b59dd580dce0b28be3e74a7b8433</hash>
 	</game>
 	
-	<game name="Homebrew/Flappy Bird (USA) (Matthias Lüdtke) (Aftermarket)">
+	<game name="Homebrew/Flappy Bird (USA) (Aftermarket) (Matthias Lüdtke)">
 		<category></category>
-		<description>Flappy Bird (USA) (Matthias Lüdtke) (Aftermarket)</description>
-		<rom name="Flappy Bird (USA) (Matthias Lüdtke) (Aftermarket).a78" size="32896" crc="59812261" md5="6b3c664b4223085f835ef1a6ca346687" sha1="267776f2da752d5b6420252a9176cf430344454f"/>
+		<description>Flappy Bird (USA) (Aftermarket) (Matthias Lüdtke)</description>
+		<rom name="Flappy Bird (USA) (Aftermarket) (Matthias Lüdtke).a78" size="32896" crc="59812261" md5="6b3c664b4223085f835ef1a6ca346687" sha1="267776f2da752d5b6420252a9176cf430344454f"/>
 		<url>https://retroachievements.org/game/24485/hashes</url>
 		<hash>bac78b53f4f6b3f68c0f8073f0073179</hash>
 	</game>
 	
-	<game name="Homebrew/Knight Guy in Low-Res World - Castle Days (World) (RC1.1) (Aftermarket)">
+	<game name="Homebrew/Knight Guy in Low-Res World - Castle Days (World) (RC1.1) (Aftermarket) (Unl)">
 		<category></category>
-		<description>Knight Guy in Low-Res World - Castle Days (World) (RC1.1) (Aftermarket)</description>
-		<rom name="Knight Guy in Low-Res World - Castle Days (World) (RC1.1) (Aftermarket).a78" size="147584" crc="539e3dd7" md5="95dfe1404d66dc1dc499c8c06171aec3" sha1="31e9ef48c43b06aa96df459b72b75c73eddc7633"/>
+		<description>Knight Guy in Low-Res World - Castle Days (World) (RC1.1) (Aftermarket) (Unl)</description>
+		<rom name="Knight Guy in Low-Res World - Castle Days (World) (RC1.1) (Aftermarket) (Unl).a78" size="147584" crc="539e3dd7" md5="95dfe1404d66dc1dc499c8c06171aec3" sha1="31e9ef48c43b06aa96df459b72b75c73eddc7633"/>
 		<url>https://retroachievements.org/game/29938/hashes</url>
 		<hash>33dbb58f9ee73e9f476b4ebbc8190c88</hash>
 	</game>
 	
-	<game name="Homebrew/Meteor Shower/Meteor Shower (World) (v1.05) (NTSC) (Aftermarket)">
+	<game name="Homebrew/Meteor Shower/Meteor Shower (World) (v1.05) (NTSC) (Aftermarket) (Unl)">
 		<category></category>
-		<description>Meteor Shower (World) (v1.05) (NTSC) (Aftermarket)</description>
-		<rom name="Meteor Shower (World) (v1.05) (NTSC) (Aftermarket).a78" size="16512" crc="8052ccb3" md5="21d1caaeca24e023fad3df23b452b93a" sha1="50f743e617c4456ea5f2f1d66725e63b9359fd41"/>
+		<description>Meteor Shower (World) (v1.05) (NTSC) (Aftermarket) (Unl)</description>
+		<rom name="Meteor Shower (World) (v1.05) (NTSC) (Aftermarket) (Unl).a78" size="16512" crc="8052ccb3" md5="21d1caaeca24e023fad3df23b452b93a" sha1="50f743e617c4456ea5f2f1d66725e63b9359fd41"/>
 		<url>https://retroachievements.org/game/24518/hashes</url>
 		<hash>c3f6201d6a9388e860328c963a3301cc</hash>
 	</game>
-	<game name="Homebrew/Meteor Shower/Meteor Shower (World) (v1.06) (NTSC) (Aftermarket)">
+	<game name="Homebrew/Meteor Shower/Meteor Shower (World) (v1.06) (NTSC) (Aftermarket) (Unl)">
 		<category></category>
-		<description>Meteor Shower (World) (v1.06) (NTSC) (Aftermarket)</description>
-		<release name="Meteor Shower (World) (v1.06) (NTSC) (Aftermarket)" region="USA"/>
-		<rom name="Meteor Shower (World) (v1.06) (NTSC) (Aftermarket).a78" size="16384" crc="aa7fc852" md5="a44241d782ee14b53483487cc8216274" sha1="687ffa98659be34bd04e3602a74ed678463549a6"/>
+		<description>Meteor Shower (World) (v1.06) (NTSC) (Aftermarket) (Unl)</description>
+		<release name="Meteor Shower (World) (v1.06) (NTSC) (Aftermarket) (Unl)" region="USA"/>
+		<rom name="Meteor Shower (World) (v1.06) (NTSC) (Aftermarket) (Unl).a78" size="16384" crc="aa7fc852" md5="a44241d782ee14b53483487cc8216274" sha1="687ffa98659be34bd04e3602a74ed678463549a6"/>
 		<url>https://retroachievements.org/game/24518/hashes</url>
 		<hash>a44241d782ee14b53483487cc8216274</hash>
 	</game>
 	
-	<game name="Homebrew/Rikki &amp; Vikki (World) (Aftermarket)">
+	<game name="Homebrew/Rikki &amp; Vikki (World) (R14) (Aftermarket) (Unl)">
 		<category></category>
-		<description>Rikki &amp; Vikki (World) (Aftermarket)</description>
-		<rom name="Rikki &amp; Vikki (World) (Aftermarket).a78" size="524288" crc="3ea5d821" md5="b3bc889e9cc498636990c5a4d980e85c" sha1="b26d3125a109fed15e380dc32f2e55d84f350450"/>
+		<description>Rikki &amp; Vikki (World) (R14) (Aftermarket) (Unl)</description>
+		<rom name="Rikki &amp; Vikki (World) (R14) (Aftermarket) (Unl).a78" size="524288" crc="3ea5d821" md5="b3bc889e9cc498636990c5a4d980e85c" sha1="b26d3125a109fed15e380dc32f2e55d84f350450"/>
 		<url>https://retroachievements.org/game/16547/hashes</url>
 		<hash>b3bc889e9cc498636990c5a4d980e85c</hash>
 	</game>
 	
-	<game name="Homebrew/Super Pac-Man (World) (v1.09) (NTSC) (Aftermarket)">
+	<game name="Homebrew/Super Pac-Man (World) (v1.09) (NTSC) (Aftermarket) (Unl)">
 		<category></category>
-		<description>Super Pac-Man (World) (v1.09) (NTSC) (Aftermarket)</description>
-		<rom name="Super Pac-Man (World) (v1.09) (NTSC) (Aftermarket).a78" size="32768" crc="415a28ad" md5="7ab539bb0e99e1e5a1c89230bde64610" sha1="e1c51fa453b8dc600e5d7f46df1443b99a1507d0"/>
+		<description>Super Pac-Man (World) (v1.09) (NTSC) (Aftermarket) (Unl)</description>
+		<rom name="Super Pac-Man (World) (v1.09) (NTSC) (Aftermarket) (Unl).a78" size="32768" crc="415a28ad" md5="7ab539bb0e99e1e5a1c89230bde64610" sha1="e1c51fa453b8dc600e5d7f46df1443b99a1507d0"/>
 		<url>https://retroachievements.org/game/31174/hashes</url>
 		<hash>7ab539bb0e99e1e5a1c89230bde64610</hash>
 	</game>
 	
-	<game name="Homebrew/TiME Salvo (USA) (Mike Saarna) (Aftermarket)">
+	<game name="Homebrew/TiME Salvo (USA) (Aftermarket) (Mike Saarna)">
 		<category></category>
-		<description>TiME Salvo (USA) (Mike Saarna) (Aftermarket)</description>
-		<rom name="TiME Salvo (USA) (Mike Saarna) (Aftermarket).a78" size="49280" crc="99908716" md5="668c10974001dc1b02466bdaaa6c7d2b" sha1="83d24c64ca9def70012c4b3fb50c949ac4ce0560"/>
+		<description>TiME Salvo (USA) (Aftermarket) (Mike Saarna)</description>
+		<rom name="TiME Salvo (USA) (Aftermarket) (Mike Saarna).a78" size="49280" crc="99908716" md5="668c10974001dc1b02466bdaaa6c7d2b" sha1="83d24c64ca9def70012c4b3fb50c949ac4ce0560"/>
 		<url>https://retroachievements.org/game/16574/hashes</url>
 		<hash>a60e4b608505d1fb201703b266f754a7</hash>
 	</game>
@@ -101,10 +101,10 @@
 		<hash>54af86a45014f0e436bdc5fc6dd03389</hash>
 	</game>
 	
-	<game name="Homebrew/Wordle (World) (v1.07) (Aftermarket)">
+	<game name="Homebrew/Wordle (World) (v1.07) (Aftermarket) (Unl)">
 		<category></category>
-		<description>Wordle (World) (v1.07) (Aftermarket)</description>
-		<rom name="Wordle (World) (v1.07) (Aftermarket).a78" size="131200" crc="718e07c5" md5="f71ec2b94f34b9290b70079550be460c" sha1="5d1bfb4f747ac621be1cd85a5663778c15928baf"/>
+		<description>Wordle (World) (v1.07) (Aftermarket) (Unl)</description>
+		<rom name="Wordle (World) (v1.07) (Aftermarket) (Unl).a78" size="131200" crc="718e07c5" md5="f71ec2b94f34b9290b70079550be460c" sha1="5d1bfb4f747ac621be1cd85a5663778c15928baf"/>
 		<url>https://retroachievements.org/game/24466/hashes</url>
 		<hash>71ce8910b0efd5d0014a9695cce3b7ad</hash>
 	</game>

--- a/DATs/RetroAchievements (Subfolders)/RA - Atari 7800.dat
+++ b/DATs/RetroAchievements (Subfolders)/RA - Atari 7800.dat
@@ -53,6 +53,14 @@
 		<hash>33dbb58f9ee73e9f476b4ebbc8190c88</hash>
 	</game>
 	
+	<game name="Homebrew/Lift (World) (v20240711) (Aftermarket) (Inufuto)">
+		<category></category>
+		<description>Lift (World) (v20240711) (Aftermarket) (Inufuto)</description>
+		<rom name="Lift (World) (v20240711) (Aftermarket) (Inufuto).a78" size="16512" crc="f7c9c471" md5="61d1c414c835ea9db7daca739043fa64" sha1="6344f9d52010ca54caf00ea9cc5f97c93b4ba107"/>
+		<url>https://retroachievements.org/game/38104/hashes</url>
+		<hash>6765d3723f4256d680d374327f9aa42c</hash>
+	</game>
+	
 	<game name="Homebrew/Meteor Shower/Meteor Shower (World) (v1.05) (NTSC) (Aftermarket) (Unl)">
 		<category></category>
 		<description>Meteor Shower (World) (v1.05) (NTSC) (Aftermarket) (Unl)</description>
@@ -258,6 +266,14 @@
 		<rom name="Kung-Fu Master (USA).a78" size="32768" crc="297899bb" md5="f57d0af323d4e173fb49ed447f0563d7" sha1="8824bffdf4f30a8191e581752a75259a663092ca"/>
 		<url>https://retroachievements.org/game/16945/hashes</url>
 		<hash>f57d0af323d4e173fb49ed447f0563d7</hash>
+	</game>
+	
+	<game name="Retail/Mario Bros. (USA)">
+		<category></category>
+		<description>Mario Bros. (USA)</description>
+		<rom name="Mario Bros. (USA).a78" size="49152" crc="8021a13b" md5="431ca060201ee1f9eb49d44962874049" sha1="12e04b67094af622641c536379c69ecad2ee98ed"/>
+		<url>https://retroachievements.org/game/13366/hashes</url>
+		<hash>431ca060201ee1f9eb49d44962874049</hash>
 	</game>
 	
 	<game name="Retail/Mean 18 Ultimate Golf (USA)">

--- a/DATs/RetroAchievements (Subfolders)/RA - Atari Jaguar CD.dat
+++ b/DATs/RetroAchievements (Subfolders)/RA - Atari Jaguar CD.dat
@@ -15,65 +15,65 @@
 		<clrmamepro forcepacking="unzip"/>
 		<romvault forcepacking="unzip"/>
 	</header>
-	<game name="Homebrew/Home Run Derby/Home Run Derby (World) (v2.0) (MGNS8M) (Demo) (Aftermarket)">
+	<game name="Homebrew/Home Run Derby/Home Run Derby (World) (v2.0) (Aftermarket) (Unl) (MGNS8M)">
 		<category></category>
-		<description>Home Run Derby (World) (v2.0) (MGNS8M) (Demo) (Aftermarket)</description>
-		<rom name="Home Run Derby (World) (v2.0) (MGNS8M) (Demo) (Aftermarket).cdi" size="16334440" crc="37dcea03" md5="82aede01ec23dd9f4a8c9131c439a6c8" sha1="5934c163cde32b46f531413b26c009a4c8dc9e2f"/>
+		<description>Home Run Derby (World) (v2.0) (Aftermarket) (Unl) (MGNS8M)</description>
+		<rom name="Home Run Derby (World) (v2.0) (Aftermarket) (Unl) (MGNS8M).cdi" size="16334440" crc="37dcea03" md5="82aede01ec23dd9f4a8c9131c439a6c8" sha1="5934c163cde32b46f531413b26c009a4c8dc9e2f"/>
 		<url>https://retroachievements.org/game/26665/hashes</url>
 		<hash>bc696313d459a3829c209c81a04e5f6a</hash>
 	</game>
-	<game name="Homebrew/Home Run Derby/Home Run Derby (World) (v1.0) (MGNS8M) (Demo) (Aftermarket)">
+	<game name="Homebrew/Home Run Derby/Home Run Derby (World) (v1.0) (Aftermarket) (Unl) (MGNS8M)">
 		<category></category>
-		<description>Home Run Derby (World) (v1.0) (MGNS8M) (Demo) (Aftermarket)</description>
-		<rom name="Home Run Derby (World) (v1.0) (MGNS8M) (Demo) (Aftermarket).cdi" size="16334440" crc="5df9cee0" md5="8a202ef9ce960d36232ca00bd8dd0e5e" sha1="50ce7774a4df542b251f850a50f9611e867cf518"/>
+		<description>Home Run Derby (World) (v1.0) (Aftermarket) (Unl) (MGNS8M)</description>
+		<rom name="Home Run Derby (World) (v1.0) (Aftermarket) (Unl) (MGNS8M).cdi" size="16334440" crc="5df9cee0" md5="8a202ef9ce960d36232ca00bd8dd0e5e" sha1="50ce7774a4df542b251f850a50f9611e867cf518"/>
 		<url>https://retroachievements.org/game/26665/hashes</url>
 		<hash>89c1de1195d7f25bda63875201445f25</hash>
 	</game>
 	
-	<game name="Homebrew/Alice's Mom's Rescue (World) (OrionSoft) (Aftermarket)">
+	<game name="Homebrew/Alice's Mom's Rescue (World) (Aftermarket) (Unl) (OrionSoft)">
 		<category></category>
-		<description>Alice's Mom's Rescue (World) (OrionSoft) (Aftermarket)</description>
-		<rom name="Alice's Mom's Rescue (World) (OrionSoft) (Aftermarket).cdi" size="40635552" crc="6129069f" md5="a1c193c1cfd73378835851bf88f0d79a" sha1="5b72dff04d71a85776e50c3b5c4829f7c9835bed"/>
+		<description>Alice's Mom's Rescue (World) (Aftermarket) (Unl) (OrionSoft)</description>
+		<rom name="Alice's Mom's Rescue (World) (Aftermarket) (Unl) (OrionSoft).cdi" size="40635552" crc="6129069f" md5="a1c193c1cfd73378835851bf88f0d79a" sha1="5b72dff04d71a85776e50c3b5c4829f7c9835bed"/>
 		<url>https://retroachievements.org/game/22942/hashes</url>
 		<hash>7a3837f8d61c7e60d09e7e3864195c0b</hash>
 	</game>
 	
-	<game name="Homebrew/Downfall (World) (Reboot) (Aftermarket)">
+	<game name="Homebrew/Downfall (World) (Aftermarket) (Unl) (Reboot)">
 		<category></category>
-		<description>Downfall (World) (Reboot) (Aftermarket)</description>
-		<rom name="Downfall (World) (Reboot) (Aftermarket).cdi" size="16334440" crc="8bed0f08" md5="51a69397824d347e67ec8f0efc69f6f5" sha1="bb3f3205853263b9929a28ef19844f9462953acd"/>
+		<description>Downfall (World) (Aftermarket) (Unl) (Reboot)</description>
+		<rom name="Downfall (World) (Aftermarket) (Unl) (Reboot).cdi" size="16334440" crc="8bed0f08" md5="51a69397824d347e67ec8f0efc69f6f5" sha1="bb3f3205853263b9929a28ef19844f9462953acd"/>
 		<url>https://retroachievements.org/game/24459/hashes</url>
 		<hash>ef4b4b04e5857bb172e5dc804f075ea1</hash>
 	</game>
 	
-	<game name="Homebrew/Elansar (World) (OrionSoft) (Aftermarket)">
+	<game name="Homebrew/Elansar (World) (Aftermarket) (Unl) (OrionSoft)">
 		<category></category>
-		<description>Elansar (World) (OrionSoft) (Aftermarket)</description>
-		<rom name="Elansar (World) (OrionSoft) (Aftermarket).cdi" size="52705749" crc="7f5723e2" md5="efccb8ad7c1c395e4aecd9e653348173" sha1="47591e96a7ca152d2f851050ebfa0d2e1a81c269"/>
+		<description>Elansar (World) (Aftermarket) (Unl) (OrionSoft)</description>
+		<rom name="Elansar (World) (Aftermarket) (Unl) (OrionSoft).cdi" size="52705749" crc="7f5723e2" md5="efccb8ad7c1c395e4aecd9e653348173" sha1="47591e96a7ca152d2f851050ebfa0d2e1a81c269"/>
 		<url>https://retroachievements.org/game/24515/hashes</url>
 		<hash>87a5b4eecd0b5ebd56a44d924fa54077</hash>
 	</game>
 
-	<game name="Homebrew/Full Circle - Rocketeer (World) (Promo) (Reboot) (Aftermarket)">
+	<game name="Homebrew/Full Circle - Rocketeer (World) (Promo) (Aftermarket) (Unl) (Reboot)">
 		<category></category>
-		<description>Full Circle - Rocketeer (World) (Promo) (Reboot) (Aftermarket)</description>
-		<rom name="Full Circle - Rocketeer (World) (Promo) (Reboot) (Aftermarket).cdi" size="16334440" crc="67b0c629" md5="651f6076fe47024f1e64944ab27b8ff7" sha1="75f0fe79d6662e96fc2b56983f7cbea40e07d2d7"/>
+		<description>Full Circle - Rocketeer (World) (Promo) (Aftermarket) (Unl) (Reboot)</description>
+		<rom name="Full Circle - Rocketeer (World) (Promo) (Aftermarket) (Unl) (Reboot).cdi" size="16334440" crc="67b0c629" md5="651f6076fe47024f1e64944ab27b8ff7" sha1="75f0fe79d6662e96fc2b56983f7cbea40e07d2d7"/>
 		<url>https://retroachievements.org/game/24462/hashes</url>
 		<hash>97f5012d44f6332ad2e3c020715787b7</hash>
 	</game>
 
-	<game name="Homebrew/Jagmatch (World) (Sebastian Mihai) (Aftermarket)">
+	<game name="Homebrew/Jagmatch (World) (Aftermarket) (Unl) (Sebastian Mihai)">
 		<category></category>
-		<description>Jagmatch (World) (Sebastian Mihai) (Aftermarket)</description>
-		<rom name="Jagmatch (World) (Sebastian Mihai) (Aftermarket).cdi" size="16334440" crc="ee114035" md5="7f7eb633f7415703b83620af49449bed" sha1="8254706690c7bf411973f3894e0430aff0dde2a5"/>
+		<description>Jagmatch (World) (Aftermarket) (Unl) (Sebastian Mihai)</description>
+		<rom name="Jagmatch (World) (Aftermarket) (Unl) (Sebastian Mihai).cdi" size="16334440" crc="ee114035" md5="7f7eb633f7415703b83620af49449bed" sha1="8254706690c7bf411973f3894e0430aff0dde2a5"/>
 		<url>https://retroachievements.org/game/24304/hashes</url>
 		<hash>b406a7402a14c406e26aa21f4e4b8817</hash>
 	</game>
 
-	<game name="Homebrew/Kobayashi Maru (World) (Promo-Final) (Reboot) (Aftermarket)">
+	<game name="Homebrew/Kobayashi Maru (World) (Promo-Final) (Aftermarket) (Unl) (Reboot)">
 		<category></category>
-		<description>Kobayashi Maru (World) (Promo-Final) (Reboot) (Aftermarket)</description>
-		<rom name="Kobayashi Maru (World) (Promo-Final) (Reboot) (Aftermarket).cdi" size="16334440" crc="efbbe60b" md5="e796fc84fdb4f4b2e5ea94c98a83bd51" sha1="188d60d8ced4440a93bde68990d31853e97a59bb"/>
+		<description>Kobayashi Maru (World) (Promo-Final) (Aftermarket) (Unl) (Reboot)</description>
+		<rom name="Kobayashi Maru (World) (Promo-Final) (Aftermarket) (Unl) (Reboot).cdi" size="16334440" crc="efbbe60b" md5="e796fc84fdb4f4b2e5ea94c98a83bd51" sha1="188d60d8ced4440a93bde68990d31853e97a59bb"/>
 		<url>https://retroachievements.org/game/24385/hashes</url>
 		<hash>1afcfa7cc6565e8b774ac2556ce8d8ca</hash>
 	</game>
@@ -92,10 +92,10 @@
 		<hash>D19987D55D2B0AA6D0FF82EF9D859341</hash>
 	</game>
 	
-	<game name="Homebrew/SuperFly DX (World) (v1.1) (Reboot) (Aftermarket)">
+	<game name="Homebrew/SuperFly DX (World) (v1.1) (Aftermarket) (Unl) (Reboot)">
 		<category></category>
-		<description>SuperFly DX (World) (v1.1) (Reboot) (Aftermarket)</description>
-		<rom name="SuperFly DX (World) (v1.1) (Reboot) (Aftermarket).cdi" size="16334440" crc="6abbf100" md5="dd749830a6e7447f23a7f1f3a85803d3" sha1="7cf73aa7420bf8837aae735ec777bb2a0a2d8852"/>
+		<description>SuperFly DX (World) (v1.1) (Aftermarket) (Unl) (Reboot)</description>
+		<rom name="SuperFly DX (World) (v1.1) (Aftermarket) (Unl) (Reboot).cdi" size="16334440" crc="6abbf100" md5="dd749830a6e7447f23a7f1f3a85803d3" sha1="7cf73aa7420bf8837aae735ec777bb2a0a2d8852"/>
 		<url>https://retroachievements.org/game/24088/hashes</url>
 		<hash>b7a6ddb06827fc8cbaa3fee0369e6fda</hash>
 	</game>

--- a/DATs/RetroAchievements (Subfolders)/RA - Atari Jaguar CD.dat
+++ b/DATs/RetroAchievements (Subfolders)/RA - Atari Jaguar CD.dat
@@ -5,8 +5,8 @@
 		<name>RA - Atari Jaguar CD</name>
 		<description>Atari Jaguar CD</description>
 		<category>Subfolders</category>
-		<version>20251225</version>
-		<date>25 December 2025</date>
+		<version>20260417</version>
+		<date>17 April 2026</date>
 		<author>AzgoRAth, NeoRetroGamer (Contributor), Jumphil (Contributor)</author>
 		<homepage>https://retroachievements.org</homepage>
 		<url>https://retroachievements.org/system/77/games</url>

--- a/DATs/RetroAchievements (Subfolders)/RA - Atari Jaguar.dat
+++ b/DATs/RetroAchievements (Subfolders)/RA - Atari Jaguar.dat
@@ -13,50 +13,50 @@
 		<titlecount>20</titlecount>
 		<hashcount>20</hashcount>
 	</header>
-	<game name="Homebrew/OSMOZYS (World) (Demo) (Aftermarket)">
+	<game name="Homebrew/OSMOZYS (World) (Demo) (Aftermarket) (Unl)">
 		<category></category>
-		<description>OSMOZYS (World) (Demo) (Aftermarket)</description>
-		<rom name="OSMOZYS (World) (Demo) (Aftermarket).j64" size="2097152" crc="3463527f" md5="985bd1236c3c416381240fb537e86536" sha1="d9626311fe481b1bdb22de9b750e122061412a20"/>
+		<description>OSMOZYS (World) (Demo) (Aftermarket) (Unl)</description>
+		<rom name="OSMOZYS (World) (Demo) (Aftermarket) (Unl).j64" size="2097152" crc="3463527f" md5="985bd1236c3c416381240fb537e86536" sha1="d9626311fe481b1bdb22de9b750e122061412a20"/>
 		<url>https://retroachievements.org/game/20427/hashes</url>
 		<hash>985bd1236c3c416381240fb537e86536</hash>
 	</game>
 	
-	<game name="Homebrew/Star Fighter (USA) (Demo) (Gedalya) (Aftermarket)">
+	<game name="Homebrew/Star Fighter (USA) (Demo) (Aftermarket) (Gedalya)">
 		<category></category>
-		<description>Star Fighter (USA) (Demo) (Gedalya) (Aftermarket)</description>
-		<rom name="Star Fighter (USA) (Demo) (Gedalya) (Aftermarket).j64" size="4194304" crc="832bf4ca" md5="a5767fc6c628759a5b6ba99874ff8bc4" sha1="193edcd6f0bf0524f012c60e73e6f7f9ad9a2fc7"/>
+		<description>Star Fighter (USA) (Demo) (Aftermarket) (Gedalya)</description>
+		<rom name="Star Fighter (USA) (Demo) (Aftermarket) (Gedalya).j64" size="4194304" crc="832bf4ca" md5="a5767fc6c628759a5b6ba99874ff8bc4" sha1="193edcd6f0bf0524f012c60e73e6f7f9ad9a2fc7"/>
 		<url>https://retroachievements.org/game/27930/hashes</url>
 		<hash>a5767fc6c628759a5b6ba99874ff8bc4</hash>
 	</game>
 	
-	<game name="Homebrew/Alice's Mom's Rescue (World) (Aftermarket)">
+	<game name="Homebrew/Alice's Mom's Rescue (World) (En,Fr,De,Es,It) (Aftermarket) (Unl)">
 		<category></category>
-		<description>Alice's Mom's Rescue (World) (Aftermarket)</description>
-		<rom name="Alice's Mom's Rescue (World) (Aftermarket).j64" size="4194304" crc="d47bb973" md5="4d18fba4b15fda9e5ed96f4f18427a2d" sha1="e09c3447e61791f514ffddec1cd47d1fcb7f1fa8"/>
+		<description>Alice's Mom's Rescue (World) (En,Fr,De,Es,It) (Aftermarket) (Unl)</description>
+		<rom name="Alice's Mom's Rescue (World) (En,Fr,De,Es,It) (Aftermarket) (Unl).j64" size="4194304" crc="d47bb973" md5="4d18fba4b15fda9e5ed96f4f18427a2d" sha1="e09c3447e61791f514ffddec1cd47d1fcb7f1fa8"/>
 		<url>https://retroachievements.org/game/24630/hashes</url>
 		<hash>4d18fba4b15fda9e5ed96f4f18427a2d</hash>
 	</game>
 	
-	<game name="Homebrew/Black Out! (World) (Aftermarket)">
+	<game name="Homebrew/Black Out! (World) (Aftermarket) (Unl)">
 		<category></category>
-		<description>Black Out! (World) (Aftermarket)</description>
-		<rom name="Black Out! (World) (Aftermarket).j64" size="1963132" crc="2e793832" md5="f3f81e5c5ab19410d683d11d1cbb85f2" sha1="318fc3e305449535ff7a3cffe2445ed47c1e3ac3"/>
+		<description>Black Out! (World) (Aftermarket) (Unl)</description>
+		<rom name="Black Out! (World) (Aftermarket) (Unl).j64" size="1963132" crc="2e793832" md5="f3f81e5c5ab19410d683d11d1cbb85f2" sha1="318fc3e305449535ff7a3cffe2445ed47c1e3ac3"/>
 		<url>https://retroachievements.org/game/20634/hashes</url>
 		<hash>f3f81e5c5ab19410d683d11d1cbb85f2</hash>
 	</game>
 	
-	<game name="Homebrew/Downfall (World) (Aftermarket)">
+	<game name="Homebrew/Downfall (World) (Aftermarket) (Unl)">
 		<category></category>
-		<description>Downfall (World) (Aftermarket)</description>
-		<rom name="Downfall (World) (Aftermarket).j64" size="2097152" crc="acfceabd" md5="4206ec6abeee07b9525fdda9925f3e55" sha1="8939ba84cf27e7c4bc659f6d61c07c5b03ccdc9d"/>
+		<description>Downfall (World) (Aftermarket) (Unl)</description>
+		<rom name="Downfall (World) (Aftermarket) (Unl).j64" size="2097152" crc="acfceabd" md5="4206ec6abeee07b9525fdda9925f3e55" sha1="8939ba84cf27e7c4bc659f6d61c07c5b03ccdc9d"/>
 		<url>https://retroachievements.org/game/22522/hashes</url>
 		<hash>4206ec6abeee07b9525fdda9925f3e55</hash>
 	</game>
 	
-	<game name="Homebrew/Frog Feast (World) (Aftermarket)">
+	<game name="Homebrew/Frog Feast (World) (Aftermarket) (Unl)">
     	<category></category>
-		<description>Frog Feast (World) (Aftermarket)</description>
-    	<rom name="Frog Feast (World) (Aftermarket).j64" size="1048576" crc="6038e95f" md5="54af14494cb3b9d584adcbd2d1a5216e" sha1="5b2295907f6fdadf5f44b1e392dcd6f5471fd095"/>
+		<description>Frog Feast (World) (Aftermarket) (Unl)</description>
+    	<rom name="Frog Feast (World) (Aftermarket) (Unl).j64" size="1048576" crc="6038e95f" md5="54af14494cb3b9d584adcbd2d1a5216e" sha1="5b2295907f6fdadf5f44b1e392dcd6f5471fd095"/>
     	<url>https://retroachievements.org/game/16892/hashes</url>
 		<hash>54af14494cb3b9d584adcbd2d1a5216e</hash>
 	</game>
@@ -173,10 +173,10 @@
 		<hash>5f2115d0bdcae4f3aa8e832f23f4ebdd</hash>
 	</game>
 	
-	<game name="Retail/Zero 5 (World) (Aftermarket)">
+	<game name="Retail/Zero 5 (World) (Aftermarket) (Unl)">
 		<category></category>
-		<description>Zero 5 (World) (Aftermarket)</description>
-		<rom name="Zero 5 (World) (Aftermarket).j64" size="2097152" crc="61c7eec0" md5="08b31fae8cbd44ac65d44baf1a0545a2" sha1="b68de2cd49cb70e92f2415837edfa7ab46770a78"/>
+		<description>Zero 5 (World) (Aftermarket) (Unl)</description>
+		<rom name="Zero 5 (World) (Aftermarket) (Unl).j64" size="2097152" crc="61c7eec0" md5="08b31fae8cbd44ac65d44baf1a0545a2" sha1="b68de2cd49cb70e92f2415837edfa7ab46770a78"/>
 		<url>https://retroachievements.org/game/16922/hashes</url>
 		<hash>08b31fae8cbd44ac65d44baf1a0545a2</hash>
 	</game>

--- a/DATs/RetroAchievements (Subfolders)/RA - Atari Jaguar.dat
+++ b/DATs/RetroAchievements (Subfolders)/RA - Atari Jaguar.dat
@@ -5,8 +5,8 @@
 		<name>RA - Atari Jaguar</name>
 		<description>Atari Jaguar</description>
 		<category>Subfolders</category>
-		<version>20251225</version>
-		<date>25 December 2025</date>
+		<version>20260417</version>
+		<date>17 April 2026</date>
 		<author>AzgoRAth, NeoRetroGamer (Contributor), Jumphil (Contributor)</author>
 		<homepage>https://retroachievements.org</homepage>
 		<url>https://retroachievements.org/system/17/games</url>

--- a/DATs/RetroAchievements (Subfolders)/RA - Atari Lynx.dat
+++ b/DATs/RetroAchievements (Subfolders)/RA - Atari Lynx.dat
@@ -252,6 +252,14 @@
 		<hash>c9ed2a3bdefd6d5fdf67302d87b5cfb2</hash>
 	</game>
 	
+	<game name="Retail/Pac-Land (USA, Europe)">
+		<category></category>
+		<description>Pac-Land (USA, Europe)</description>
+		<rom name="Pac-Land (USA, Europe).lyx" size="131072" crc="aa50dd22" md5="0a14754b351b4f11a1359e252b8eb992" sha1="58b57835703e3145a54e1c0ada38c9218bf4cd3d"/>
+		<url>https://retroachievements.org/game/10600/hashes</url>
+		<hash>0a14754b351b4f11a1359e252b8eb992</hash>
+	</game>
+	
 	<game name="Retail/Pinball Jam (USA, Europe)">
 		<category></category>
 		<description>Pinball Jam (USA, Europe)</description>

--- a/DATs/RetroAchievements (Subfolders)/RA - Atari Lynx.dat
+++ b/DATs/RetroAchievements (Subfolders)/RA - Atari Lynx.dat
@@ -13,73 +13,73 @@
 		<titlecount>39</titlecount>
 		<hashcount>40</hashcount>
 	</header>
-	<game name="Homebrew/CHIP-8 Emulator (World) (Aftermarket)">
+	<game name="Homebrew/CHIP-8 Emulator (World) (Aftermarket) (Unl)">
 		<category></category>
-		<description>CHIP-8 Emulator (World) (Aftermarket)</description>
-		<rom name="CHIP-8 Emulator (World) (Aftermarket).lyx" size="23511" crc="ed70fbcc" md5="3d4c70cba51a5c1f0e2fc3c1acb4be50" sha1="27e4cf003e98bc8a66c3627976b18e33fa820b12"/>
+		<description>CHIP-8 Emulator (World) (Aftermarket) (Unl)</description>
+		<rom name="CHIP-8 Emulator (World) (Aftermarket) (Unl).lyx" size="23511" crc="ed70fbcc" md5="3d4c70cba51a5c1f0e2fc3c1acb4be50" sha1="27e4cf003e98bc8a66c3627976b18e33fa820b12"/>
 		<url>https://retroachievements.org/game/25950/hashes</url>
 		<hash>3d4c70cba51a5c1f0e2fc3c1acb4be50</hash>
 	</game>
 	
-	<game name="Homebrew/Flappy Bird/Flappy Bird (86) (World) (tonma) (Aftermarket)">
+	<game name="Homebrew/Flappy Bird/Flappy Bird (86) (World) (Aftermarket) (tonma)">
 		<category></category>
-		<description>Flappy Bird (86) (World) (tonma) (Aftermarket)</description>
-		<rom name="Flappy Bird (86) (World) (tonma) (Aftermarket).lyx" size="32111" crc="c61f1606" md5="85e80cae6da0cbced0d409a48a49c33e" sha1="eae69daddb1a9de53fc45755af135dd25d185c2a"/>
+		<description>Flappy Bird (86) (World) (Aftermarket) (tonma)</description>
+		<rom name="Flappy Bird (86) (World) (Aftermarket) (tonma).lyx" size="32111" crc="c61f1606" md5="85e80cae6da0cbced0d409a48a49c33e" sha1="eae69daddb1a9de53fc45755af135dd25d185c2a"/>
 		<url>https://retroachievements.org/game/19508/hashes</url>
 		<hash>0173ec92e8e8a0359901f310c5f12bb1</hash>
 	</game>
-	<game name="Homebrew/Flappy Bird/Flappy Bird (EE) (World) (tonma) (Aftermarket)">
+	<game name="Homebrew/Flappy Bird/Flappy Bird (EE) (World) (Aftermarket) (tonma)">
 		<category></category>
-		<description>Flappy Bird (EE) (World) (tonma) (Aftermarket)</description>
-		<rom name="Flappy Bird (EE) (World) (tonma) (Aftermarket).lyx" size="32073" crc="e6787336" md5="84d02bc4f902462f654216007a379fbb" sha1="da3ca5809a475f70a2275ceac43198f98dbe0b79"/>
+		<description>Flappy Bird (EE) (World) (Aftermarket) (tonma)</description>
+		<rom name="Flappy Bird (EE) (World) (Aftermarket) (tonma).lyx" size="32073" crc="e6787336" md5="84d02bc4f902462f654216007a379fbb" sha1="da3ca5809a475f70a2275ceac43198f98dbe0b79"/>
 		<url>https://retroachievements.org/game/19508/hashes</url>
 		<hash>8f05d2ffdadffdbce7a1040a9aa0f8e7</hash>
 	</game>
 	
-	<game name="Homebrew/Critter Championship (World) (Aftermarket)">
+	<game name="Homebrew/Critter Championship (World) (Demo) (Aftermarket) (Unl)">
 		<category></category>
-		<description>Critter Championship (World) (Aftermarket)</description>
-		<rom name="Critter Championship (World) (Aftermarket).lnx" size="82289" crc="1785665b" md5="e138c8c988b6ed948e33af73eae1764f" sha1="c3399a6ac822ff3de2659de5894df505a08e7a90"/>
+		<description>Critter Championship (World) (Demo) (Aftermarket) (Unl)</description>
+		<rom name="Critter Championship (World) (Demo) (Aftermarket) (Unl).lnx" size="82289" crc="1785665b" md5="e138c8c988b6ed948e33af73eae1764f" sha1="c3399a6ac822ff3de2659de5894df505a08e7a90"/>
 		<url>https://retroachievements.org/game/19715/hashes</url>
 		<hash>757852d987db4cc79a1a81eadc9dd821</hash>
 	</game>
 	
-	<game name="Homebrew/Running Knight (World) (LynxJam 2023) (Dr. Ludos) (Aftermarket)">
+	<game name="Homebrew/Running Knight (World) (LynxJam 2023) (Aftermarket) (Unl) (Dr. Ludos)">
 		<category></category>
-		<description>Running Knight (World) (LynxJam 2023) (Dr. Ludos) (Aftermarket)</description>
-		<rom name="Running Knight (World) (LynxJam 2023) (Dr. Ludos) (Aftermarket).lnx" size="262208" crc="482719d8" md5="f3663cf094ca1ab6883d6b3c03e7429d" sha1="f826cecb0e2ddc3620d6509b821591aa11d0ec4e"/>
+		<description>Running Knight (World) (LynxJam 2023) (Aftermarket) (Unl) (Dr. Ludos)</description>
+		<rom name="Running Knight (World) (LynxJam 2023) (Aftermarket) (Unl) (Dr. Ludos).lnx" size="262208" crc="482719d8" md5="f3663cf094ca1ab6883d6b3c03e7429d" sha1="f826cecb0e2ddc3620d6509b821591aa11d0ec4e"/>
 		<url>https://retroachievements.org/game/29053/hashes</url>
 		<hash>24077ab7bf46300ff02aa4ca78a81c2c</hash>
 	</game>
 	
-	<game name="Homebrew/Scooternia (World) (Aftermarket)">
+	<game name="Homebrew/Scooternia (World) (Demo) (Aftermarket) (Unl)">
 		<category></category>
-		<description>Scooternia (World) (Aftermarket)</description>
-		<rom name="Scooternia (World) (Aftermarket).lyx" size="262144" crc="7606dcac" md5="459aaf1e66384ea3534e3ce2149a1718" sha1="93e228f35b5b38f1d5bfac0fbb934ea5fbc98263"/>
+		<description>Scooternia (World) (Demo) (Aftermarket) (Unl)</description>
+		<rom name="Scooternia (World) (Demo) (Aftermarket) (Unl).lyx" size="262144" crc="7606dcac" md5="459aaf1e66384ea3534e3ce2149a1718" sha1="93e228f35b5b38f1d5bfac0fbb934ea5fbc98263"/>
 		<url>https://retroachievements.org/game/24300/hashes</url>
 		<hash>459aaf1e66384ea3534e3ce2149a1718</hash>
 	</game>
 	
-	<game name="Homebrew/T-Tris (World) (Alt) (Aftermarket)">
+	<game name="Homebrew/T-Tris (World) (Pirate) (Alt)">
 		<category></category>
-		<description>T-Tris (World) (Alt) (Aftermarket)</description>
-		<rom name="T-Tris (World) (Alt) (Aftermarket).bll" size="15700" crc="a261fcbc" md5="1b6a8a0b7f80332e9c7dfecaded8683e" sha1="d337d0b38e22f42c92691ad2a80d48125d908b7f"/>
+		<description>T-Tris (World) (Pirate) (Alt)</description>
+		<rom name="T-Tris (World) (Pirate) (Alt).bll" size="15700" crc="a261fcbc" md5="1b6a8a0b7f80332e9c7dfecaded8683e" sha1="d337d0b38e22f42c92691ad2a80d48125d908b7f"/>
 		<url>https://retroachievements.org/game/24898/hashes</url>
 		<hash>1b6a8a0b7f80332e9c7dfecaded8683e</hash>
 	</game>
 	
-	<game name="Homebrew/Timeloop (World) (Aftermarket)">
+	<game name="Homebrew/Timeloop (World) (Aftermarket) (Unl)">
 		<category></category>
-		<description>Timeloop (World) (Aftermarket)</description>
-		<rom name="Timeloop (World) (Aftermarket).lnx" size="262208" crc="5508e5f5" md5="dc0919e6666a61b11a0f904b543a7518" sha1="7c30f02e6a908b1c93e8251e0ed3f96234ebe72f"/>
+		<description>Timeloop (World) (Aftermarket) (Unl)</description>
+		<rom name="Timeloop (World) (Aftermarket) (Unl).lnx" size="262208" crc="5508e5f5" md5="dc0919e6666a61b11a0f904b543a7518" sha1="7c30f02e6a908b1c93e8251e0ed3f96234ebe72f"/>
 		<url>https://retroachievements.org/game/27007/hashes</url>
 		<hash>749f3e82357bab232731f0e56f97569c</hash>
 	</game>
 	
-	<game name="Homebrew/Z.A.P. (World) (Aftermarket)">
+	<game name="Homebrew/Z.A.P. (World) (Aftermarket) (Unl)">
 		<category></category>
-		<description>Z.A.P. (World) (Aftermarket)</description>
-		<rom name="Z.A.P. (World) (Aftermarket).lnx" size="24873" crc="6b51794e" md5="fb84478cb62f47c0773996515ada47c9" sha1="7cd0c413e12c812fdb6476f7ed661111fe90bec1"/>
+		<description>Z.A.P. (World) (Aftermarket) (Unl)</description>
+		<rom name="Z.A.P. (World) (Aftermarket) (Unl).lnx" size="24873" crc="6b51794e" md5="fb84478cb62f47c0773996515ada47c9" sha1="7cd0c413e12c812fdb6476f7ed661111fe90bec1"/>
 		<url>https://retroachievements.org/game/19714/hashes</url>
 		<hash>d5079e2e6e1ad9c2b730e47c240a4da0</hash>
 	</game>
@@ -220,10 +220,10 @@
 		<hash>e5e42190918847b8c6056e78316ee91d</hash>
 	</game>
 	
-	<game name="Retail/Lexis (World) (Aftermarket)">
+	<game name="Retail/Lexis (World) (Aftermarket) (Unl)">
 		<category></category>
-		<description>Lexis (World) (Aftermarket)</description>
-		<rom name="Lexis (World) (Aftermarket).lyx" size="262144" crc="0271b6e9" md5="7ee41edaef283459c9df93366c5da267" sha1="b973cee4a58dbae5ab2d540b38db90aae78ba323"/>
+		<description>Lexis (World) (Aftermarket) (Unl)</description>
+		<rom name="Lexis (World) (Aftermarket) (Unl).lyx" size="262144" crc="0271b6e9" md5="7ee41edaef283459c9df93366c5da267" sha1="b973cee4a58dbae5ab2d540b38db90aae78ba323"/>
 		<url>https://retroachievements.org/game/10242/hashes</url>
 		<hash>7ee41edaef283459c9df93366c5da267</hash>
 	</game>

--- a/DATs/RetroAchievements (Subfolders)/RA - Atari Lynx.dat
+++ b/DATs/RetroAchievements (Subfolders)/RA - Atari Lynx.dat
@@ -5,8 +5,8 @@
 		<name>RA - Atari Lynx</name>
 		<description>Atari Lynx</description>
 		<category>Subfolders</category>
-		<version>20260208</version>
-		<date>08 February 2026</date>
+		<version>20260417</version>
+		<date>17 April 2026</date>
 		<author>AzgoRAth, NeoRetroGamer (Contributor), Jumphil (Contributor)</author>
 		<homepage>https://retroachievements.org</homepage>
 		<url>https://retroachievements.org/system/13/games</url>

--- a/DATs/RetroAchievements (Subfolders)/RA - Atari Lynx.dat
+++ b/DATs/RetroAchievements (Subfolders)/RA - Atari Lynx.dat
@@ -5,8 +5,8 @@
 		<name>RA - Atari Lynx</name>
 		<description>Atari Lynx</description>
 		<category>Subfolders</category>
-		<version>20260417</version>
-		<date>17 April 2026</date>
+		<version>20260424</version>
+		<date>24 April 2026</date>
 		<author>AzgoRAth, NeoRetroGamer (Contributor), Jumphil (Contributor)</author>
 		<homepage>https://retroachievements.org</homepage>
 		<url>https://retroachievements.org/system/13/games</url>

--- a/DATs/RetroAchievements (Subfolders)/RA - Colecovision.dat
+++ b/DATs/RetroAchievements (Subfolders)/RA - Colecovision.dat
@@ -5,8 +5,8 @@
 		<name>RA - Colecovision</name>
 		<description>Colecovision</description>
 		<category>Subfolders</category>
-		<version>20260417</version>
-		<date>17 April 2026</date>
+		<version>20260424</version>
+		<date>24 April 2026</date>
 		<author>AzgoRAth, NeoRetroGamer (Contributor), Jumphil (Contributor)</author>
 		<homepage>https://retroachievements.org</homepage>
 		<url>https://retroachievements.org/system/44/games</url>
@@ -321,6 +321,14 @@
 		<rom name="Popeye (USA).col" size="16384" crc="a095454d" md5="a7773e1265e0089bc8f148527256a20e" sha1="f54f110ba5864bb3418f84e1c2cdc5c856dda771"/>
 		<url>https://retroachievements.org/game/18259/hashes</url>
 		<hash>a7773e1265e0089bc8f148527256a20e</hash>
+	</game>
+	
+	<game name="Retail/Rocky - Super Action Boxing (USA, Europe)">
+		<category></category>
+		<description>Rocky - Super Action Boxing (USA, Europe)</description>
+		<rom name="Rocky - Super Action Boxing (USA, Europe).col" size="20480" crc="37f144d3" md5="d35fdb81f4a733925b0a33dfb53d9d78" sha1="11def2adb622bbf62bfd2ac14d8151c8f2f772eb"/>
+		<url>https://retroachievements.org/game/32358/hashes</url>
+		<hash>d35fdb81f4a733925b0a33dfb53d9d78</hash>
 	</game>
 	
 	<game name="Retail/Spy Hunter (USA)">

--- a/DATs/RetroAchievements (Subfolders)/RA - Colecovision.dat
+++ b/DATs/RetroAchievements (Subfolders)/RA - Colecovision.dat
@@ -5,8 +5,8 @@
 		<name>RA - Colecovision</name>
 		<description>Colecovision</description>
 		<category>Subfolders</category>
-		<version>20260227</version>
-		<date>27 February 2026</date>
+		<version>20260417</version>
+		<date>17 April 2026</date>
 		<author>AzgoRAth, NeoRetroGamer (Contributor), Jumphil (Contributor)</author>
 		<homepage>https://retroachievements.org</homepage>
 		<url>https://retroachievements.org/system/44/games</url>

--- a/DATs/RetroAchievements (Subfolders)/RA - Colecovision.dat
+++ b/DATs/RetroAchievements (Subfolders)/RA - Colecovision.dat
@@ -13,96 +13,96 @@
 		<titlecount>40</titlecount>
 		<hashcount>42</hashcount>
 	</header>
-	<game name="Homebrew/Dragon's Lair (World) (Aftermarket)">
+	<game name="Homebrew/Dragon's Lair (World) (SGM) (Aftermarket) (Team Pixelboy)">
 		<category></category>
-		<description>Dragon's Lair (World) (Aftermarket)</description>
-		<rom name="Dragon's Lair (World) (Aftermarket).col" size="262144" crc="12ceee08" md5="3568ed427a9e33de164b44402103ae64" sha1="e74f80fef5276ee6d58b2ed6ee8ebeec668db324"/>
+		<description>Dragon's Lair (World) (SGM) (Aftermarket) (Team Pixelboy)</description>
+		<rom name="Dragon's Lair (World) (SGM) (Aftermarket) (Team Pixelboy).col" size="262144" crc="12ceee08" md5="3568ed427a9e33de164b44402103ae64" sha1="e74f80fef5276ee6d58b2ed6ee8ebeec668db324"/>
 		<url>https://retroachievements.org/game/33722/hashes</url>
 		<hash>3568ed427a9e33de164b44402103ae64</hash>
 	</game>
 	
-	<game name="Homebrew/Frostbite (World) (Aftermarket)">
+	<game name="Homebrew/Frostbite (World) (Aftermarket) (Unl)">
 		<category></category>
-		<description>Frostbite (World) (Aftermarket)</description>
-		<rom name="Frostbite (World) (Aftermarket).col" size="32768" crc="b3212318" md5="9c3a581843ce1efe220e7e726cadb9ea" sha1="92ed60d081e192053823b62b90a647279b241dd5"/>
+		<description>Frostbite (World) (Aftermarket) (Unl)</description>
+		<rom name="Frostbite (World) (Aftermarket) (Unl).col" size="32768" crc="b3212318" md5="9c3a581843ce1efe220e7e726cadb9ea" sha1="92ed60d081e192053823b62b90a647279b241dd5"/>
 		<url>https://retroachievements.org/game/25263/hashes</url>
 		<hash>9c3a581843ce1efe220e7e726cadb9ea</hash>
 	</game>
 	
-	<game name="Homebrew/Ice Muncher/Ice Muncher (World) (v1.0) (Aftermarket)">
+	<game name="Homebrew/Ice Muncher/Ice Muncher (World) (v1.0) (Aftermarket) (Unl)">
 		<category></category>
-		<description>Ice Muncher (World) (v1.0) (Aftermarket)</description>
-		<rom name="Ice Muncher (World) (v1.0) (Aftermarket).col" size="29615" crc="8cf16f2f" md5="d0c499b2af27b4d717de879f47607625" sha1="e15b10be51112035fe69ed84f260b2bbe192d3b7"/>
+		<description>Ice Muncher (World) (v1.0) (Aftermarket) (Unl)</description>
+		<rom name="Ice Muncher (World) (v1.0) (Aftermarket) (Unl).col" size="29615" crc="8cf16f2f" md5="d0c499b2af27b4d717de879f47607625" sha1="e15b10be51112035fe69ed84f260b2bbe192d3b7"/>
 		<url>https://retroachievements.org/game/25104/hashes</url>
 		<hash>d0c499b2af27b4d717de879f47607625</hash>
 	</game>
-	<game name="Homebrew/Ice Muncher/Ice Muncher (World) (v1.1) (Aftermarket)">
+	<game name="Homebrew/Ice Muncher/Ice Muncher (World) (v1.1) (Aftermarket) (Unl)">
 		<category></category>
-		<description>Ice Muncher (World) (v1.1) (Aftermarket)</description>
-		<rom name="Ice Muncher (World) (v1.1) (Aftermarket).col" size="29580" crc="9be9516f" md5="47210914b12d9bd06c15d9f5f9e896fe" sha1="e9296cabf5b0054a710e1c54df920131bde36e1b"/>
+		<description>Ice Muncher (World) (v1.1) (Aftermarket) (Unl)</description>
+		<rom name="Ice Muncher (World) (v1.1) (Aftermarket) (Unl).col" size="29580" crc="9be9516f" md5="47210914b12d9bd06c15d9f5f9e896fe" sha1="e9296cabf5b0054a710e1c54df920131bde36e1b"/>
 		<url>https://retroachievements.org/game/25104/hashes</url>
 		<hash>47210914b12d9bd06c15d9f5f9e896fe</hash>
 	</game>
 	
-	<game name="Homebrew/Minesweeper (World) (Aftermarket)">
+	<game name="Homebrew/Minesweeper (World) (Aftermarket) (Unl)">
 		<category></category>
-		<description>Minesweeper (World) (Aftermarket)</description>
-		<rom name="Minesweeper (World) (Aftermarket).col" size="13604" crc="5cd9d34a" md5="53021bab905ed4bc85a00ccc0e2bf595" sha1="f8eb14dd0916042028907477997ab9ee44655208"/>
+		<description>Minesweeper (World) (Aftermarket) (Unl)</description>
+		<rom name="Minesweeper (World) (Aftermarket) (Unl).col" size="13604" crc="5cd9d34a" md5="53021bab905ed4bc85a00ccc0e2bf595" sha1="f8eb14dd0916042028907477997ab9ee44655208"/>
 		<url>https://retroachievements.org/game/22414/hashes</url>
 		<hash>53021bab905ed4bc85a00ccc0e2bf595</hash>
 	</game>
 	
-	<game name="Homebrew/Multiverse (World) (Aftermarket)">
+	<game name="Homebrew/Multiverse (World) (Aftermarket) (Unl)">
 		<category></category>
-		<description>Multiverse (World) (Aftermarket)</description>
-		<rom name="Multiverse (World) (Aftermarket).col" size="32768" crc="d45475ac" md5="f8f57b1c5171a771b3987be56ef9f0ff" sha1="86cd2a4011957f417d50c3de8dd52c4c14e8e52a"/>
+		<description>Multiverse (World) (Aftermarket) (Unl)</description>
+		<rom name="Multiverse (World) (Aftermarket) (Unl).col" size="32768" crc="d45475ac" md5="f8f57b1c5171a771b3987be56ef9f0ff" sha1="86cd2a4011957f417d50c3de8dd52c4c14e8e52a"/>
 		<url>https://retroachievements.org/game/29939/hashes</url>
 		<hash>f8f57b1c5171a771b3987be56ef9f0ff</hash>
 	</game>
 	
-	<game name="Homebrew/Pac-Man Collection (World) (Aftermarket)">
+	<game name="Homebrew/Pac-Man Collection (World) (Aftermarket) (Unl)">
 		<category></category>
-		<description>Pac-Man Collection (World) (Aftermarket)</description>
-		<rom name="Pac-Man Collection (World) (Aftermarket).col" size="131072" crc="f3ccacb3" md5="9cebe6571aa12803eadcefd9cde6b1b6" sha1="b88ea5f1b052a224068bcc920c6a18760f263c8f"/>
+		<description>Pac-Man Collection (World) (Aftermarket) (Unl)</description>
+		<rom name="Pac-Man Collection (World) (Aftermarket) (Unl).col" size="131072" crc="f3ccacb3" md5="9cebe6571aa12803eadcefd9cde6b1b6" sha1="b88ea5f1b052a224068bcc920c6a18760f263c8f"/>
 		<url>https://retroachievements.org/game/29868/hashes</url>
 		<hash>9cebe6571aa12803eadcefd9cde6b1b6</hash>
 	</game>
 	
-	<game name="Homebrew/Quest for the Golden Chalice (World) (Aftermarket)">
+	<game name="Homebrew/Quest for the Golden Chalice (World) (Aftermarket) (Unl)">
 		<category></category>
-		<description>Quest for the Golden Chalice (World) (Aftermarket)</description>
-		<rom name="Quest for the Golden Chalice (World) (Aftermarket).col" size="32768" crc="6da37da8" md5="eabcb4a9a1eac2c6f8a7d002987d9e55" sha1="21398973ba4ebd563ccfb0f3c1c03c6a447f4eea"/>
+		<description>Quest for the Golden Chalice (World) (Aftermarket) (Unl)</description>
+		<rom name="Quest for the Golden Chalice (World) (Aftermarket) (Unl).col" size="32768" crc="6da37da8" md5="eabcb4a9a1eac2c6f8a7d002987d9e55" sha1="21398973ba4ebd563ccfb0f3c1c03c6a447f4eea"/>
 		<url>https://retroachievements.org/game/24468/hashes</url>
 		<hash>eabcb4a9a1eac2c6f8a7d002987d9e55</hash>
 	</game>
 	
-	<game name="Homebrew/Sega Flipper (SG-1000 Conversion) (World) (Aftermarket)">
+	<game name="Homebrew/Sega Flipper (SG-1000 Conversion) (World) (Aftermarket) (Unl)">
 		<category></category>
-		<description>Sega Flipper (SG-1000 Conversion) (World) (Aftermarket)</description>
-		<rom name="Sega Flipper (SG-1000 Conversion) (World) (Aftermarket).col" size="16384" crc="e7739f82" md5="e61ca91de0e9591fb16204e8a626923a" sha1="4a6d106f0fe36ed9dbe7823f1c9044e17aeea181"/>
+		<description>Sega Flipper (SG-1000 Conversion) (World) (Aftermarket) (Unl)</description>
+		<rom name="Sega Flipper (SG-1000 Conversion) (World) (Aftermarket) (Unl).col" size="16384" crc="e7739f82" md5="e61ca91de0e9591fb16204e8a626923a" sha1="4a6d106f0fe36ed9dbe7823f1c9044e17aeea181"/>
 		<url>https://retroachievements.org/game/25957/hashes</url>
 		<hash>e61ca91de0e9591fb16204e8a626923a</hash>
 	</game>
 	
-	<game name="Homebrew/Sudoku/Sudoku (World) (v1.0) (Aftermarket)">
+	<game name="Homebrew/Sudoku/Sudoku (World) (v1.0) (Aftermarket) (Unl)">
 		<category></category>
-		<description>Sudoku (World) (v1.0) (Aftermarket)</description>
-		<rom name="Sudoku (World) (v1.0) (Aftermarket).col" size="10496" crc="12144312" md5="94476e431aca0f9590964d6797d5dee9" sha1="0124ba683340188c7a9a89122af7a54db07e1edb"/>
+		<description>Sudoku (World) (v1.0) (Aftermarket) (Unl)</description>
+		<rom name="Sudoku (World) (v1.0) (Aftermarket) (Unl).col" size="10496" crc="12144312" md5="94476e431aca0f9590964d6797d5dee9" sha1="0124ba683340188c7a9a89122af7a54db07e1edb"/>
 		<url>https://retroachievements.org/game/14471/hashes</url>
 		<hash>94476e431aca0f9590964d6797d5dee9</hash>
 	</game>
-	<game name="Homebrew/Sudoku/Sudoku (World) (v2.0) (Aftermarket)">
+	<game name="Homebrew/Sudoku/Sudoku (World) (v2.0) (Aftermarket) (Unl)">
 		<category></category>
-		<description>Sudoku (World) (v2.0) (Aftermarket)</description>
-		<rom name="Sudoku (World) (v2.0) (Aftermarket).col" size="10496" crc="2aa3abb2" md5="e34e775b40367815197dc4086aab2f89" sha1="499c9746f0dacab59a3fb23f80169df34cfbb91a"/>
+		<description>Sudoku (World) (v2.0) (Aftermarket) (Unl)</description>
+		<rom name="Sudoku (World) (v2.0) (Aftermarket) (Unl).col" size="10496" crc="2aa3abb2" md5="e34e775b40367815197dc4086aab2f89" sha1="499c9746f0dacab59a3fb23f80169df34cfbb91a"/>
 		<url>https://retroachievements.org/game/14471/hashes</url>
 		<hash>e34e775b40367815197dc4086aab2f89</hash>
 	</game>
 
-	<game name="Homebrew/Where's Derpy (USA) (v1.2) (gameblabla) (Aftermarket)">
+	<game name="Homebrew/Where's Derpy (USA) (v1.2) (Aftermarket) (gameblabla)">
 		<category></category>
-		<description>Where's Derpy (USA) (v1.2) (gameblabla) (Aftermarket)</description>
-		<rom name="Where's Derpy (USA) (v1.2) (gameblabla) (Aftermarket).col" size="27740" crc="53059516" md5="291282d0946c56d3763044d73fbff74c" sha1="a595ebac485814cd6e4c40b33dfbcab25d0e9c03"/>
+		<description>Where's Derpy (USA) (v1.2) (Aftermarket) (gameblabla)</description>
+		<rom name="Where's Derpy (USA) (v1.2) (Aftermarket) (gameblabla).col" size="27740" crc="53059516" md5="291282d0946c56d3763044d73fbff74c" sha1="a595ebac485814cd6e4c40b33dfbcab25d0e9c03"/>
 		<url>https://retroachievements.org/game/34944/hashes</url>
 		<hash>291282d0946c56d3763044d73fbff74c</hash>
 	</game>

--- a/DATs/RetroAchievements (Subfolders)/RA - Elektor TV Games Computer.dat
+++ b/DATs/RetroAchievements (Subfolders)/RA - Elektor TV Games Computer.dat
@@ -5,13 +5,13 @@
 		<name>RA - Elektor TV Games Computer</name>
 		<description>Elektor TV Games Computer</description>
 		<category>Subfolders</category>
-		<version>20251225</version>
-		<date>25 December 2025</date>
+		<version>20260428</version>
+		<date>28 April 2026</date>
 		<author>AzgoRAth, NeoRetroGamer (Contributor), Jumphil (Contributor)</author>
 		<homepage>https://retroachievements.org</homepage>
 		<url>https://retroachievements.org/system/75/games</url>
-		<titlecount>26</titlecount>
-		<hashcount>26</hashcount>
+		<titlecount>29</titlecount>
+		<hashcount>29</hashcount>
 	</header>
 	<game name="Retail/Asteroids (Europe) (ESS-011-5)">
 		<category></category>
@@ -195,6 +195,14 @@
 		<rom name="Rocket Hunting (Europe) (ESS-010-9).tvc" size="5875" crc="76f288a3" md5="ff5f7f6c0bba34a081acb131653ca758" sha1="09ae6cf098e1182d3744f8be2f35cf6f3d385daa"/>
 		<url>https://retroachievements.org/game/24661/hashes</url>
 		<hash>ff5f7f6c0bba34a081acb131653ca758</hash>
+	</game>
+	
+	<game name="Retail/Rocket Shooting (Europe) (ESS-006-3)">
+		<category></category>
+		<description>Rocket Shooting (Europe) (ESS-006-3)</description>
+		<rom name="Rocket Shooting (Europe) (ESS-006-3).tvc" size="1077" crc="f8b41252" md5="472a9af429b440ba09a84ed6bc4630a6" sha1="392dafc12acae84bf2631f924f2519cddc00f556"/>
+		<url>https://retroachievements.org/game/24662/hashes</url>
+		<hash>472a9af429b440ba09a84ed6bc4630a6</hash>
 	</game>
 	
 	<game name="Retail/Snakes and Ladders (Europe) (ESS-011-1)">

--- a/DATs/RetroAchievements (Subfolders)/RA - Emerson Arcadia 2001.dat
+++ b/DATs/RetroAchievements (Subfolders)/RA - Emerson Arcadia 2001.dat
@@ -5,26 +5,26 @@
 		<name>RA - Emerson Arcadia 2001</name>
 		<description>Emerson Arcadia 2001</description>
 		<category>Subfolders</category>
-		<version>20251225</version>
-		<date>25 December 2025</date>
+		<version>20260428</version>
+		<date>28 April 2026</date>
 		<author>AzgoRAth, NeoRetroGamer (Contributor), Jumphil (Contributor)</author>
 		<homepage>https://retroachievements.org</homepage>
 		<url>https://retroachievements.org/system/73/games</url>
-		<titlecount>29</titlecount>
-		<hashcount>31</hashcount>
+		<titlecount>32</titlecount>
+		<hashcount>34</hashcount>
 	</header>
-	<game name="Homebrew/JTron (World) (2003) (Amigan Software) (Aftermarket)">
+	<game name="Homebrew/JTron (World) (2003) (Amigan Software)">
 		<category></category>
-		<description>JTron (World) (2003) (Amigan Software) (Aftermarket)</description>
-		<rom name="JTron (World) (2003) (Amigan Software) (Aftermarket).bin" size="2048" crc="a768c764" md5="906040af349e793bae5b062f3074e71e" sha1="9f6ace424cfbba87eaf06c165fa561099f8d8634"/>
+		<description>JTron (World) (2003) (Amigan Software)</description>
+		<rom name="JTron (World) (2003) (Amigan Software).bin" size="2048" crc="a768c764" md5="906040af349e793bae5b062f3074e71e" sha1="9f6ace424cfbba87eaf06c165fa561099f8d8634"/>
 		<url>https://retroachievements.org/game/24924/hashes</url>
 		<hash>906040af349e793bae5b062f3074e71e</hash>
 	</game>
 	
-	<game name="Homebrew/Tetris (Austria) (2003) (Peter Trauner) (Aftermarket)">
+	<game name="Homebrew/Tetris (Austria) (2003) (Peter Trauner)">
 		<category></category>
-		<description>Tetris (Austria) (2003) (Peter Trauner) (Aftermarket)</description>
-		<rom name="Tetris (Austria) (2003) (Peter Trauner) (Aftermarket).bin" size="4096" crc="296c8465" md5="69cf3728f7db96c311bc8b3b8917baff" sha1="ee910ce4753986989ac44fc9ead97920f14d1571"/>
+		<description>Tetris (Austria) (2003) (Peter Trauner)</description>
+		<rom name="Tetris (Austria) (2003) (Peter Trauner).bin" size="4096" crc="296c8465" md5="69cf3728f7db96c311bc8b3b8917baff" sha1="ee910ce4753986989ac44fc9ead97920f14d1571"/>
 		<url>https://retroachievements.org/game/24691/hashes</url>
 		<hash>69cf3728f7db96c311bc8b3b8917baff</hash>
 	</game>
@@ -93,6 +93,14 @@
 		<hash>2938509d9c2a2316b460b2a617581771</hash>
 	</game>
 	
+	<game name="Retail/Dr. Slump (Japan) (1983) (Bandai)">
+		<category></category>
+		<description>Dr. Slump (Japan) (1983) (Bandai)</description>
+		<rom name="Dr. Slump (Japan) (1983) (Bandai).bin" size="8192" crc="927c375a" md5="2a636fc1b2c414f87c078c06f279d618" sha1="389259f1505deef5c0fb83f9cf8b0f7fa4ed5d04"/>
+		<url>https://retroachievements.org/game/24687/hashes</url>
+		<hash>2a636fc1b2c414f87c078c06f279d618</hash>
+	</game>
+	
 	<game name="Retail/Escape (USA, Europe)">
 		<category></category>
 		<description>Escape (USA, Europe)</description>
@@ -117,10 +125,10 @@
 		<hash>9640b53728b797b11f90c912a8ccadaf</hash>
 	</game>
 	
-	<game name="Retail/Jump Bug/Jump Bug (1982) (UA) (DE)">
+	<game name="Retail/Jump Bug/Jump Bug (1982)(UA)(DE)">
 		<category></category>
-		<description>Jump Bug (1982) (UA) (DE)</description>
-		<rom name="Jump Bug (1982) (UA) (DE).bin" size="8192" crc="dc0264b8" md5="6f2cfbf3c07d1b096f096fc8a763e500" sha1="bf3ccf7a54409f22ca4295b1df1c01bfbbe9f0a2"/>
+		<description>Jump Bug (1982)(UA)(DE)</description>
+		<rom name="Jump Bug (1982)(UA)(DE).bin" size="8192" crc="dc0264b8" md5="6f2cfbf3c07d1b096f096fc8a763e500" sha1="bf3ccf7a54409f22ca4295b1df1c01bfbbe9f0a2"/>
 		<url>https://retroachievements.org/game/21597/hashes</url>
 		<hash>6f2cfbf3c07d1b096f096fc8a763e500</hash>
 	</game>
@@ -148,10 +156,10 @@
 		<hash>4a9404e44df9a747549f7af0b18df632</hash>
 	</game>
 	
-	<game name="Retail/Mobile Soldier Gundam (Japan) (1983) (Bandai)">
+	<game name="Retail/Mobile Soldier Gundam (1983)(Bandai)(JP)">
 		<category></category>
-		<description>Mobile Soldier Gundam (Japan) (1983) (Bandai)</description>
-		<rom name="Mobile Soldier Gundam (Japan) (1983) (Bandai).bin" size="8192" crc="1241f128" md5="eca02a18e0ff4222283ab16947fe6911" sha1="4b07a88b06008ddfc3676983e826e107caf3ba0f"/>
+		<description>Mobile Soldier Gundam (1983)(Bandai)(JP)</description>
+		<rom name="Mobile Soldier Gundam (1983)(Bandai)(JP).bin" size="8192" crc="1241f128" md5="eca02a18e0ff4222283ab16947fe6911" sha1="4b07a88b06008ddfc3676983e826e107caf3ba0f"/>
 		<url>https://retroachievements.org/game/24688/hashes</url>
 		<hash>eca02a18e0ff4222283ab16947fe6911</hash>
 	</game>
@@ -211,6 +219,14 @@
 		<hash>376d97f9f74ab1c64fc888385506027b</hash>
 	</game>
 	
+	<game name="Retail/Space Attack (USA, Europe)">
+		<category></category>
+		<description>Space Attack (USA, Europe)</description>
+		<rom name="Space Attack (USA, Europe).bin" size="4096" crc="e3794a2c" md5="dbd76221e35fa6c8133a03f57dfe79d2" sha1="25a27466dc3ffb6013cd4f632947834002c80105"/>
+		<url>https://retroachievements.org/game/21610/hashes</url>
+		<hash>dbd76221e35fa6c8133a03f57dfe79d2</hash>
+	</game>
+	
 	<game name="Retail/Space Mission (USA, Europe)">
 		<category></category>
 		<description>Space Mission (USA, Europe)</description>
@@ -235,18 +251,18 @@
 		<hash>463fcdc2f5667e23700e6c8f75495fa9</hash>
 	</game>
 	
-	<game name="Retail/Super Bug (Europe)">
+	<game name="Retail/Super Bug (1983)(UA)(EU)">
 		<category></category>
-		<description>Super Bug (Europe)</description>
-		<rom name="Super Bug (Europe).bin" size="4096" crc="fef2aae9" md5="40c65c30b00b8458d3567389d777a47a" sha1="1e7f7b81ecd2f766c94bd5ff17763374fb0318f1"/>
+		<description>Super Bug (1983)(UA)(EU)</description>
+		<rom name="Super Bug (1983)(UA)(EU).bin" size="4096" crc="fef2aae9" md5="40c65c30b00b8458d3567389d777a47a" sha1="1e7f7b81ecd2f766c94bd5ff17763374fb0318f1"/>
 		<url>https://retroachievements.org/game/24923/hashes</url>
 		<hash>40c65c30b00b8458d3567389d777a47a</hash>
 	</game>
 	
-	<game name="Retail/Super Dimension Fortress Macross (Japan) (1983) (Bandai)">
+	<game name="Retail/Super Dimension Fortress Macross (1983)(Bandai)(JP)">
 		<category></category>
-		<description>Super Dimension Fortress Macross (Japan) (1983) (Bandai)</description>
-		<rom name="Super Dimension Fortress Macross (Japan) (1983) (Bandai).bin" size="8192" crc="4c885af2" md5="60ee33a137802d27b5b0567ff4de52ae" sha1="3d24ab9e42ff44a223bb53c5491dea7f41691df2"/>
+		<description>Super Dimension Fortress Macross (1983)(Bandai)(JP)</description>
+		<rom name="Super Dimension Fortress Macross (1983)(Bandai)(JP).bin" size="8192" crc="4c885af2" md5="60ee33a137802d27b5b0567ff4de52ae" sha1="3d24ab9e42ff44a223bb53c5491dea7f41691df2"/>
 		<url>https://retroachievements.org/game/24689/hashes</url>
 		<hash>60ee33a137802d27b5b0567ff4de52ae</hash>
 	</game>
@@ -259,10 +275,10 @@
 		<hash>3bc3df43b6d82f10cf9651372a784f9b</hash>
 	</game>
 	
-	<game name="Retail/End, The (Europe)">
+	<game name="Retail/The End (Europe)">
 		<category></category>
-		<description>End, The (Europe)</description>
-		<rom name="End, The (Europe).bin" size="4096" crc="e66f362d" md5="f0a5e571220685d852e64bb217c8eae8" sha1="1148aa1525d7b46640babb50b004c79abec45d3a"/>
+		<description>The End (Europe)</description>
+		<rom name="The End (Europe).bin" size="4096" crc="e66f362d" md5="f0a5e571220685d852e64bb217c8eae8" sha1="1148aa1525d7b46640babb50b004c79abec45d3a"/>
 		<url>https://retroachievements.org/game/21590/hashes</url>
 		<hash>f0a5e571220685d852e64bb217c8eae8</hash>
 	</game>

--- a/DATs/RetroAchievements (Subfolders)/RA - Fairchild Channel F.dat
+++ b/DATs/RetroAchievements (Subfolders)/RA - Fairchild Channel F.dat
@@ -5,13 +5,13 @@
 		<name>RA - Fairchild Channel F</name>
 		<description>Fairchild Channel F</description>
 		<category>Subfolders</category>
-		<version>20260417</version>
-		<date>17 April 2026</date>
+		<version>20260426</version>
+		<date>26 April 2026</date>
 		<author>AzgoRAth, NeoRetroGamer (Contributor), Jumphil (Contributor)</author>
 		<homepage>https://retroachievements.org</homepage>
 		<url>https://retroachievements.org/system/57/games</url>
-		<titlecount>33</titlecount>
-		<hashcount>36</hashcount>
+		<titlecount>36</titlecount>
+		<hashcount>39</hashcount>
 	</header>
 	<game name="Homebrew/2048-F8 (USA) (Aftermarket) (Unl)">
 		<category></category>
@@ -27,6 +27,14 @@
 		<rom name="3rees (USA) (Aftermarket) (Unl).bin" size="5444" crc="f203f9cf" md5="1a7590de88e21345f60ec2bc8b2b9269" sha1="bc2c1f82a6568d5724c46e152af1b846b869a3aa"/>
 		<url>https://retroachievements.org/game/10302/hashes</url>
 		<hash>1a7590de88e21345f60ec2bc8b2b9269</hash>
+	</game>
+	
+	<game name="Homebrew/Adventures of the Stalk of Celery! (World) (v42) (Chris Read)">
+		<category></category>
+		<description>Adventures of the Stalk of Celery! (World) (v42) (Chris Read)</description>
+		<rom name="Adventures of the Stalk of Celery! (World) (v42) (Chris Read).bin" size="30720" crc="84aa9472" md5="a7f0df802a1eaba82dd9cf2aa7ce3cd4" sha1="12b291950507fb7df148008f4da1c8141c48a008"/>
+		<url>https://retroachievements.org/game/37897/hashes</url>
+		<hash>a7f0df802a1eaba82dd9cf2aa7ce3cd4</hash>
 	</game>
 	
 	<game name="Homebrew/Boxing (USA) (Aftermarket) (Unl)">
@@ -202,6 +210,14 @@
 		<hash>4c10fa5c7316c59efa241043fc67dfa8</hash>
 	</game>
 	
+	<game name="Retail/Drag Race (USA)">
+		<category></category>
+		<description>Drag Race (USA)</description>
+		<rom name="Drag Race (USA).bin" size="2048" crc="6a64dda3" md5="f80af74b09d058b90e719bb7dfbdd50e" sha1="d915c8997f56ae09548498feecebf3c3bfcdf6c4"/>
+		<url>https://retroachievements.org/game/9016/hashes</url>
+		<hash>f80af74b09d058b90e719bb7dfbdd50e</hash>
+	</game>
+	
 	<game name="Retail/Maze, Jailbreak, Blind-man's-bluff, Trailblazer (USA)">
 		<category></category>
 		<description>Maze, Jailbreak, Blind-man's-bluff, Trailblazer (USA)</description>
@@ -302,6 +318,14 @@
 		<rom name="Galactic Space Wars, Lunar Lander (USA).bin" size="2048" crc="c8ef3410" md5="9e0711b140e22729687db1e1354980ab" sha1="fc3cadc90d73ce7e3b32b5c9a855d621e79c592a"/>
 		<url>https://retroachievements.org/game/10306/hashes</url>
 		<hash>9e0711b140e22729687db1e1354980ab</hash>
+	</game>
+	
+	<game name="Retail/Casino Poker (USA)">
+		<category></category>
+		<description>Casino Poker (USA)</description>
+		<rom name="Casino Poker (USA).bin" size="4096" crc="5aa30c12" md5="bb7f7bbbe21f142591cdcafa98d7f6e4" sha1="4540b1cfca461d6eba26754c34090aa74822a4bd"/>
+		<url>https://retroachievements.org/game/8995/hashes</url>
+		<hash>bb7f7bbbe21f142591cdcafa98d7f6e4</hash>
 	</game>
 	
 	<game name="Retail/Alien Invasion (USA)">

--- a/DATs/RetroAchievements (Subfolders)/RA - Fairchild Channel F.dat
+++ b/DATs/RetroAchievements (Subfolders)/RA - Fairchild Channel F.dat
@@ -5,8 +5,8 @@
 		<name>RA - Fairchild Channel F</name>
 		<description>Fairchild Channel F</description>
 		<category>Subfolders</category>
-		<version>20251225</version>
-		<date>25 December 2025</date>
+		<version>20260417</version>
+		<date>17 April 2026</date>
 		<author>AzgoRAth, NeoRetroGamer (Contributor), Jumphil (Contributor)</author>
 		<homepage>https://retroachievements.org</homepage>
 		<url>https://retroachievements.org/system/57/games</url>

--- a/DATs/RetroAchievements (Subfolders)/RA - Fairchild Channel F.dat
+++ b/DATs/RetroAchievements (Subfolders)/RA - Fairchild Channel F.dat
@@ -13,113 +13,113 @@
 		<titlecount>33</titlecount>
 		<hashcount>36</hashcount>
 	</header>
-	<game name="Homebrew/2048-F8 (USA) (Aftermarket)">
+	<game name="Homebrew/2048-F8 (USA) (Aftermarket) (Unl)">
 		<category></category>
-		<description>2048-F8 (USA) (Aftermarket)</description>
-		<rom name="2048-F8 (USA) (Aftermarket).bin" size="4702" crc="d737aadd" md5="88c078fe7229add65f031b601064543e" sha1="726676f0a204d05f8c2f754d6369cc384c3b7925"/>
+		<description>2048-F8 (USA) (Aftermarket) (Unl)</description>
+		<rom name="2048-F8 (USA) (Aftermarket) (Unl).bin" size="4702" crc="d737aadd" md5="88c078fe7229add65f031b601064543e" sha1="726676f0a204d05f8c2f754d6369cc384c3b7925"/>
 		<url>https://retroachievements.org/game/20267/hashes</url>
 		<hash>88c078fe7229add65f031b601064543e</hash>
 	</game>
 	
-	<game name="Homebrew/3rees (USA) (Aftermarket)">
+	<game name="Homebrew/3rees (USA) (Aftermarket) (Unl)">
 		<category></category>
-		<description>3rees (USA) (Aftermarket)</description>
-		<rom name="3rees (USA) (Aftermarket).bin" size="5444" crc="f203f9cf" md5="1a7590de88e21345f60ec2bc8b2b9269" sha1="bc2c1f82a6568d5724c46e152af1b846b869a3aa"/>
+		<description>3rees (USA) (Aftermarket) (Unl)</description>
+		<rom name="3rees (USA) (Aftermarket) (Unl).bin" size="5444" crc="f203f9cf" md5="1a7590de88e21345f60ec2bc8b2b9269" sha1="bc2c1f82a6568d5724c46e152af1b846b869a3aa"/>
 		<url>https://retroachievements.org/game/10302/hashes</url>
 		<hash>1a7590de88e21345f60ec2bc8b2b9269</hash>
 	</game>
 	
-	<game name="Homebrew/Boxing (USA) (Aftermarket)">
+	<game name="Homebrew/Boxing (USA) (Aftermarket) (Unl)">
 		<category></category>
-		<description>Boxing (USA) (Aftermarket)</description>
-		<rom name="Boxing (USA) (Aftermarket).bin" size="4096" crc="2e8aa291" md5="65a71a450cae1e60589efcf9b1a10456" sha1="f34411ab9d872bc5899dd6c6f1e9dd7daf9d37fd"/>
+		<description>Boxing (USA) (Aftermarket) (Unl)</description>
+		<rom name="Boxing (USA) (Aftermarket) (Unl).bin" size="4096" crc="2e8aa291" md5="65a71a450cae1e60589efcf9b1a10456" sha1="f34411ab9d872bc5899dd6c6f1e9dd7daf9d37fd"/>
 		<url>https://retroachievements.org/game/22567/hashes</url>
 		<hash>65a71a450cae1e60589efcf9b1a10456</hash>
 	</game>
 	
-	<game name="Homebrew/Centipede (USA) (v1.01) (Aftermarket)">
+	<game name="Homebrew/Centipede (USA) (v1.01) (Aftermarket) (Unl)">
 		<category></category>
-		<description>Centipede (USA) (v1.01) (Aftermarket)</description>
-		<rom name="Centipede (USA) (v1.01) (Aftermarket).bin" size="8105" crc="146e2370" md5="74c3961468a024d30095b0b4314e4eb0" sha1="87353ed1e8794f68378e16634908fe08c215f51c"/>
+		<description>Centipede (USA) (v1.01) (Aftermarket) (Unl)</description>
+		<rom name="Centipede (USA) (v1.01) (Aftermarket) (Unl).bin" size="8105" crc="146e2370" md5="74c3961468a024d30095b0b4314e4eb0" sha1="87353ed1e8794f68378e16634908fe08c215f51c"/>
 		<url>https://retroachievements.org/game/20237/hashes</url>
 		<hash>74c3961468a024d30095b0b4314e4eb0</hash>
 	</game>
 	
-	<game name="Homebrew/Fnvader (USA) (Aftermarket)">
+	<game name="Homebrew/Fnvader (USA) (Aftermarket) (Unl)">
 		<category></category>
-		<description>Fnvader (USA) (Aftermarket)</description>
-		<rom name="Fnvader (USA) (Aftermarket).bin" size="4349" crc="9e52e997" md5="5f2c587bf948be2b67cfae924e4508bb" sha1="e047f0406b46381b1ee94042d89131763daca8e7"/>
+		<description>Fnvader (USA) (Aftermarket) (Unl)</description>
+		<rom name="Fnvader (USA) (Aftermarket) (Unl).bin" size="4349" crc="9e52e997" md5="5f2c587bf948be2b67cfae924e4508bb" sha1="e047f0406b46381b1ee94042d89131763daca8e7"/>
 		<url>https://retroachievements.org/game/8985/hashes</url>
 		<hash>5f2c587bf948be2b67cfae924e4508bb</hash>
 	</game>
 	
-	<game name="Homebrew/Shark (USA) (Aftermarket)">
+	<game name="Homebrew/Shark (USA) (Aftermarket) (Unl)">
 		<category></category>
-		<description>Shark (USA) (Aftermarket)</description>
-		<rom name="Shark (USA) (Aftermarket).bin" size="3072" crc="e4bd59a1" md5="3f101828e1e64235a673f337addb3952" sha1="65a529a63407c7bc467af445af851207600f73be"/>
+		<description>Shark (USA) (Aftermarket) (Unl)</description>
+		<rom name="Shark (USA) (Aftermarket) (Unl).bin" size="3072" crc="e4bd59a1" md5="3f101828e1e64235a673f337addb3952" sha1="65a529a63407c7bc467af445af851207600f73be"/>
 		<url>https://retroachievements.org/game/22416/hashes</url>
 		<hash>3f101828e1e64235a673f337addb3952</hash>
 	</game>
 	
-	<game name="Homebrew/Space Race (USA) (v2023) (MikeBloke) (Aftermarket)">
+	<game name="Homebrew/Space Race (USA) (v2023) (Aftermarket) (MikeBloke)">
 		<category></category>
-		<description>Space Race (USA) (v2023) (MikeBloke) (Aftermarket)</description>
-		<rom name="Space Race (USA) (v2023) (MikeBloke) (Aftermarket).bin" size="4094" crc="55a76115" md5="b604104cacfda30315b60b00b3ca5ade" sha1="c6faa060ce3483f885205f9e1c070c5193712435"/>
+		<description>Space Race (USA) (v2023) (Aftermarket) (MikeBloke)</description>
+		<rom name="Space Race (USA) (v2023) (Aftermarket) (MikeBloke).bin" size="4094" crc="55a76115" md5="b604104cacfda30315b60b00b3ca5ade" sha1="c6faa060ce3483f885205f9e1c070c5193712435"/>
 		<url>https://retroachievements.org/game/22592/hashes</url>
 		<hash>b604104cacfda30315b60b00b3ca5ade</hash>
 	</game>
 	
-	<game name="Homebrew/Speed Race/Speed Race (USA) (Directional Controls) (Aftermarket)">
+	<game name="Homebrew/Speed Race/Speed Race (Directional Controls) (USA) (Aftermarket) (Unl)">
 		<category></category>
-		<description>Speed Race (USA) (Directional Controls) (Aftermarket)</description>
-		<rom name="Speed Race (USA) (Directional Controls) (Aftermarket).bin" size="2046" crc="29897ff8" md5="a7b94e4941ed058ff4af9cedc21b808b" sha1="99e4af26bbcc5df10995ffbcd73fd7cd8629611f"/>
+		<description>Speed Race (Directional Controls) (USA) (Aftermarket) (Unl)</description>
+		<rom name="Speed Race (Directional Controls) (USA) (Aftermarket) (Unl).bin" size="2046" crc="29897ff8" md5="a7b94e4941ed058ff4af9cedc21b808b" sha1="99e4af26bbcc5df10995ffbcd73fd7cd8629611f"/>
 		<url>https://retroachievements.org/game/9086/hashes</url>
 		<hash>a7b94e4941ed058ff4af9cedc21b808b</hash>
 	</game>
-	<game name="Homebrew/Speed Race/Speed Race (USA) (Twist Controls) (Aftermarket)">
+	<game name="Homebrew/Speed Race/Speed Race (Twist Controls) (USA) (Aftermarket) (Unl)">
 		<category></category>
-		<description>Speed Race (USA) (Twist Controls) (Aftermarket)</description>
-		<rom name="Speed Race (USA) (Twist Controls) (Aftermarket).bin" size="2046" crc="7635b11f" md5="b17b3c8744c4ac8a550212b016dcae5b" sha1="dadadc3a23347c6efe2f5f5020c269bbfcdea61a"/>
+		<description>Speed Race (Twist Controls) (USA) (Aftermarket) (Unl)</description>
+		<rom name="Speed Race (Twist Controls) (USA) (Aftermarket) (Unl).bin" size="2046" crc="7635b11f" md5="b17b3c8744c4ac8a550212b016dcae5b" sha1="dadadc3a23347c6efe2f5f5020c269bbfcdea61a"/>
 		<url>https://retroachievements.org/game/9086/hashes</url>
 		<hash>b17b3c8744c4ac8a550212b016dcae5b</hash>
 	</game>
 	
-	<game name="Homebrew/Submarine (USA) (Aftermarket)">
+	<game name="Homebrew/Submarine (USA) (Aftermarket) (Unl)">
 		<category></category>
-		<description>Submarine (USA) (Aftermarket)</description>
-		<rom name="Submarine (USA) (Aftermarket).bin" size="2046" crc="636b4ea1" md5="ece8baaf22ef385939e5c37e496cc60c" sha1="f8629ca015312dea362fbeaae32359431048c4e3"/>
+		<description>Submarine (USA) (Aftermarket) (Unl)</description>
+		<rom name="Submarine (USA) (Aftermarket) (Unl).bin" size="2046" crc="636b4ea1" md5="ece8baaf22ef385939e5c37e496cc60c" sha1="f8629ca015312dea362fbeaae32359431048c4e3"/>
 		<url>https://retroachievements.org/game/25416/hashes</url>
 		<hash>ece8baaf22ef385939e5c37e496cc60c</hash>
 	</game>
 	
-	<game name="Homebrew/Tents and Trees (USA) (Aftermarket)">
+	<game name="Homebrew/Tents and Trees (USA) (Aftermarket) (Unl)">
 		<category></category>
-		<description>Tents and Trees (USA) (Aftermarket)</description>
-		<rom name="Tents and Trees (USA) (Aftermarket).bin" size="3800" crc="02257e89" md5="0d272a1c51bfe148ad12105f3f39446d" sha1="f01a3956ec1d39018541a7be731776eaee191914"/>
+		<description>Tents and Trees (USA) (Aftermarket) (Unl)</description>
+		<rom name="Tents and Trees (USA) (Aftermarket) (Unl).bin" size="3800" crc="02257e89" md5="0d272a1c51bfe148ad12105f3f39446d" sha1="f01a3956ec1d39018541a7be731776eaee191914"/>
 		<url>https://retroachievements.org/game/20238/hashes</url>
 		<hash>0d272a1c51bfe148ad12105f3f39446d</hash>
 	</game>
 	
-	<game name="Homebrew/Pac-Man (USA) (v2006-02-20,b28) (Aftermarket)">
+	<game name="Homebrew/Pac-Man (USA) (v2006-02-20,b28) (Aftermarket) (Unl)">
 		<category></category>
-		<description>Pac-Man (USA) (v2006-02-20,b28) (Aftermarket)</description>
-		<rom name="Pac-Man (USA) (v2006-02-20,b28) (Aftermarket).bin" size="4096" crc="39ec3044" md5="1ae3fb8784c395c07bbd37bb44476871" sha1="633de00bb19b8dcc41658ba9601a3393aa044cf6"/>
+		<description>Pac-Man (USA) (v2006-02-20,b28) (Aftermarket) (Unl)</description>
+		<rom name="Pac-Man (USA) (v2006-02-20,b28) (Aftermarket) (Unl).bin" size="4096" crc="39ec3044" md5="1ae3fb8784c395c07bbd37bb44476871" sha1="633de00bb19b8dcc41658ba9601a3393aa044cf6"/>
 		<url>https://retroachievements.org/game/20217/hashes</url>
 		<hash>1ae3fb8784c395c07bbd37bb44476871</hash>
 	</game>
 	
-	<game name="Homebrew/Tetris (USA) (2004) (Trauner, Peter) (Aftermarket)">
+	<game name="Homebrew/Tetris (2004) (Trauner, Peter) (USA) (Aftermarket) (Unl)">
 		<category></category>
-		<description>Tetris (USA) (2004) (Trauner, Peter) (Aftermarket)</description>
-		<rom name="Tetris (USA) (2004) (Trauner, Peter) (Aftermarket).bin" size="4096" crc="44c556fa" md5="2aebeda05478e8b7f5c1eca037ac6c2f" sha1="98f73b2119ec2195117c6fcd290d8eb2d6410907"/>
+		<description>Tetris (2004) (Trauner, Peter) (USA) (Aftermarket) (Unl)</description>
+		<rom name="Tetris (2004) (Trauner, Peter) (USA) (Aftermarket) (Unl).bin" size="4096" crc="44c556fa" md5="2aebeda05478e8b7f5c1eca037ac6c2f" sha1="98f73b2119ec2195117c6fcd290d8eb2d6410907"/>
 		<url>https://retroachievements.org/game/20220/hashes</url>
 		<hash>2aebeda05478e8b7f5c1eca037ac6c2f</hash>
 	</game>
 	
-	<game name="Homebrew/wrdl-f (World) (Aftermarket)">
+	<game name="Homebrew/wrdl-f (USA) (Aftermarket) (Unl)">
 		<category></category>
-		<description>wrdl-f (World) (Aftermarket)</description>
-		<rom name="wrdl-f (World) (Aftermarket).rom" size="8161" crc="0ae07b86" md5="745479a23fb09dda3df3179c56719ca8" sha1="cbe3eef9b8de73f600f704b381b594be29c1f345"/>
+		<description>wrdl-f (USA) (Aftermarket) (Unl)</description>
+		<rom name="wrdl-f (USA) (Aftermarket) (Unl).rom" size="8161" crc="0ae07b86" md5="745479a23fb09dda3df3179c56719ca8" sha1="cbe3eef9b8de73f600f704b381b594be29c1f345"/>
 		<url>https://retroachievements.org/game/20231/hashes</url>
 		<hash>745479a23fb09dda3df3179c56719ca8</hash>
 	</game>

--- a/DATs/RetroAchievements (Subfolders)/RA - GCE Vectrex.dat
+++ b/DATs/RetroAchievements (Subfolders)/RA - GCE Vectrex.dat
@@ -13,113 +13,113 @@
 		<titlecount>32</titlecount>
 		<hashcount>34</hashcount>
 	</header>
-	<game name="Homebrew/Beluga Dreams (World) (v2019) (Aftermarket)">
+	<game name="Homebrew/Beluga Dreams (World) (v2019) (Aftermarket) (Unl)">
 		<category></category>
-		<description>Beluga Dreams (World) (v2019) (Aftermarket)</description>
-		<rom name="Beluga Dreams (World) (v2019) (Aftermarket).bin" size="10778" crc="1ea3b7b4" md5="e3f901324b064e0eec6aa5f655518afa" sha1="34c232b2a9d43a2c9e39f181f7a38872120e0296"/>
+		<description>Beluga Dreams (World) (v2019) (Aftermarket) (Unl)</description>
+		<rom name="Beluga Dreams (World) (v2019) (Aftermarket) (Unl).bin" size="10778" crc="1ea3b7b4" md5="e3f901324b064e0eec6aa5f655518afa" sha1="34c232b2a9d43a2c9e39f181f7a38872120e0296"/>
 		<url>https://retroachievements.org/game/25165/hashes</url>
 		<hash>e3f901324b064e0eec6aa5f655518afa</hash>
 	</game>
 	
-	<game name="Homebrew/Every Day Is Halloween (World) (v1.0) (Aftermarket)">
+	<game name="Homebrew/Every Day Is Halloween (World) (v1.0) (Aftermarket) (Unl)">
 		<category></category>
-		<description>Every Day Is Halloween (World) (v1.0) (Aftermarket)</description>
-		<rom name="Every Day Is Halloween (World) (v1.0) (Aftermarket).bin" size="32768" crc="277a58fa" md5="806c2ae784e05b12ec5f0c734c341765" sha1="2a5bcc2c7911a19c5a0e21124b0382cae31b2c88"/>
+		<description>Every Day Is Halloween (World) (v1.0) (Aftermarket) (Unl)</description>
+		<rom name="Every Day Is Halloween (World) (v1.0) (Aftermarket) (Unl).bin" size="32768" crc="277a58fa" md5="806c2ae784e05b12ec5f0c734c341765" sha1="2a5bcc2c7911a19c5a0e21124b0382cae31b2c88"/>
 		<url>https://retroachievements.org/game/25172/hashes</url>
 		<hash>806c2ae784e05b12ec5f0c734c341765</hash>
 	</game>
 	
-	<game name="Homebrew/Galaxy Wars - Space Launcher (World) (v1.0) (Aftermarket)">
+	<game name="Homebrew/Galaxy Wars - Space Launcher (World) (v1.0) (Aftermarket) (Unl)">
 		<category></category>
-		<description>Galaxy Wars - Space Launcher (World) (v1.0) (Aftermarket)</description>
-		<rom name="Galaxy Wars - Space Launcher (World) (v1.0) (Aftermarket).bin" size="32768" crc="da706fa2" md5="490674405868a95e614c9b492f18e45b" sha1="ab41c9c6ebf3e145b8c29f60754fbf733a1f0c2a"/>
+		<description>Galaxy Wars - Space Launcher (World) (v1.0) (Aftermarket) (Unl)</description>
+		<rom name="Galaxy Wars - Space Launcher (World) (v1.0) (Aftermarket) (Unl).bin" size="32768" crc="da706fa2" md5="490674405868a95e614c9b492f18e45b" sha1="ab41c9c6ebf3e145b8c29f60754fbf733a1f0c2a"/>
 		<url>https://retroachievements.org/game/25173/hashes</url>
 		<hash>490674405868a95e614c9b492f18e45b</hash>
 	</game>
 	
-	<game name="Homebrew/Hex (World) (v20140310) (Aftermarket)">
+	<game name="Homebrew/Hex (World) (v20140310) (Aftermarket) (Unl)">
 		<category></category>
-		<description>Hex (World) (v20140310) (Aftermarket)</description>
-		<rom name="Hex (World) (v20140310) (Aftermarket).bin" size="4224" crc="5b0b4605" md5="a5eed865b98c73f062c023e65b727c93" sha1="967f7d04235411c62a840a2f8fea8736bf1959f1"/>
+		<description>Hex (World) (v20140310) (Aftermarket) (Unl)</description>
+		<rom name="Hex (World) (v20140310) (Aftermarket) (Unl).bin" size="4224" crc="5b0b4605" md5="a5eed865b98c73f062c023e65b727c93" sha1="967f7d04235411c62a840a2f8fea8736bf1959f1"/>
 		<url>https://retroachievements.org/game/25177/hashes</url>
 		<hash>a5eed865b98c73f062c023e65b727c93</hash>
 	</game>
 	
-	<game name="Homebrew/Moon Knight (World) (v1.0) (Aftermarket)">
+	<game name="Homebrew/Moon Knight (World) (v1.0) (Aftermarket) (Unl)">
 		<category></category>
-		<description>Moon Knight (World) (v1.0) (Aftermarket)</description>
-		<rom name="Moon Knight (World) (v1.0) (Aftermarket).bin" size="7349" crc="76cf8a06" md5="92620a41b504045b9cc0d18434ce46a1" sha1="1fccfcf861abe27410a5683b0db6236bcb5bdadd"/>
+		<description>Moon Knight (World) (v1.0) (Aftermarket) (Unl)</description>
+		<rom name="Moon Knight (World) (v1.0) (Aftermarket) (Unl).bin" size="7349" crc="76cf8a06" md5="92620a41b504045b9cc0d18434ce46a1" sha1="1fccfcf861abe27410a5683b0db6236bcb5bdadd"/>
 		<url>https://retroachievements.org/game/26956/hashes</url>
 		<hash>92620a41b504045b9cc0d18434ce46a1</hash>
 	</game>
 	
-	<game name="Homebrew/Quartz's Quest (World) (v1.2) (Aftermarket)">
+	<game name="Homebrew/Quartz's Quest (World) (v1.2) (Aftermarket) (Unl)">
 		<category></category>
-		<description>Quartz's Quest (World) (v1.2) (Aftermarket)</description>
-		<rom name="Quartz's Quest (World) (v1.2) (Aftermarket).vec" size="23741" crc="cd9d1623" md5="e018b905f4a6be9b162beca5611c6010" sha1="f0e02abef5048902b523bd6ae58561fd1c0bbdf6"/>
+		<description>Quartz's Quest (World) (v1.2) (Aftermarket) (Unl)</description>
+		<rom name="Quartz's Quest (World) (v1.2) (Aftermarket) (Unl).vec" size="23741" crc="cd9d1623" md5="e018b905f4a6be9b162beca5611c6010" sha1="f0e02abef5048902b523bd6ae58561fd1c0bbdf6"/>
 		<url>https://retroachievements.org/game/23000/hashes</url>
 		<hash>e018b905f4a6be9b162beca5611c6010</hash>
 	</game>
 	
-	<game name="Homebrew/Storm Storm (World) (v2017) (Aftermarket)">
+	<game name="Homebrew/Storm Storm (World) (v2017) (Aftermarket) (Unl)">
 		<category></category>
-		<description>Storm Storm (World) (v2017) (Aftermarket)</description>
-		<rom name="Storm Storm (World) (v2017) (Aftermarket).bin" size="2374" crc="e4e4682d" md5="7e32709fa556f0df6b73adfa86de292f" sha1="49f7428cb459fb67d7a6a20feb17367c4693ce9a"/>
+		<description>Storm Storm (World) (v2017) (Aftermarket) (Unl)</description>
+		<rom name="Storm Storm (World) (v2017) (Aftermarket) (Unl).bin" size="2374" crc="e4e4682d" md5="7e32709fa556f0df6b73adfa86de292f" sha1="49f7428cb459fb67d7a6a20feb17367c4693ce9a"/>
 		<url>https://retroachievements.org/game/29174/hashes</url>
 		<hash>7e32709fa556f0df6b73adfa86de292f</hash>
 	</game>
 	
-	<game name="Homebrew/Turkey Hero (World) (v0.97) (Aftermarket)">
+	<game name="Homebrew/Turkey Hero (World) (v0.97) (Aftermarket) (Unl)">
 		<category></category>
-		<description>Turkey Hero (World) (v0.97) (Aftermarket)</description>
-		<rom name="Turkey Hero (World) (v0.97) (Aftermarket).bin" size="27356" crc="9882e195" md5="af799d55b39593eaa844df3235a51fd6" sha1="f02f1952dee7786b1f982987eac0347534889251"/>
+		<description>Turkey Hero (World) (v0.97) (Aftermarket) (Unl)</description>
+		<rom name="Turkey Hero (World) (v0.97) (Aftermarket) (Unl).bin" size="27356" crc="9882e195" md5="af799d55b39593eaa844df3235a51fd6" sha1="f02f1952dee7786b1f982987eac0347534889251"/>
 		<url>https://retroachievements.org/game/25170/hashes</url>
 		<hash>af799d55b39593eaa844df3235a51fd6</hash>
 	</game>
 	
-	<game name="Homebrew/Vec-Man/Vec-Man (World) (v2.5 - ParaJVE Version) (Aftermarket)">
+	<game name="Homebrew/Vec-Man/Vec-Man (World) (v2.5 - ParaJVE Version) (Aftermarket) (Unl)">
 		<category></category>
-		<description>Vec-Man (World) (v2.5 - ParaJVE Version) (Aftermarket)</description>
-		<rom name="Vec-Man (World) (v2.5 - ParaJVE Version) (Aftermarket).bin" size="27224" crc="cf1a247d" md5="bf8dc3f580487a61f8034c7defa79d9c" sha1="d6a7c33d812a8da3563aca8838797a693ac8d2d2"/>
+		<description>Vec-Man (World) (v2.5 - ParaJVE Version) (Aftermarket) (Unl)</description>
+		<rom name="Vec-Man (World) (v2.5 - ParaJVE Version) (Aftermarket) (Unl).bin" size="27224" crc="cf1a247d" md5="bf8dc3f580487a61f8034c7defa79d9c" sha1="d6a7c33d812a8da3563aca8838797a693ac8d2d2"/>
 		<url>https://retroachievements.org/game/25297/hashes</url>
 		<hash>bf8dc3f580487a61f8034c7defa79d9c</hash>
 	</game>
-	<game name="Homebrew/Vec-Man/Vec-Man (World) (v2.5) (Aftermarket)">
+	<game name="Homebrew/Vec-Man/Vec-Man (World) (v2.5) (Aftermarket) (Unl)">
 		<category></category>
-		<description>Vec-Man (World) (v2.5) (Aftermarket)</description>
-		<rom name="Vec-Man (World) (v2.5) (Aftermarket).bin" size="28171" crc="ebb800ed" md5="b4e85c762a44f2bdff59ddb9e4d35fb5" sha1="e271f67e5196353a141f2cf083de578dc695c220"/>
+		<description>Vec-Man (World) (v2.5) (Aftermarket) (Unl)</description>
+		<rom name="Vec-Man (World) (v2.5) (Aftermarket) (Unl).bin" size="28171" crc="ebb800ed" md5="b4e85c762a44f2bdff59ddb9e4d35fb5" sha1="e271f67e5196353a141f2cf083de578dc695c220"/>
 		<url>https://retroachievements.org/game/25297/hashes</url>
 		<hash>b4e85c762a44f2bdff59ddb9e4d35fb5</hash>
 	</game>
 	
-	<game name="Homebrew/Veccy Bird (World) (v1.5) (Aftermarket)">
+	<game name="Homebrew/Veccy Bird (World) (v1.5) (Aftermarket) (Unl)">
 		<category></category>
-		<description>Veccy Bird (World) (v1.5) (Aftermarket)</description>
-		<rom name="Veccy Bird (World) (v1.5) (Aftermarket).bin" size="5649" crc="f2c6e043" md5="0f91dc3b4acddf52baec0b12cb6ffe85" sha1="cbfd50fe2d558635286779ee7378d0a049d22393"/>
+		<description>Veccy Bird (World) (v1.5) (Aftermarket) (Unl)</description>
+		<rom name="Veccy Bird (World) (v1.5) (Aftermarket) (Unl).bin" size="5649" crc="f2c6e043" md5="0f91dc3b4acddf52baec0b12cb6ffe85" sha1="cbfd50fe2d558635286779ee7378d0a049d22393"/>
 		<url>https://retroachievements.org/game/19526/hashes</url>
 		<hash>0f91dc3b4acddf52baec0b12cb6ffe85</hash>
 	</game>
 	
-	<game name="Homebrew/Vector Pong (World) (v1.04) (Aftermarket)">
+	<game name="Homebrew/Vector Pong (World) (v1.04) (Aftermarket) (Unl)">
 		<category></category>
-		<description>Vector Pong (World) (v1.04) (Aftermarket)</description>
-		<rom name="Vector Pong (World) (v1.04) (Aftermarket).bin" size="10674" crc="10506248" md5="c92f22327e3ba5750d061d817531761a" sha1="1a06cee551489ef156332a62f43ac1a3794efc06"/>
+		<description>Vector Pong (World) (v1.04) (Aftermarket) (Unl)</description>
+		<rom name="Vector Pong (World) (v1.04) (Aftermarket) (Unl).bin" size="10674" crc="10506248" md5="c92f22327e3ba5750d061d817531761a" sha1="1a06cee551489ef156332a62f43ac1a3794efc06"/>
 		<url>https://retroachievements.org/game/20041/hashes</url>
 		<hash>c92f22327e3ba5750d061d817531761a</hash>
 	</game>
 	
-	<game name="Homebrew/Vectrexagon (World) (v1.2) (Aftermarket)">
+	<game name="Homebrew/Vectrexagon (World) (v1.2) (Aftermarket) (Unl)">
 		<category></category>
-		<description>Vectrexagon (World) (v1.2) (Aftermarket)</description>
-		<rom name="Vectrexagon (World) (v1.2) (Aftermarket).bin" size="24685" crc="bcc8e15b" md5="7fd05f6a7b71e44f8b6b2fc4519e39cb" sha1="224584ad88ffde4c2e7d1518cca417b72b2a71c7"/>
+		<description>Vectrexagon (World) (v1.2) (Aftermarket) (Unl)</description>
+		<rom name="Vectrexagon (World) (v1.2) (Aftermarket) (Unl).bin" size="24685" crc="bcc8e15b" md5="7fd05f6a7b71e44f8b6b2fc4519e39cb" sha1="224584ad88ffde4c2e7d1518cca417b72b2a71c7"/>
 		<url>https://retroachievements.org/game/22998/hashes</url>
 		<hash>7fd05f6a7b71e44f8b6b2fc4519e39cb</hash>
 	</game>
 	
-	<game name="Prototype/Dark Tower (USA) (Proto) (Fred Taft)">
+	<game name="Prototype/Dark Tower (USA) (Proto)">
 		<category></category>
-		<description>Dark Tower (USA) (Proto) (Fred Taft)</description>
-		<rom name="Dark Tower (USA) (Proto) (Fred Taft).vec" size="12288" crc="09f51459" md5="6ac9f45324a62a5edeb9a7a94c45ac50" sha1="fbfd58464d42986d10f1b37f321071ec74525469"/>
+		<description>Dark Tower (USA) (Proto)</description>
+		<rom name="Dark Tower (USA) (Proto).vec" size="12288" crc="09f51459" md5="6ac9f45324a62a5edeb9a7a94c45ac50" sha1="fbfd58464d42986d10f1b37f321071ec74525469"/>
 		<url>https://retroachievements.org/game/2120/hashes</url>
 		<hash>6ac9f45324a62a5edeb9a7a94c45ac50</hash>
 	</game>
@@ -132,10 +132,10 @@
 		<hash>9657037a461eee919462eb6a01879685</hash>
 	</game>
 	
-	<game name="Retail/Bedlam (USA, Europe)">
+	<game name="Retail/Bedlam (World)">
 		<category></category>
-		<description>Bedlam (USA, Europe)</description>
-		<rom name="Bedlam (USA, Europe).vec" size="4096" crc="a2fa649b" md5="268e75778f282d853d77acf42c6c8734" sha1="3ff3fa4feda6d562dedff2a10cfa8679d8318044"/>
+		<description>Bedlam (World)</description>
+		<rom name="Bedlam (World).vec" size="4096" crc="a2fa649b" md5="268e75778f282d853d77acf42c6c8734" sha1="3ff3fa4feda6d562dedff2a10cfa8679d8318044"/>
 		<url>https://retroachievements.org/game/4158/hashes</url>
 		<hash>268e75778f282d853d77acf42c6c8734</hash>
 	</game>
@@ -164,10 +164,10 @@
 		<hash>9b61653ed9dafd4cfb7f9d94404259ac</hash>
 	</game>
 	
-	<game name="Retail/Fortress of Narzod (USA, Europe)">
+	<game name="Retail/Fortress of Narzod (USA)">
 		<category></category>
-		<description>Fortress of Narzod (USA, Europe)</description>
-		<rom name="Fortress of Narzod (USA, Europe).vec" size="8192" crc="13a35c8a" md5="e65b3262e9447a747d93e0ccb1dbb7df" sha1="286e061331289b031de33725a4966c379c1df47f"/>
+		<description>Fortress of Narzod (USA)</description>
+		<rom name="Fortress of Narzod (USA).vec" size="8192" crc="13a35c8a" md5="e65b3262e9447a747d93e0ccb1dbb7df" sha1="286e061331289b031de33725a4966c379c1df47f"/>
 		<url>https://retroachievements.org/game/2215/hashes</url>
 		<hash>e65b3262e9447a747d93e0ccb1dbb7df</hash>
 	</game>
@@ -204,10 +204,10 @@
 		<hash>f94173910549038d4d8f329413a5aa54</hash>
 	</game>
 	
-	<game name="Retail/Scramble (USA, Europe)">
+	<game name="Retail/Scramble (World)">
 		<category></category>
-		<description>Scramble (USA, Europe)</description>
-		<rom name="Scramble (USA, Europe).vec" size="4096" crc="707c8ffe" md5="95370908561a782edf138df41ccb8f18" sha1="38e38b5c60466146d4648f8929b5ce3a08dcbe0d"/>
+		<description>Scramble (World)</description>
+		<rom name="Scramble (World).vec" size="4096" crc="707c8ffe" md5="95370908561a782edf138df41ccb8f18" sha1="38e38b5c60466146d4648f8929b5ce3a08dcbe0d"/>
 		<url>https://retroachievements.org/game/7495/hashes</url>
 		<hash>95370908561a782edf138df41ccb8f18</hash>
 	</game>
@@ -228,18 +228,18 @@
 		<hash>2decdf9f55df7fb99761b2fe51425e40</hash>
 	</game>
 	
-	<game name="Retail/Spike (USA, Europe)">
+	<game name="Retail/Spike (World)">
 		<category></category>
-		<description>Spike (USA, Europe)</description>
-		<rom name="Spike (USA, Europe).vec" size="8192" crc="62a61843" md5="5a90ab748f7b220edaf8c1d67e0bfe89" sha1="8bba6705e6f69f55ab6d105eac2fd5b0c0d16d9f"/>
+		<description>Spike (World)</description>
+		<rom name="Spike (World).vec" size="8192" crc="62a61843" md5="5a90ab748f7b220edaf8c1d67e0bfe89" sha1="8bba6705e6f69f55ab6d105eac2fd5b0c0d16d9f"/>
 		<url>https://retroachievements.org/game/6242/hashes</url>
 		<hash>5a90ab748f7b220edaf8c1d67e0bfe89</hash>
 	</game>
 	
-	<game name="Retail/Spinball (USA)">
+	<game name="Retail/Spinball (World)">
 		<category></category>
-		<description>Spinball (USA)</description>
-		<rom name="Spinball (USA).vec" size="8192" crc="02f41733" md5="ecc143f87a702af7a1786b58a78ace01" sha1="2e8285061530ccadfa2d8d11c374ae244449ebfa"/>
+		<description>Spinball (World)</description>
+		<rom name="Spinball (World).vec" size="8192" crc="02f41733" md5="ecc143f87a702af7a1786b58a78ace01" sha1="2e8285061530ccadfa2d8d11c374ae244449ebfa"/>
 		<url>https://retroachievements.org/game/7603/hashes</url>
 		<hash>ecc143f87a702af7a1786b58a78ace01</hash>
 	</game>
@@ -268,10 +268,10 @@
 		<hash>0b67a6339e9c1d8385e8fdfc48f447bc</hash>
 	</game>
 	
-	<game name="Retail/Web Wars/WebWars (USA)">
+	<game name="Retail/Web Wars/WebWars (World)">
 		<category></category>
-		<description>WebWars (USA)</description>
-		<rom name="WebWars (USA).vec" size="8192" crc="2ee20103" md5="a398c18b4ce87929471b559b2bc7e79f" sha1="08e2df9f7769c16a4d730adf8d659f8ea4be7f9d"/>
+		<description>WebWars (World)</description>
+		<rom name="WebWars (World).vec" size="8192" crc="2ee20103" md5="a398c18b4ce87929471b559b2bc7e79f" sha1="08e2df9f7769c16a4d730adf8d659f8ea4be7f9d"/>
 		<url>https://retroachievements.org/game/7017/hashes</url>
 		<hash>a398c18b4ce87929471b559b2bc7e79f</hash>
 	</game>

--- a/DATs/RetroAchievements (Subfolders)/RA - GCE Vectrex.dat
+++ b/DATs/RetroAchievements (Subfolders)/RA - GCE Vectrex.dat
@@ -5,8 +5,8 @@
 		<name>RA - GCE Vectrex</name>
 		<description>GCE Vectrex</description>
 		<category>Subfolders</category>
-		<version>20250622</version>
-		<date>22 June 2025</date>
+		<version>20260417</version>
+		<date>17 April 2026</date>
 		<author>AzgoRAth, NeoRetroGamer (Contributor), Jumphil (Contributor)</author>
 		<homepage>https://retroachievements.org</homepage>
 		<url>https://retroachievements.org/system/46/games</url>

--- a/DATs/RetroAchievements (Subfolders)/RA - GCE Vectrex.dat
+++ b/DATs/RetroAchievements (Subfolders)/RA - GCE Vectrex.dat
@@ -5,13 +5,13 @@
 		<name>RA - GCE Vectrex</name>
 		<description>GCE Vectrex</description>
 		<category>Subfolders</category>
-		<version>20260417</version>
-		<date>17 April 2026</date>
+		<version>20260426</version>
+		<date>26 April 2026</date>
 		<author>AzgoRAth, NeoRetroGamer (Contributor), Jumphil (Contributor)</author>
 		<homepage>https://retroachievements.org</homepage>
 		<url>https://retroachievements.org/system/46/games</url>
-		<titlecount>32</titlecount>
-		<hashcount>34</hashcount>
+		<titlecount>34</titlecount>
+		<hashcount>36</hashcount>
 	</header>
 	<game name="Homebrew/Beluga Dreams (World) (v2019) (Aftermarket) (Unl)">
 		<category></category>
@@ -35,6 +35,14 @@
 		<rom name="Galaxy Wars - Space Launcher (World) (v1.0) (Aftermarket) (Unl).bin" size="32768" crc="da706fa2" md5="490674405868a95e614c9b492f18e45b" sha1="ab41c9c6ebf3e145b8c29f60754fbf733a1f0c2a"/>
 		<url>https://retroachievements.org/game/25173/hashes</url>
 		<hash>490674405868a95e614c9b492f18e45b</hash>
+	</game>
+	
+	<game name="Homebrew/Gravitrex (World) (v2002) (Aftermarket) (Unl)">
+		<category></category>
+		<description>Gravitrex (World) (v2002) (Aftermarket) (Unl)</description>
+		<rom name="Gravitrex (World) (v2002) (Aftermarket) (Unl).vec" size="32768" crc="83b06492" md5="d5012ddedd1a9fe2b9d14e82eddaa55d" sha1="4120a657ce2a702371d09fe7fd58dc9cc4b7e5cb"/>
+		<url>https://retroachievements.org/game/25302/hashes</url>
+		<hash>d5012ddedd1a9fe2b9d14e82eddaa55d</hash>
 	</game>
 	
 	<game name="Homebrew/Hex (World) (v20140310) (Aftermarket) (Unl)">
@@ -75,6 +83,14 @@
 		<rom name="Turkey Hero (World) (v0.97) (Aftermarket) (Unl).bin" size="27356" crc="9882e195" md5="af799d55b39593eaa844df3235a51fd6" sha1="f02f1952dee7786b1f982987eac0347534889251"/>
 		<url>https://retroachievements.org/game/25170/hashes</url>
 		<hash>af799d55b39593eaa844df3235a51fd6</hash>
+	</game>
+	
+	<game name="Homebrew/Turkey Runner (World) (v0.90) (Aftermarket) (Brett Walach)">
+		<category></category>
+		<description>Turkey Runner (World) (v0.90) (Aftermarket) (Brett Walach)</description>
+		<rom name="Turkey Runner (World) (v0.90) (Aftermarket) (Brett Walach).vec" size="29693" crc="176e33d2" md5="f03893002b146a458c894cddadfc738d" sha1="e174c2d7180a850e6d4e586e141ceb64004661ab"/>
+		<url>https://retroachievements.org/game/25211/hashes</url>
+		<hash>f03893002b146a458c894cddadfc738d</hash>
 	</game>
 	
 	<game name="Homebrew/Vec-Man/Vec-Man (World) (v2.5 - ParaJVE Version) (Aftermarket) (Unl)">

--- a/DATs/RetroAchievements (Subfolders)/RA - Interton VC 4000.dat
+++ b/DATs/RetroAchievements (Subfolders)/RA - Interton VC 4000.dat
@@ -5,34 +5,34 @@
 		<name>RA - Interton VC 4000</name>
 		<description>Interton VC 4000</description>
 		<category>Subfolders</category>
-		<version>20251225</version>
-		<date>25 December 2025</date>
+		<version>20260428</version>
+		<date>28 April 2026</date>
 		<author>AzgoRAth, NeoRetroGamer (Contributor), Jumphil (Contributor)</author>
 		<homepage>https://retroachievements.org</homepage>
 		<url>https://retroachievements.org/system/74/games</url>
-		<titlecount>34</titlecount>
-		<hashcount>37</hashcount>
+		<titlecount>36</titlecount>
+		<hashcount>39</hashcount>
 	</header>
-	<game name="Homebrew/Canabalt (World) (v20180101) (senilyDeluxe) (Aftermarket)">
+	<game name="Homebrew/Canabalt (World) (v20180101) (Aftermarket) (senilyDeluxe)">
 		<category></category>
-		<description>Canabalt (World) (v20180101) (senilyDeluxe) (Aftermarket)</description>
-		<rom name="Canabalt (World) (v20180101) (senilyDeluxe) (Aftermarket).bin" size="4031" crc="c8311b54" md5="82c999bc12e38600ad9e70508d2dab8c" sha1="17c2adfd214a273114a9519ccce8d0a0de1efd38"/>
+		<description>Canabalt (World) (v20180101) (Aftermarket) (senilyDeluxe)</description>
+		<rom name="Canabalt (World) (v20180101) (Aftermarket) (senilyDeluxe).bin" size="4031" crc="c8311b54" md5="82c999bc12e38600ad9e70508d2dab8c" sha1="17c2adfd214a273114a9519ccce8d0a0de1efd38"/>
 		<url>https://retroachievements.org/game/24634/hashes</url>
 		<hash>82c999bc12e38600ad9e70508d2dab8c</hash>
 	</game>
 	
-	<game name="Homebrew/Flappy Birds 2 (World) (v20170530) (senilyDeluxe) (Aftermarket)">
+	<game name="Homebrew/Flappy Birds 2 (World) (v20170530) (Aftermarket) (senilyDeluxe)">
 		<category></category>
-		<description>Flappy Birds 2 (World) (v20170530) (senilyDeluxe) (Aftermarket)</description>
-		<rom name="Flappy Birds 2 (World) (v20170530) (senilyDeluxe) (Aftermarket).bin" size="2048" crc="e6f6830a" md5="312050bd0346e2bb54ec2308d7f281ef" sha1="7a78690e755a4634437e653a272b1ba17fad82f6"/>
+		<description>Flappy Birds 2 (World) (v20170530) (Aftermarket) (senilyDeluxe)</description>
+		<rom name="Flappy Birds 2 (World) (v20170530) (Aftermarket) (senilyDeluxe).bin" size="2048" crc="e6f6830a" md5="312050bd0346e2bb54ec2308d7f281ef" sha1="7a78690e755a4634437e653a272b1ba17fad82f6"/>
 		<url>https://retroachievements.org/game/24633/hashes</url>
 		<hash>312050bd0346e2bb54ec2308d7f281ef</hash>
 	</game>
 	
-	<game name="Homebrew/Tetris (World) (v20200922) (SimonAugustin) (Aftermarket)">
+	<game name="Homebrew/Tetris (World) (v20200922) (Aftermarket) (SimonAugustin)">
 		<category></category>
-		<description>Tetris (World) (v20200922) (SimonAugustin) (Aftermarket)</description>
-		<rom name="Tetris (World) (v20200922) (SimonAugustin) (Aftermarket).bin" size="4096" crc="9cbb3c2e" md5="0cbac5ace65a63613587152d2ef87311" sha1="abeb3c61a7818914b3219ee74018a8d2d3176dcc"/>
+		<description>Tetris (World) (v20200922) (Aftermarket) (SimonAugustin)</description>
+		<rom name="Tetris (World) (v20200922) (Aftermarket) (SimonAugustin).bin" size="4096" crc="9cbb3c2e" md5="0cbac5ace65a63613587152d2ef87311" sha1="abeb3c61a7818914b3219ee74018a8d2d3176dcc"/>
 		<url>https://retroachievements.org/game/24632/hashes</url>
 		<hash>0cbac5ace65a63613587152d2ef87311</hash>
 	</game>
@@ -75,6 +75,14 @@
 		<rom name="Circus (Europe).bin" size="2048" crc="0ab80f3e" md5="7f3916bb403c86b40f12847362ef3904" sha1="cff0b7066669aad1e35803767fd98ecef4ea162d"/>
 		<url>https://retroachievements.org/game/21629/hashes</url>
 		<hash>7f3916bb403c86b40f12847362ef3904</hash>
+	</game>
+	
+	<game name="Retail/Come Come (Europe) (19xx) (Palson)">
+		<category></category>
+		<description>Come Come (Europe) (19xx) (Palson)</description>
+		<rom name="Come Come (Europe) (19xx) (Palson).bin" size="4096" crc="bd90fca7" md5="dd262c3a2df1e273c012cd076ce7b8bf" sha1="a739e585b6e7a58295b656d81d7781f9646546ca"/>
+		<url>https://retroachievements.org/game/24635/hashes</url>
+		<hash>dd262c3a2df1e273c012cd076ce7b8bf</hash>
 	</game>
 	
 	<game name="Retail/Crazy Crab (World) (1983) (Radofin Electronics)">
@@ -228,10 +236,10 @@
 		<hash>dff0d751378612a78da0dfa015374664</hash>
 	</game>
 	
-	<game name="Retail/Munch &amp; Crunch/Munch &amp; Crunch - Enhanced (World) (1982) (Voltmace - Derek Andrews)">
+	<game name="Retail/Munch &amp; Crunch/Munch &amp; Crunch (World) (1982) (Voltmace - Derek Andrews) (Enhanced)">
 		<category></category>
-		<description>Munch &amp; Crunch - Enhanced (World) (1982) (Voltmace - Derek Andrews)</description>
-		<rom name="Munch &amp; Crunch - Enhanced (World) (1982) (Voltmace - Derek Andrews).bin" size="4121" crc="2bef2934" md5="266bd11247683b0ff4da015fb305b9c4" sha1="157cf0085e8663efe33f3a64415bf8e2bbe3f70f"/>
+		<description>Munch &amp; Crunch (World) (1982) (Voltmace - Derek Andrews) (Enhanced)</description>
+		<rom name="Munch &amp; Crunch (World) (1982) (Voltmace - Derek Andrews) (Enhanced).bin" size="4121" crc="2bef2934" md5="266bd11247683b0ff4da015fb305b9c4" sha1="157cf0085e8663efe33f3a64415bf8e2bbe3f70f"/>
 		<url>https://retroachievements.org/game/24639/hashes</url>
 		<hash>266bd11247683b0ff4da015fb305b9c4</hash>
 	</game>

--- a/DATs/RetroAchievements (Subfolders)/RA - Magnavox Odyssey 2.dat
+++ b/DATs/RetroAchievements (Subfolders)/RA - Magnavox Odyssey 2.dat
@@ -5,34 +5,34 @@
 		<name>RA - Magnavox Odyssey 2</name>
 		<description>Magnavox Odyssey 2</description>
 		<category>Subfolders</category>
-		<version>20251225</version>
-		<date>25 December 2025</date>
+		<version>20260428</version>
+		<date>28 April 2025</date>
 		<author>AzgoRAth, NeoRetroGamer (Contributor), Jumphil (Contributor)</author>
 		<homepage>https://retroachievements.org</homepage>
 		<url>https://retroachievements.org/system/23/games</url>
-		<titlecount>29</titlecount>
-		<hashcount>36</hashcount>
+		<titlecount>31</titlecount>
+		<hashcount>37</hashcount>
 	</header>
-	<game name="Homebrew/Boobs (World) (v1.3a) (Chris Read) (Aftermarket)">
+	<game name="Homebrew/Boobs (Homebrew) (v1.3a) (Chris Read)">
 		<category></category>
-		<description>Boobs (World) (v1.3a) (Chris Read) (Aftermarket)</description>
-		<rom name="Boobs (World) (v1.3a) (Chris Read) (Aftermarket).bin" size="2048" crc="9847f5d0" md5="2ff854e7bdaf79ebacc70610d7129a63" sha1="0d6b44e2445dbb3bf70c4e05f222822845c29762"/>
+		<description>Boobs (Homebrew) (v1.3a) (Chris Read)</description>
+		<rom name="Boobs (Homebrew) (v1.3a) (Chris Read).bin" size="2048" crc="9847f5d0" md5="2ff854e7bdaf79ebacc70610d7129a63" sha1="0d6b44e2445dbb3bf70c4e05f222822845c29762"/>
 		<url>https://retroachievements.org/game/20059/hashes</url>
 		<hash>2ff854e7bdaf79ebacc70610d7129a63</hash>
 	</game>
 	
-	<game name="Homebrew/GoSub 2 (World) (v3.7) (Chris Read) (Unl) (Aftermarket)">
+	<game name="Homebrew/GoSub 2 (World) (v3.7) (Aftermarket) (Unl) (Chris Read)">
 		<category></category>
-		<description>GoSub 2 (World) (v3.7) (Chris Read) (Unl) (Aftermarket)</description>
-		<rom name="GoSub 2 (World) (v3.7) (Chris Read) (Unl) (Aftermarket).bin" size="2048" crc="f5fa8d31" md5="262eb2a2a228c9d5877af6acc13b6cec" sha1="85a44a99b254d92a7433ee46e4caa91483d7fea2"/>
+		<description>GoSub 2 (World) (v3.7) (Aftermarket) (Unl) (Chris Read)</description>
+		<rom name="GoSub 2 (World) (v3.7) (Aftermarket) (Unl) (Chris Read).bin" size="2048" crc="f5fa8d31" md5="262eb2a2a228c9d5877af6acc13b6cec" sha1="85a44a99b254d92a7433ee46e4caa91483d7fea2"/>
 		<url>https://retroachievements.org/game/20045/hashes</url>
 		<hash>262eb2a2a228c9d5877af6acc13b6cec</hash>
 	</game>
 	
-	<game name="Homebrew/Happy Bird (World) (Rafael Cardoso-2600 Connection) (Aftermarket)">
+	<game name="Homebrew/Happy Bird (Homebrew) (Rafael Cardoso-2600 Connection)">
 		<category></category>
-		<description>Happy Bird (World) (Rafael Cardoso-2600 Connection) (Aftermarket)</description>
-		<rom name="Happy Bird (World) (Rafael Cardoso-2600 Connection) (Aftermarket).bin" size="4096" crc="28e6901b" md5="449661989f35b981901fef21330e005c" sha1="2b34ef0e1a8c0371f00a33d6950e0807f3cb886e"/>
+		<description>Happy Bird (Homebrew) (Rafael Cardoso-2600 Connection)</description>
+		<rom name="Happy Bird (Homebrew) (Rafael Cardoso-2600 Connection).bin" size="4096" crc="28e6901b" md5="449661989f35b981901fef21330e005c" sha1="2b34ef0e1a8c0371f00a33d6950e0807f3cb886e"/>
 		<url>https://retroachievements.org/game/20039/hashes</url>
 		<hash>449661989f35b981901fef21330e005c</hash>
 	</game>

--- a/DATs/RetroAchievements (Subfolders)/RA - Mattel Intellivision.dat
+++ b/DATs/RetroAchievements (Subfolders)/RA - Mattel Intellivision.dat
@@ -5,74 +5,82 @@
 		<name>RA - Mattel Intellivision</name>
 		<description>Mattel Intellivision</description>
 		<category>Subfolders</category>
-		<version>20260227</version>
-		<date>27 February 2026</date>
+		<version>20260428</version>
+		<date>28 April 2026</date>
 		<author>AzgoRAth, NeoRetroGamer (Contributor), Jumphil (Contributor)</author>
 		<homepage>https://retroachievements.org</homepage>
 		<url>https://retroachievements.org/system/45/games</url>
-		<titlecount>36</titlecount>
-		<hashcount>36</hashcount>
+		<titlecount>38</titlecount>
+		<hashcount>38</hashcount>
 	</header>
-	<game name="Homebrew/4-Tris (World) (Aftermarket)">
+	<game name="Homebrew/4-Tris (World) (Aftermarket) (Unl)">
 		<category></category>
-		<description>4-Tris (World) (Aftermarket)</description>
-		<rom name="4-Tris (World) (Aftermarket).rom" size="16441" crc="7fd2a11a" md5="bdf1ffe620738e6f54740ded6e175693" sha1="17efae049715528a2a85c9412f5c0ec4824f3557"/>
+		<description>4-Tris (World) (Aftermarket) (Unl)</description>
+		<rom name="4-Tris (World) (Aftermarket) (Unl).rom" size="16441" crc="7fd2a11a" md5="bdf1ffe620738e6f54740ded6e175693" sha1="17efae049715528a2a85c9412f5c0ec4824f3557"/>
 		<url>https://retroachievements.org/game/17712/hashes</url>
 		<hash>bdf1ffe620738e6f54740ded6e175693</hash>
 	</game>
 	
-	<game name="Homebrew/Antarctic Tales - Enhanced Edition (World) (v20210707) (Aftermarket)">
+	<game name="Homebrew/Antarctic Tales (World) (Aftermarket) (Unl)">
 		<category></category>
-		<description>Antarctic Tales - Enhanced Edition (World) (v20210707) (Aftermarket)</description>
-		<rom name="Antarctic Tales - Enhanced Edition (World) (v20210707) (Aftermarket).rom" size="77396" crc="9ba5a798" md5="27051b100ff89970d8a24291e8b6cb67" sha1="bc8d07fc972770dabf6a77ef73a7be15c0521c3e"/>
+		<description>Antarctic Tales (World) (Aftermarket) (Unl)</description>
+		<rom name="Antarctic Tales (World) (Aftermarket) (Unl).rom" size="77396" crc="9ba5a798" md5="27051b100ff89970d8a24291e8b6cb67" sha1="bc8d07fc972770dabf6a77ef73a7be15c0521c3e"/>
 		<url>https://retroachievements.org/game/24890/hashes</url>
 		<hash>27051b100ff89970d8a24291e8b6cb67</hash>
 	</game>
 	
-	<game name="Homebrew/DK Arcade (World) (Intelligentvision) (Aftermarket)">
+	<game name="Homebrew/DK Arcade (World) (Intelligentvision) (Aftermarket) (Unl)">
 		<category></category>
-		<description>DK Arcade (World) (Intelligentvision) (Aftermarket)</description>
-		<rom name="DK Arcade (World) (Intelligentvision) (Aftermarket).int" size="49152" crc="ef1bec41" md5="607d0a959d1c64f6feb66433b4171d5f" sha1="fad323a8c88b7155ec4456e8909fe21e3cdbbe07"/>
+		<description>DK Arcade (World) (Intelligentvision) (Aftermarket) (Unl)</description>
+		<rom name="DK Arcade (World) (Intelligentvision) (Aftermarket) (Unl).int" size="49152" crc="ef1bec41" md5="607d0a959d1c64f6feb66433b4171d5f" sha1="fad323a8c88b7155ec4456e8909fe21e3cdbbe07"/>
 		<url>https://retroachievements.org/game/31167/hashes</url>
 		<hash>607d0a959d1c64f6feb66433b4171d5f</hash>
 	</game>
 	
-	<game name="Homebrew/Flapee Bird (World) (Aftermarket)">
+	<game name="Homebrew/Flapee Bird (World) (Aftermarket) (Unl)">
 		<category></category>
-		<description>Flapee Bird (World) (Aftermarket)</description>
-		<rom name="Flapee Bird (World) (Aftermarket).bin" size="9728" crc="9c7de352" md5="5b065c30735a4b0feee2aac48ebaf633" sha1="f91d4507baf41626d839308659e68de048c767c8"/>
+		<description>Flapee Bird (World) (Aftermarket) (Unl)</description>
+		<rom name="Flapee Bird (World) (Aftermarket) (Unl).bin" size="9728" crc="9c7de352" md5="5b065c30735a4b0feee2aac48ebaf633" sha1="f91d4507baf41626d839308659e68de048c767c8"/>
 		<url>https://retroachievements.org/game/20037/hashes</url>
 		<hash>5b065c30735a4b0feee2aac48ebaf633</hash>
 	</game>
 	
-	<game name="Homebrew/Princess Quest (World) (Aftermarket)">
+	<game name="Homebrew/Intellivania (World) (Aftermarket) (Unl)">
 		<category></category>
-		<description>Princess Quest (World) (Aftermarket)</description>
-		<rom name="Princess Quest (World) (Aftermarket).rom" size="76357" crc="38e9ef48" md5="ed8e8a3c94b8f3b59579047a297cac32" sha1="a9841432efa5aeea64ca44155a034efaded2201e"/>
+		<description>Intellivania (World) (Aftermarket) (Unl)</description>
+		<rom name="Intellivania (World) (Aftermarket) (Unl).int" size="88656" crc="b7a33e8e" md5="7431758763b233ab4b14155c4cf0f001" sha1="6490f5cfba9bd69c05ad89a0d1a7a9d71bc0e43a"/>
+		<url>https://retroachievements.org/game/33028/hashes</url>
+		<hash>7431758763b233ab4b14155c4cf0f001</hash>
+	</game>
+	
+	<game name="Homebrew/Princess Quest (World) (Aftermarket) (Unl)">
+		<category></category>
+		<description>Princess Quest (World) (Aftermarket) (Unl)</description>
+		<rom name="Princess Quest (World) (Aftermarket) (Unl).rom" size="76357" crc="38e9ef48" md5="ed8e8a3c94b8f3b59579047a297cac32" sha1="a9841432efa5aeea64ca44155a034efaded2201e"/>
 		<url>https://retroachievements.org/game/22456/hashes</url>
 		<hash>ed8e8a3c94b8f3b59579047a297cac32</hash>
 	</game>
 	
-	<game name="Homebrew/Pumpkin Attack (World) (Aftermarket)">
+	<game name="Homebrew/Pumpkin Attack (World) (Aftermarket) (Unl)">
 		<category></category>
-		<description>Pumpkin Attack (World) (Aftermarket)</description>
-		<rom name="Pumpkin Attack (World) (Aftermarket).rom" size="26685" crc="26e0bcaa" md5="b593690baa3643df336e2385e9c24dfe" sha1="4288013866edc5e398fc58ba2c686fe2ac781fb4"/>
+		<description>Pumpkin Attack (World) (Aftermarket) (Unl)</description>
+		<rom name="Pumpkin Attack (World) (Aftermarket) (Unl).rom" size="26685" crc="26e0bcaa" md5="b593690baa3643df336e2385e9c24dfe" sha1="4288013866edc5e398fc58ba2c686fe2ac781fb4"/>
 		<url>https://retroachievements.org/game/29151/hashes</url>
 		<hash>b593690baa3643df336e2385e9c24dfe</hash>
 	</game>
 	
-	<game name="Homebrew/Tag-Along Todd (World) (v3.13) (Aftermarket)">
+	<game name="Homebrew/Tag-Along Todd (World) (v3.13) (Aftermarket) (Unl)">
 		<category></category>
-		<description>Tag-Along Todd (World) (v3.13) (Aftermarket)</description>
-		<rom name="Tag-Along Todd (World) (v3.13) (Aftermarket).bin" size="10752" crc="1ecdd51b" md5="57e82ac5ef6c1bff0b810874c4b2c30c" sha1="9e1666a68d50bb4a1f618cc2f9bcd7dfbadc8188"/>
+		<description>Tag-Along Todd (World) (v3.13) (Aftermarket) (Unl)</description>
+		<rom name="Tag-Along Todd (World) (v3.13) (Aftermarket) (Unl).bin" size="10752" crc="1ecdd51b" md5="57e82ac5ef6c1bff0b810874c4b2c30c" sha1="9e1666a68d50bb4a1f618cc2f9bcd7dfbadc8188"/>
 		<url>https://retroachievements.org/game/20050/hashes</url>
 		<hash>57e82ac5ef6c1bff0b810874c4b2c30c</hash>
 	</game>
 	
-	<game name="Homebrew/Ultimate Pong (World) (v9.0) (Aftermarket)">
+	<game name="Homebrew/Ultimate Pong (World) (v9.0) (Aftermarket) (Unl)">
 		<category></category>
-		<description>Ultimate Pong (World) (v9.0) (Aftermarket)</description>
-		<rom name="Ultimate Pong (World) (v9.0) (Aftermarket).bin" size="57925" crc="30575596" md5="03a20a7287601bdae309693ca4f6f0b9" sha1="9469d231a910777b8f46276fa497dc75d7a6a88f"/>
+		<description>Ultimate Pong (World) (v9.0) (Aftermarket) (Unl)</description>
+		<rom name="Ultimate Pong (World) (v9.0) (Aftermarket) (Unl).bin" size="57925" crc="30575596" md5="03a20a7287601bdae309693ca4f6f0b9" sha1="9469d231a910777b8f46276fa497dc75d7a6a88f"/>
 		<url>https://retroachievements.org/game/24463/hashes</url>
 		<hash>03a20a7287601bdae309693ca4f6f0b9</hash>
 	</game>

--- a/DATs/RetroAchievements (Subfolders)/RA - Mega Duck.dat
+++ b/DATs/RetroAchievements (Subfolders)/RA - Mega Duck.dat
@@ -5,104 +5,120 @@
 		<name>RA - Mega Duck</name>
 		<description>Mega Duck</description>
 		<category>Subfolders</category>
-		<version>20251225</version>
-		<date>25 December 2025</date>
+		<version>20262704</version>
+		<date>27 April 2026</date>
 		<author>AzgoRAth, NeoRetroGamer (Contributor), Jumphil (Contributor)</author>
 		<homepage>https://retroachievements.org</homepage>
 		<url>https://retroachievements.org/system/69/games</url>
-		<titlecount>32</titlecount>
-		<hashcount>35</hashcount>
+		<titlecount>34</titlecount>
+		<hashcount>37</hashcount>
 	</header>
-	<game name="Homebrew/Aerial (World) (Inufuto) (Aftermarket)">
+	<game name="Homebrew/Aerial (World) (Aftermarket) (Inufuto)">
 		<category></category>
-		<description>Aerial (World) (Inufuto) (Aftermarket)</description>
-		<rom name="Aerial (World) (Inufuto) (Aftermarket).bin" size="16384" crc="6a324ac3" md5="b26307c090211b85672a3a71ef3bd53f" sha1="6028dd33cf97caffa9025010399127ee5fd75669"/>
+		<description>Aerial (World) (Aftermarket) (Inufuto)</description>
+		<rom name="Aerial (World) (Aftermarket) (Inufuto).bin" size="16384" crc="6a324ac3" md5="b26307c090211b85672a3a71ef3bd53f" sha1="6028dd33cf97caffa9025010399127ee5fd75669"/>
 		<url>https://retroachievements.org/game/31453/hashes</url>
 		<hash>b26307c090211b85672a3a71ef3bd53f</hash>
 	</game>
 	
-	<game name="Homebrew/Black Castle (World) (Aftermarket)">
+	<game name="Homebrew/Battlot (World) (v20241021) (Aftermarket) (Inufuto)">
 		<category></category>
-		<description>Black Castle (World) (Aftermarket)</description>
-		<rom name="Black Castle (World) (Aftermarket).bin" size="65536" crc="312fec34" md5="0b41ffad1c44a3252f2ece6ee0f502f3" sha1="96ec1dea0b406905338a6ff71149662a132b3209"/>
+		<description>Battlot (World) (v20241021) (Aftermarket) (Inufuto)</description>
+		<rom name="Battlot (World) (v20241021) (Aftermarket) (Inufuto).bin" size="16384" crc="0972ECFD" md5="d1d16b0fe4d8dc9e08a10bdc92b2e732" sha1="e8931410ea6aa36bfe38775c84217ffaec9ac420"/>
+		<url>https://retroachievements.org/game/38259/hashes</url>
+		<hash>d1d16b0fe4d8dc9e08a10bdc92b2e732</hash>
+	</game>
+	
+	<game name="Homebrew/Black Castle (World) (Aftermarket) (Unl)">
+		<category></category>
+		<description>Black Castle (World) (Aftermarket) (Unl)</description>
+		<rom name="Black Castle (World) (Aftermarket) (Unl).bin" size="65536" crc="312fec34" md5="0b41ffad1c44a3252f2ece6ee0f502f3" sha1="96ec1dea0b406905338a6ff71149662a132b3209"/>
 		<url>https://retroachievements.org/game/24049/hashes</url>
 		<hash>0b41ffad1c44a3252f2ece6ee0f502f3</hash>
 	</game>
 	
-	<game name="Homebrew/Cacorm Mini (World) (v20241020) (Inufuto) (Aftermarket)">
+	<game name="Homebrew/Cacorm Mini (World) (v20241020) (Aftermarket) (Inufuto)">
 		<category></category>
-		<description>Cacorm Mini (World) (v20241020) (Inufuto) (Aftermarket)</description>
-		<rom name="Cacorm Mini (World) (v20241020) (Inufuto) (Aftermarket).bin" size="16384" crc="58c63d67" md5="30fd14ff650d9d77a601ec4ce21b6f52" sha1="e929debce85d951da3ab5302f58ba75615e4e066"/>
+		<description>Cacorm Mini (World) (v20241020) (Aftermarket) (Inufuto)</description>
+		<rom name="Cacorm Mini (World) (v20241020) (Aftermarket) (Inufuto).bin" size="16384" crc="58c63d67" md5="30fd14ff650d9d77a601ec4ce21b6f52" sha1="e929debce85d951da3ab5302f58ba75615e4e066"/>
 		<url>https://retroachievements.org/game/33639/hashes</url>
 		<hash>30fd14ff650d9d77a601ec4ce21b6f52</hash>
 	</game>
 	
-	<game name="Homebrew/Canyon Racer/Canyon Racer (World) (v0.7.6) (Aftermarket)">
+	<game name="Homebrew/Canyon Racer/Canyon Racer (World) (v0.7.6) (Aftermarket) (Unl)">
 		<category></category>
-		<description>Canyon Racer (World) (v0.7.6) (Aftermarket)</description>
-		<rom name="Canyon Racer (World) (v0.7.6) (Aftermarket).bin" size="32768" crc="f794d8cf" md5="b5811af4ede6a03dc85aa23da8bbc1e7" sha1="50b382e0f54f98311809a292913a885c85b9f694"/>
+		<description>Canyon Racer (World) (v0.7.6) (Aftermarket) (Unl)</description>
+		<rom name="Canyon Racer (World) (v0.7.6) (Aftermarket) (Unl).bin" size="32768" crc="f794d8cf" md5="b5811af4ede6a03dc85aa23da8bbc1e7" sha1="50b382e0f54f98311809a292913a885c85b9f694"/>
 		<url>https://retroachievements.org/game/24082/hashes</url>
 		<hash>b5811af4ede6a03dc85aa23da8bbc1e7</hash>
 	</game>
-	<game name="Homebrew/Canyon Racer/Canyon Racer (World) (v0.7.6) (No FX) (Aftermarket)">
+	<game name="Homebrew/Canyon Racer/Canyon Racer (World) (v0.7.6) (No FX) (Aftermarket) (Unl)">
 		<category></category>
-		<description>Canyon Racer (World) (v0.7.6) (No FX) (Aftermarket)</description>
-		<rom name="Canyon Racer (World) (v0.7.6) (No FX) (Aftermarket).bin" size="32768" crc="9fa63c31" md5="fcb469fa705f23d493689e2f7312d822" sha1="f85491c8ed827483f45ff5f13ee5e195fdcaff1e"/>
+		<description>Canyon Racer (World) (v0.7.6) (No FX) (Aftermarket) (Unl)</description>
+		<rom name="Canyon Racer (World) (v0.7.6) (No FX) (Aftermarket) (Unl).bin" size="32768" crc="9fa63c31" md5="fcb469fa705f23d493689e2f7312d822" sha1="f85491c8ed827483f45ff5f13ee5e195fdcaff1e"/>
 		<url>https://retroachievements.org/game/24082/hashes</url>
 		<hash>fcb469fa705f23d493689e2f7312d822</hash>
 	</game>
 	
-	<game name="Homebrew/Hopman (World) (Inufuto) (Aftermarket)">
+	<game name="Homebrew/Hopman (World) (Aftermarket) (Inufuto)">
 		<category></category>
-		<description>Hopman (World) (Inufuto) (Aftermarket)</description>
-		<rom name="Hopman (World) (Inufuto) (Aftermarket).bin" size="16384" crc="a7b2ba02" md5="115a709d9d524c1ea5d36c65d9b8dbe8" sha1="95102b92b7d52332f0ea7ad04e36b92561687958"/>
+		<description>Hopman (World) (Aftermarket) (Inufuto)</description>
+		<rom name="Hopman (World) (Aftermarket) (Inufuto).bin" size="16384" crc="a7b2ba02" md5="115a709d9d524c1ea5d36c65d9b8dbe8" sha1="95102b92b7d52332f0ea7ad04e36b92561687958"/>
 		<url>https://retroachievements.org/game/31699/hashes</url>
 		<hash>115a709d9d524c1ea5d36c65d9b8dbe8</hash>
 	</game>
 	
-	<game name="Homebrew/Max Pirate (World) (v20240504) (Aftermarket)">
+	<game name="Homebrew/Max Pirate (World) (v20240504) (Aftermarket) (Unl)">
 		<category></category>
-		<description>Max Pirate (World) (v20240504) (Aftermarket)</description>
-		<rom name="Max Pirate (World) (v20240504) (Aftermarket).bin" size="32768" crc="2eacd525" md5="ac17e9ce88054fde0132242e23873923" sha1="539b18cd46ef8090b01941d37cc5c0c731c332d6"/>
+		<description>Max Pirate (World) (v20240504) (Aftermarket) (Unl)</description>
+		<rom name="Max Pirate (World) (v20240504) (Aftermarket) (Unl).bin" size="32768" crc="2eacd525" md5="ac17e9ce88054fde0132242e23873923" sha1="539b18cd46ef8090b01941d37cc5c0c731c332d6"/>
 		<url>https://retroachievements.org/game/30904/hashes</url>
 		<hash>ac17e9ce88054fde0132242e23873923</hash>
 	</game>
 	
-	<game name="Homebrew/Pegged (World) (v1.2) (Under4Mhz) (Aftermarket)">
+	<game name="Homebrew/Pegged (World) (v1.2) (Aftermarket) (Under4Mhz)">
 		<category></category>
-		<description>Pegged (World) (v1.2) (Under4Mhz) (Aftermarket)</description>
-		<rom name="Pegged (World) (v1.2) (Under4Mhz) (Aftermarket).cb" size="32768" crc="c8afd1d2" md5="651635c9b964bdd1fde94adf6b6f38ec" sha1="ab492a3c815a9558d29a90dfa837c571080616fd"/>
+		<description>Pegged (World) (v1.2) (Aftermarket) (Under4Mhz)</description>
+		<rom name="Pegged (World) (v1.2) (Aftermarket) (Under4Mhz).cb" size="32768" crc="c8afd1d2" md5="651635c9b964bdd1fde94adf6b6f38ec" sha1="ab492a3c815a9558d29a90dfa837c571080616fd"/>
 		<url>https://retroachievements.org/game/24917/hashes</url>
 		<hash>651635c9b964bdd1fde94adf6b6f38ec</hash>
 	</game>
 	
-	<game name="Homebrew/Penguin Migrant (World) (SunnyChowTheGuy) (Aftermarket)">
+	<game name="Homebrew/Penguin Migrant (World) (Aftermarket) (SunnyChowTheGuy)">
 		<category></category>
-		<description>Penguin Migrant (World) (SunnyChowTheGuy) (Aftermarket)</description>
-		<rom name="Penguin Migrant (World) (SunnyChowTheGuy) (Aftermarket).bin" size="32768" crc="94237a93" md5="4f78024f2102292fc03929cdd957319e" sha1="017606edfb915e320c2ff10a7aa12d205cb0b5dc"/>
+		<description>Penguin Migrant (World) (Aftermarket) (SunnyChowTheGuy)</description>
+		<rom name="Penguin Migrant (World) (Aftermarket) (SunnyChowTheGuy).bin" size="32768" crc="94237a93" md5="4f78024f2102292fc03929cdd957319e" sha1="017606edfb915e320c2ff10a7aa12d205cb0b5dc"/>
 		<url>https://retroachievements.org/game/29153/hashes</url>
 		<hash>4f78024f2102292fc03929cdd957319e</hash>
 	</game>
 	
-	<game name="Homebrew/Vexed/Vexed (World) (v1.08) (Aftermarket)">
+	<game name="Homebrew/Sushi Nights (World) (v1.0) (Aftermarket) (untoxa)">
 		<category></category>
-		<description>Vexed (World) (v1.08) (Aftermarket)</description>
-		<rom name="Vexed (World) (v1.08) (Aftermarket).bin" size="32768" crc="2279c9c8" md5="ae0594e43294653ecf58532316c59cca" sha1="2dfa082c008b6c4725184aff1727d794cd655cbd"/>
+		<description>Sushi Nights (World) (v1.0) (Aftermarket) (untoxa)</description>
+		<rom name="Sushi Nights (World) (v1.0) (Aftermarket) (untoxa).duck" size="131072" crc="B3CDC6BB" md5="accd004bb0b89a4e113fc7b3cca7d973" sha1="ea5c87ce1f83daccfa4b6d9902aea48b1ca107c2"/>
+		<url>https://retroachievements.org/game/38351/hashes</url>
+		<hash>accd004bb0b89a4e113fc7b3cca7d973</hash>
+	</game>
+	
+	<game name="Homebrew/Vexed/Vexed (World) (v1.08) (Aftermarket) (Unl)">
+		<category></category>
+		<description>Vexed (World) (v1.08) (Aftermarket) (Unl)</description>
+		<rom name="Vexed (World) (v1.08) (Aftermarket) (Unl).bin" size="32768" crc="2279c9c8" md5="ae0594e43294653ecf58532316c59cca" sha1="2dfa082c008b6c4725184aff1727d794cd655cbd"/>
 		<url>https://retroachievements.org/game/24916/hashes</url>
 		<hash>ae0594e43294653ecf58532316c59cca</hash>
 	</game>
-	<game name="Homebrew/Vexed/Vexed (World) (v1.09) (Aftermarket)">
+	<game name="Homebrew/Vexed/Vexed (World) (v1.09) (Aftermarket) (Unl)">
 		<category></category>
-		<description>Vexed (World) (v1.09) (Aftermarket)</description>
-		<rom name="Vexed (World) (v1.09) (Aftermarket).bin" size="32768" crc="02a2467e" md5="cb62769fabf28a722bf21e41844cc053" sha1="a168115a121188634a6435278f7746c2e398e498"/>
+		<description>Vexed (World) (v1.09) (Aftermarket) (Unl)</description>
+		<rom name="Vexed (World) (v1.09) (Aftermarket) (Unl).bin" size="32768" crc="02a2467e" md5="cb62769fabf28a722bf21e41844cc053" sha1="a168115a121188634a6435278f7746c2e398e498"/>
 		<url>https://retroachievements.org/game/24916/hashes</url>
 		<hash>cb62769fabf28a722bf21e41844cc053</hash>
 	</game>
 	
-	<game name="Homebrew/Waternet (World) (Aftermarket)">
+	<game name="Homebrew/Waternet (World) (Aftermarket) (Unl)">
 		<category></category>
-		<description>Waternet (World) (Aftermarket)</description>
-		<rom name="Waternet (World) (Aftermarket).bin" size="32768" crc="d6f9dcfa" md5="34d48f05d6be1d64b22732fc03b19301" sha1="c7181cee5ddee2f665d21c38b5a44838f7b8f511"/>
+		<description>Waternet (World) (Aftermarket) (Unl)</description>
+		<rom name="Waternet (World) (Aftermarket) (Unl).bin" size="32768" crc="d6f9dcfa" md5="34d48f05d6be1d64b22732fc03b19301" sha1="c7181cee5ddee2f665d21c38b5a44838f7b8f511"/>
 		<url>https://retroachievements.org/game/20221/hashes</url>
 		<hash>34d48f05d6be1d64b22732fc03b19301</hash>
 	</game>

--- a/DATs/RetroAchievements (Subfolders)/RA - NEC TurboGrafx-16.dat
+++ b/DATs/RetroAchievements (Subfolders)/RA - NEC TurboGrafx-16.dat
@@ -5,34 +5,34 @@
 		<name>RA - NEC TurboGrafx-16</name>
 		<description>NEC TurboGrafx-16</description>
 		<category>Subfolders</category>
-		<version>20260208</version>
-		<date>08 February 2026</date>
+		<version>20260429</version>
+		<date>29 April 2026</date>
 		<author>AzgoRAth, NeoRetroGamer (Contributor), Jumphil (Contributor)</author>
 		<homepage>https://retroachievements.org</homepage>
 		<url>https://retroachievements.org/system/8/games</url>
-		<titlecount>136</titlecount>
-		<hashcount>177/228</hashcount>
+		<titlecount>134</titlecount>
+		<hashcount>176/227</hashcount>
 	</header>
-	<game name="Homebrew/Atlantean (World) (Aftermarket)">
+	<game name="Homebrew/Atlantean (World) (Aftermarket) (Unl)">
 		<category>TurboGrafx</category>
-		<description>Atlantean (World) (Aftermarket)</description>
-		<rom name="Atlantean (World) (Aftermarket).pce" size="524800" crc="ef596649" md5="b407192527c9472a489fea0aeac00f8d" sha1="d76f867256c3ff192b0cde8a1c685d558c2066c2"/>
+		<description>Atlantean (World) (Aftermarket) (Unl)</description>
+		<rom name="Atlantean (World) (Aftermarket) (Unl).pce" size="524288" crc="fddc5814" md5="29abb6671fc4a4217473cd955cb76ae8" sha1="518341d715c8fb651edc1bacb2848dbb0acae097"/>
 		<url>https://retroachievements.org/game/18084/hashes</url>
 		<hash>29abb6671fc4a4217473cd955cb76ae8</hash>
 	</game>
 	
-	<game name="Homebrew/HuZERO (World) (Aftermarket)">
+	<game name="Homebrew/HuZERO (World) (Aftermarket) (Unl)">
 		<category>TurboGrafx</category>
-		<description>HuZERO (World) (Aftermarket)</description>
-		<rom name="HuZERO (World) (Aftermarket).pce" size="262144" crc="2871c4c0" md5="b14e14493c7c45b8d61c160236ac0f85" sha1="4328878a56f4cf34a9b62f6a4a2982bb57d695e8"/>
+		<description>HuZERO (World) (Aftermarket) (Unl)</description>
+		<rom name="HuZERO (World) (Aftermarket) (Unl).pce" size="262144" crc="2871c4c0" md5="b14e14493c7c45b8d61c160236ac0f85" sha1="4328878a56f4cf34a9b62f6a4a2982bb57d695e8"/>
 		<url>https://retroachievements.org/game/20488/hashes</url>
 		<hash>b14e14493c7c45b8d61c160236ac0f85</hash>
 	</game>
 	
-	<game name="Homebrew/Maria/Maria (World) (No-Intro) (Aftermarket)">
+	<game name="Homebrew/Maria/Maria (World) (Aftermarket) (Unl)">
 		<category>TurboGrafx</category>
-		<description>Maria (World) (No-Intro) (Aftermarket)</description>
-		<rom name="Maria (World) (No-Intro) (Aftermarket).pce" size="491520" crc="192a5924" md5="de25a604c8f59525ef061ac5bb3567bd" sha1="cf64c8cf29c11310924362ff03dd7d8120debf8f"/>
+		<description>Maria (World) (Aftermarket) (Unl)</description>
+		<rom name="Maria (World) (Aftermarket) (Unl).pce" size="491520" crc="192a5924" md5="de25a604c8f59525ef061ac5bb3567bd" sha1="cf64c8cf29c11310924362ff03dd7d8120debf8f"/>
 		<url>https://retroachievements.org/game/13669/hashes</url>
 		<hash>de25a604c8f59525ef061ac5bb3567bd</hash>
 	</game>
@@ -44,58 +44,58 @@
 		<hash>79e74b94605e3842fe5958bc0e37cc3f</hash>
 	</game>
 	
-	<game name="Homebrew/Mega Man 2 (World) (v0.87) (Aftermarket)">
+	<game name="Homebrew/Mega Man 2 (World) (v0.87) (Proto) (Aftermarket) (Unl)">
 		<category>TurboGrafx</category>
-		<description>Mega Man 2 (World) (v0.87) (Aftermarket)</description>
-		<rom name="Mega Man 2 (World) (v0.87) (Aftermarket).pce" size="524288" crc="2fc86aff" md5="83079124c8efce1eee4c3a34a89441a5" sha1="3bad484a43682a11b79bb5e3ca39755922807e19"/>
+		<description>Mega Man 2 (World) (v0.87) (Proto) (Aftermarket) (Unl)</description>
+		<rom name="Mega Man 2 (World) (v0.87) (Proto) (Aftermarket) (Unl).pce" size="524288" crc="2fc86aff" md5="83079124c8efce1eee4c3a34a89441a5" sha1="3bad484a43682a11b79bb5e3ca39755922807e19"/>
 		<url>https://retroachievements.org/game/18611/hashes</url>
 		<hash>83079124c8efce1eee4c3a34a89441a5</hash>
 	</game>
 	
-	<game name="Subset/Mega Man 2 (World) (v0.87) (Aftermarket) (Subset - Bonus)">
+	<game name="Subset/Mega Man 2 (World) (v0.87) (Proto) (Aftermarket) (Unl) (Subset - Bonus)">
 		<category>TurboGrafx</category>
-		<description>Mega Man 2 (World) (v0.87) (Aftermarket) (Subset - Bonus)</description>
-		<rom name="Mega Man 2 (World) (v0.87) (Aftermarket) (Subset - Bonus).pce" size="524288" crc="64c67a8f" md5="e68b97f12b236e7b827dc77f98d29cd5" sha1="a6ac4b848d3d0d168c22a1d9954d636c5528aaea"/>
+		<description>Mega Man 2 (World) (v0.87) (Proto) (Aftermarket) (Unl) (Subset - Bonus)</description>
+		<rom name="Mega Man 2 (World) (v0.87) (Proto) (Aftermarket) (Unl) (Subset - Bonus).pce" size="524288" crc="64c67a8f" md5="e68b97f12b236e7b827dc77f98d29cd5" sha1="a6ac4b848d3d0d168c22a1d9954d636c5528aaea"/>
 		<url>https://retroachievements.org/game/18643/hashes</url>
 		<hash>e68b97f12b236e7b827dc77f98d29cd5</hash>
 	</game>
 	
-	<game name="Homebrew/Nantettatte Engine (World) (Aftermarket)">
+	<game name="Homebrew/Nantettatte Engine (World) (Aftermarket) (Unl)">
 		<category>TurboGrafx</category>
-		<description>Nantettatte Engine (World) (Aftermarket)</description>
-		<rom name="Nantettatte Engine (World) (Aftermarket).pce" size="262144" crc="3974fb41" md5="a8264f87f8c2a9a97fe46c2fa3249deb" sha1="4b9cd0d86b6406142a306adcafe6ae9efbcd9b6b"/>
+		<description>Nantettatte Engine (World) (Aftermarket) (Unl)</description>
+		<rom name="Nantettatte Engine (World) (Aftermarket) (Unl).pce" size="262144" crc="3974fb41" md5="a8264f87f8c2a9a97fe46c2fa3249deb" sha1="4b9cd0d86b6406142a306adcafe6ae9efbcd9b6b"/>
 		<url>https://retroachievements.org/game/28326/hashes</url>
 		<hash>a8264f87f8c2a9a97fe46c2fa3249deb</hash>
 	</game>
 	
-	<game name="Homebrew/Reflectron (World) (Aftermarket)">
+	<game name="Homebrew/Reflectron (World) (Aftermarket) (Unl)">
 		<category>TurboGrafx</category>
-		<description>Reflectron (World) (Aftermarket)</description>
-		<rom name="Reflectron (World) (Aftermarket).pce" size="262144" crc="6a3727e2" md5="40540be45e4f802344cfcb9f43b527b0" sha1="982a7627233c30cc23b85c666536d69faf3c2dbc"/>
+		<description>Reflectron (World) (Aftermarket) (Unl)</description>
+		<rom name="Reflectron (World) (Aftermarket) (Unl).pce" size="262144" crc="6a3727e2" md5="40540be45e4f802344cfcb9f43b527b0" sha1="982a7627233c30cc23b85c666536d69faf3c2dbc"/>
 		<url>https://retroachievements.org/game/26878/hashes</url>
 		<hash>40540be45e4f802344cfcb9f43b527b0</hash>
 	</game>
 	
-	<game name="Homebrew/Santatlantean (World) (Aftermarket)">
+	<game name="Homebrew/Santatlantean (World) (Aftermarket) (Unl)">
 		<category>TurboGrafx</category>
-		<description>Santatlantean (World) (Aftermarket)</description>
-		<rom name="Santatlantean (World) (Aftermarket).pce" size="524288" crc="f436b4ac" md5="12c9cb92855185a15b315435ec8eadf7" sha1="9e79251dc99a24ea03a2a431cac26a66e6c6a543"/>
+		<description>Santatlantean (World) (Aftermarket) (Unl)</description>
+		<rom name="Santatlantean (World) (Aftermarket) (Unl).pce" size="524288" crc="f436b4ac" md5="12c9cb92855185a15b315435ec8eadf7" sha1="9e79251dc99a24ea03a2a431cac26a66e6c6a543"/>
 		<url>https://retroachievements.org/game/18085/hashes</url>
 		<hash>12c9cb92855185a15b315435ec8eadf7</hash>
 	</game>
 	
-	<game name="Homebrew/Great Fumo Binning, The (World) (Aftermarket)">
+	<game name="Homebrew/Great Fumo Binning, The (World) (Aftermarket) (Unl)">
 		<category>TurboGrafx</category>
-		<description>Great Fumo Binning, The (World) (Aftermarket)</description>
-		<rom name="Great Fumo Binning, The (World) (Aftermarket).pce" size="73728" crc="8f92ac67" md5="de60a6746244d36a1bc9b8cc0abc481b" sha1="f81162d7eee56ab1e69abc33d7048e8ad127f11f"/>
+		<description>Great Fumo Binning, The (World) (Aftermarket) (Unl)</description>
+		<rom name="Great Fumo Binning, The (World) (Aftermarket) (Unl).pce" size="73728" crc="8f92ac67" md5="de60a6746244d36a1bc9b8cc0abc481b" sha1="f81162d7eee56ab1e69abc33d7048e8ad127f11f"/>
 		<url>https://retroachievements.org/game/25183/hashes</url>
 		<hash>de60a6746244d36a1bc9b8cc0abc481b</hash>
 	</game>
 	
-	<game name="Homebrew/Tongueman's Logic (World) (Aftermarket)">
+	<game name="Homebrew/Tongueman's Logic (World) (Aftermarket) (Unl)">
 		<category>TurboGrafx</category>
-		<description>Tongueman's Logic (World) (Aftermarket)</description>
-		<rom name="Tongueman's Logic (World) (Aftermarket).pce" size="524288" crc="fe451c22" md5="15107f07c3b7a65a7e784add44349961" sha1="456c4a07b6e5d0a4e231aad3a479f97f3df02e21"/>
+		<description>Tongueman's Logic (World) (Aftermarket) (Unl)</description>
+		<rom name="Tongueman's Logic (World) (Aftermarket) (Unl).pce" size="524288" crc="fe451c22" md5="15107f07c3b7a65a7e784add44349961" sha1="456c4a07b6e5d0a4e231aad3a479f97f3df02e21"/>
 		<url>https://retroachievements.org/game/14467/hashes</url>
 		<hash>15107f07c3b7a65a7e784add44349961</hash>
 	</game>
@@ -107,10 +107,10 @@
 		<url>https://retroachievements.org/game/9565/hashes</url>
 		<hash>71c5cffeab1cb60a04b5e77a338117ac</hash>
 	</game>
-	<game name="Unlicensed/Lady Sword/Lady Sword (Japan) (En) (v1.0) (EsperKnight,filler,Grant Laughlin,Tomaitheous) (Unl)">
+	<game name="Unlicensed/Lady Sword/Lady Sword - Ryakudatsu Sareta 10-nin no Otome (Japan) (En) (v1.0) (EsperKnight,filler,Grant Laughlin,Tomaitheous) (Unl)">
 		<category>TurboGrafx</category>
-		<description>Lady Sword (Japan) (En) (v1.0) (EsperKnight,filler,Grant Laughlin,Tomaitheous) (Unl)</description>
-		<rom name="Lady Sword (Japan) (En) (v1.0) (EsperKnight,filler,Grant Laughlin,Tomaitheous) (Unl).pce" size="1048576" crc="ff461dcd" md5="6b56d548b740cdbbc2993b5a8f03ffd4" sha1="7e6cf9b1c8ef96147129d297e0b39a2217d499f1"/>
+		<description>Lady Sword - Ryakudatsu Sareta 10-nin no Otome (Japan) (En) (v1.0) (EsperKnight,filler,Grant Laughlin,Tomaitheous) (Unl)</description>
+		<rom name="Lady Sword - Ryakudatsu Sareta 10-nin no Otome (Japan) (En) (v1.0) (EsperKnight,filler,Grant Laughlin,Tomaitheous) (Unl).pce" size="1048576" crc="ff461dcd" md5="6b56d548b740cdbbc2993b5a8f03ffd4" sha1="7e6cf9b1c8ef96147129d297e0b39a2217d499f1"/>
 		<url>https://retroachievements.org/game/9565/hashes</url>
 		<hash>6b56d548b740cdbbc2993b5a8f03ffd4</hash>
 	</game>
@@ -350,6 +350,28 @@
 		<hash>60bb0116b706fc30a76840ed0b5da458</hash>
 	</game>
 
+	<game name="Retail/City Hunter/City Hunter (Japan)">
+		<category>TurboGrafx</category>
+		<description>City Hunter (Japan)</description>
+		<rom name="City Hunter (Japan).pce" size="393216" crc="f91b055f" md5="32a6a97aa9e69fa8091bfda374609922" sha1="8265cb33901609ec1cf156b8e0c7fc3884bc1acd"/>
+		<url>https://retroachievements.org/game/9171/hashes</url>
+		<hash>32a6a97aa9e69fa8091bfda374609922</hash>
+	</game>
+	<game name="Retail/City Hunter/City Hunter (Japan) (En) (v1.1) (filler,cabbage)">
+		<category>TurboGrafx</category>
+		<description>City Hunter (Japan) (En) (v1.1) (filler,cabbage)</description>
+		<rom name="City Hunter (Japan) (En) (v1.1) (filler,cabbage).pce" size="393216" crc="23f3df33" md5="9dcfed2ba5b59fa8f97387e01bb96f66" sha1="b92baeda4e71a0f348e2294a9deaa6fafa7bef6f"/>
+		<url>https://retroachievements.org/game/9171/hashes</url>
+		<hash>9dcfed2ba5b59fa8f97387e01bb96f66</hash>
+	</game>
+	<game name="Retail/City Hunter/City Hunter (Japan) (Fr) (v1.0) (Terminus Traduction)">
+		<category>TurboGrafx</category>
+		<description>City Hunter (Japan) (Fr) (v1.0) (Terminus Traduction)</description>
+		<rom name="City Hunter (Japan) (Fr) (v1.0) (Terminus Traduction).pce" size="393216" crc="6301c5af" md5="ff76216eb5d8c0d773f20b3cb220f5ff" sha1="49e1113c8b3d8f4ea67c7a426a4c20d6967367ac"/>
+		<url>https://retroachievements.org/game/9171/hashes</url>
+		<hash>ff76216eb5d8c0d773f20b3cb220f5ff</hash>
+	</game>
+
 	<game name="Retail/Columns (Japan)">
 		<category>TurboGrafx</category>
 		<description>Columns (Japan)</description>
@@ -567,10 +589,10 @@
 		<url>https://retroachievements.org/game/13409/hashes</url>
 		<hash>b928568fd7258f90b5ac410c7f65c48c</hash>
 	</game>
-	<game name="Retail/Energy/Energy (Japan) (En) (v1.01) (onionzoo, cabbage)">
+	<game name="Retail/Energy/Energy (Japan) (En) (v1.01) (onionzoo,cabbage)">
 		<category>TurboGrafx</category>
-		<description>Energy (Japan) (En) (v1.01) (onionzoo, cabbage)</description>
-		<rom name="Energy (Japan) (En) (v1.01) (onionzoo, cabbage).pce" size="262144" crc="370fa62c" md5="7fc06f2e3131c1cfcddff6c69d54b8b9" sha1="d237dff176ef5193885fdc4abb469f6435dd2aac"/>
+		<description>Energy (Japan) (En) (v1.01) (onionzoo,cabbage)</description>
+		<rom name="Energy (Japan) (En) (v1.01) (onionzoo,cabbage).pce" size="262144" crc="370fa62c" md5="7fc06f2e3131c1cfcddff6c69d54b8b9" sha1="d237dff176ef5193885fdc4abb469f6435dd2aac"/>
 		<url>https://retroachievements.org/game/13409/hashes</url>
 		<hash>7fc06f2e3131c1cfcddff6c69d54b8b9</hash>
 	</game>
@@ -613,10 +635,10 @@
 		<url>https://retroachievements.org/game/7193/hashes</url>
 		<hash>3e0cd9af31efe11acf733fb15dc31131</hash>
 	</game>
-	<game name="Retail/Fushigi no Yume no Alice/Fushigi no Yume no Alice (Japan) (En) (v1.0)">
+	<game name="Retail/Fushigi no Yume no Alice/Fushigi no Yume no Alice (Japan) (En) (v1.0) (Dave Shadoff,filler,MooZ,Diogo Ribeiro)">
 		<category>TurboGrafx</category>
-		<description>Fushigi no Yume no Alice (Japan) (En) (v1.0)</description>
-		<rom name="Fushigi no Yume no Alice (Japan) (En) (v1.0).pce" size="393216" crc="c21f25c4" md5="4ed3f4820b238d5c1cb49dcaf24f382a" sha1="9868a3049e6bbc75a537415a2db8bbda17dc1864"/>
+		<description>Fushigi no Yume no Alice (Japan) (En) (v1.0) (Dave Shadoff,filler,MooZ,Diogo Ribeiro)</description>
+		<rom name="Fushigi no Yume no Alice (Japan) (En) (v1.0) (Dave Shadoff,filler,MooZ,Diogo Ribeiro).pce" size="393216" crc="c21f25c4" md5="4ed3f4820b238d5c1cb49dcaf24f382a" sha1="9868a3049e6bbc75a537415a2db8bbda17dc1864"/>
 		<url>https://retroachievements.org/game/7193/hashes</url>
 		<hash>4ed3f4820b238d5c1cb49dcaf24f382a</hash>
 	</game>
@@ -684,10 +706,10 @@
 		<hash>16fe78b1630a790bee6755e3c850a366</hash>
 	</game>
 	
-	<game name="Retail/Hanii in the Sky (Japan) (En) (v1.0) (filler, cabbage)">
+	<game name="Retail/Hanii in the Sky (Japan) (En) (v1.0) (filler,cabbage)">
 		<category>TurboGrafx</category>
-		<description>Hanii in the Sky (Japan) (En) (v1.0) (filler, cabbage)</description>
-		<rom name="Hanii in the Sky (Japan) (En) (v1.0) (filler, cabbage).pce" size="262144" crc="d1dc2f66" md5="015b8a761e1c3a8d0d474ef7e1063a55" sha1="ef3e666d73293e766e88c77e8bdfa331399789a6"/>
+		<description>Hanii in the Sky (Japan) (En) (v1.0) (filler,cabbage)</description>
+		<rom name="Hanii in the Sky (Japan) (En) (v1.0) (filler,cabbage).pce" size="262144" crc="d1dc2f66" md5="015b8a761e1c3a8d0d474ef7e1063a55" sha1="ef3e666d73293e766e88c77e8bdfa331399789a6"/>
 		<url>https://retroachievements.org/game/18741/hashes</url>
 		<hash>015b8a761e1c3a8d0d474ef7e1063a55</hash>
 	</game>
@@ -792,7 +814,7 @@
 		<url>https://retroachievements.org/game/2306/hashes</url>
 		<hash>74d9f1bd96ba2690ed4cb989ebaeb948</hash>
 	</game>
-
+	
 	<game name="Retail/Makai Hakkenden - Shada/Makai Hakkenden - Shada (Japan)">
 		<category>TurboGrafx</category>
 		<description>Makai Hakkenden - Shada (Japan)</description>
@@ -800,10 +822,10 @@
 		<url>https://retroachievements.org/game/22775/hashes</url>
 		<hash>06c9c65e0e1c0669be28cc99ace61f54</hash>
 	</game>
-	<game name="Retail/Makai Hakkenden - Shada/Makai Hakkenden - Shada (Japan) (En) (v1.0) (Shubibiman, cabbage)">
+	<game name="Retail/Makai Hakkenden - Shada/Makai Hakkenden - Shada (Japan) (En) (v1.0) (Shubibiman,cabbage)">
 		<category>TurboGrafx</category>
-		<description>Makai Hakkenden - Shada (Japan) (En) (v1.0) (Shubibiman, cabbage)</description>
-		<rom name="Makai Hakkenden - Shada (Japan) (En) (v1.0) (Shubibiman, cabbage).pce" size="262144" crc="017de16d" md5="6b33184f381d3bfc9870f5ad55b8c78a" sha1="448991d34538c40cb8d7738ed1093b86c4dd1cfd"/>
+		<description>Makai Hakkenden - Shada (Japan) (En) (v1.0) (Shubibiman,cabbage)</description>
+		<rom name="Makai Hakkenden - Shada (Japan) (En) (v1.0) (Shubibiman,cabbage).pce" size="262144" crc="017de16d" md5="6b33184f381d3bfc9870f5ad55b8c78a" sha1="448991d34538c40cb8d7738ed1093b86c4dd1cfd"/>
 		<url>https://retroachievements.org/game/22775/hashes</url>
 		<hash>6b33184f381d3bfc9870f5ad55b8c78a</hash>
 	</game>
@@ -823,10 +845,10 @@
 		<url>https://retroachievements.org/game/19923/hashes</url>
 		<hash>887b9fa8296ff3c98839e11cc7039763</hash>
 	</game>
-	<game name="Retail/Maerchen Maze/Maerchen Maze (Japan) (En) (v1.1) (MooZ &amp; Shubibiman)">
+	<game name="Retail/Maerchen Maze/Maerchen Maze (Japan) (En) (v1.1) (MooZ,Shubibiman)">
 		<category>TurboGrafx</category>
-		<description>Maerchen Maze (Japan) (En) (v1.1) (MooZ &amp; Shubibiman)</description>
-		<rom name="Maerchen Maze (Japan) (En) (v1.1) (MooZ &amp; Shubibiman).pce" size="262144" crc="b7166358" md5="f34299acd4a789ad51e7b10be3a8947d" sha1="caf03a4bd2b8e74746b98c0b8be312231e447064"/>
+		<description>Maerchen Maze (Japan) (En) (v1.1) (MooZ,Shubibiman)</description>
+		<rom name="Maerchen Maze (Japan) (En) (v1.1) (MooZ,Shubibiman).pce" size="262144" crc="b7166358" md5="f34299acd4a789ad51e7b10be3a8947d" sha1="caf03a4bd2b8e74746b98c0b8be312231e447064"/>
 		<url>https://retroachievements.org/game/19923/hashes</url>
 		<hash>f34299acd4a789ad51e7b10be3a8947d</hash>
 	</game>

--- a/DATs/RetroAchievements (Subfolders)/RA - Nintendo Pokemon Mini.dat
+++ b/DATs/RetroAchievements (Subfolders)/RA - Nintendo Pokemon Mini.dat
@@ -5,162 +5,162 @@
 		<name>RA - Nintendo Pokemon Mini</name>
 		<description>Nintendo Pokemon Mini</description>
 		<category>Subfolders</category>
-		<version>20260227</version>
-		<date>27 February 2026</date>
+		<version>20260428</version>
+		<date>28 April 2026</date>
 		<author>AzgoRAth, NeoRetroGamer (Contributor), Jumphil (Contributor)</author>
 		<homepage>https://retroachievements.org</homepage>
 		<url>https://retroachievements.org/system/24/games</url>
-		<titlecount>38</titlecount>
-		<hashcount>50</hashcount>
+		<titlecount>40</titlecount>
+		<hashcount>52</hashcount>
 	</header>
-	<game name="Homebrew/2048 (World) (Demo) (Aftermarket)">
+	<game name="Homebrew/2048 (World) (Aftermarket) (Unl)">
 		<category></category>
-		<description>2048 (World) (Demo) (Aftermarket)</description>
-		<rom name="2048 (World) (Demo) (Aftermarket).min" size="65536" crc="f7e4e560" md5="59a694c43054a267c434424edfb7aa10" sha1="0e8912627e2ff35c9467ce6da6f03ceac8419524"/>
+		<description>2048 (World) (Aftermarket) (Unl)</description>
+		<rom name="2048 (World) (Aftermarket) (Unl).min" size="65536" crc="f7e4e560" md5="59a694c43054a267c434424edfb7aa10" sha1="0e8912627e2ff35c9467ce6da6f03ceac8419524"/>
 		<url>https://retroachievements.org/game/24918/hashes</url>
 		<hash>59a694c43054a267c434424edfb7aa10</hash>
 	</game>
 	
-	<game name="Homebrew/GJPG (World) (Demo) (Aftermarket)">
+	<game name="Homebrew/GJPG (World) (Demo) (Aftermarket) (Unl)">
 		<category></category>
-		<description>GJPG (World) (Demo) (Aftermarket)</description>
-		<rom name="GJPG (World) (Demo) (Aftermarket).min" size="34176" crc="9bb36b84" md5="86756b56e0d2e6c40a9e746f67a2d1c0" sha1="6becf786c3975c57dc338add6f7f8b3f85b7bf7d"/>
+		<description>GJPG (World) (Demo) (Aftermarket) (Unl)</description>
+		<rom name="GJPG (World) (Demo) (Aftermarket) (Unl).min" size="34176" crc="9bb36b84" md5="86756b56e0d2e6c40a9e746f67a2d1c0" sha1="6becf786c3975c57dc338add6f7f8b3f85b7bf7d"/>
 		<url>https://retroachievements.org/game/21565/hashes</url>
 		<hash>86756b56e0d2e6c40a9e746f67a2d1c0</hash>
 	</game>
 	
-	<game name="Homebrew/Loopover (World) (Demo) (Aftermarket)">
+	<game name="Homebrew/Loopover (World) (Demo) (Aftermarket) (Unl)">
 		<category></category>
-		<description>Loopover (World) (Demo) (Aftermarket)</description>
-		<rom name="Loopover (World) (Demo) (Aftermarket).min" size="65600" crc="fc2a1c6a" md5="be6a27e04fa02f2c7214431e0aa8a2cd" sha1="1a11c8abccffccddff2f760e8945bdf2e2af461a"/>
+		<description>Loopover (World) (Demo) (Aftermarket) (Unl)</description>
+		<rom name="Loopover (World) (Demo) (Aftermarket) (Unl).min" size="65600" crc="fc2a1c6a" md5="be6a27e04fa02f2c7214431e0aa8a2cd" sha1="1a11c8abccffccddff2f760e8945bdf2e2af461a"/>
 		<url>https://retroachievements.org/game/21715/hashes</url>
 		<hash>be6a27e04fa02f2c7214431e0aa8a2cd</hash>
 	</game>
 	
-	<game name="Homebrew/P-Type (World) (Demo) (Aftermarket)">
+	<game name="Homebrew/P-Type (World) (Demo) (Aftermarket) (Unl)">
 		<category></category>
-		<description>P-Type (World) (Demo) (Aftermarket)</description>
-		<rom name="P-Type (World) (Demo) (Aftermarket).min" size="20864" crc="c02810fc" md5="389dc3409fe795b18a0894548dd7bed6" sha1="f2285e76442fa0f18b39f8153eb1912f96392447"/>
+		<description>P-Type (World) (Demo) (Aftermarket) (Unl)</description>
+		<rom name="P-Type (World) (Demo) (Aftermarket) (Unl).min" size="20864" crc="c02810fc" md5="389dc3409fe795b18a0894548dd7bed6" sha1="f2285e76442fa0f18b39f8153eb1912f96392447"/>
 		<url>https://retroachievements.org/game/19505/hashes</url>
 		<hash>389dc3409fe795b18a0894548dd7bed6</hash>
 	</game>
 	
-	<game name="Homebrew/Pazuru (World) (Demo) (Aftermarket)">
+	<game name="Homebrew/Pazuru (World) (Aftermarket) (Unl)">
 		<category></category>
-		<description>Pazuru (World) (Demo) (Aftermarket)</description>
-		<rom name="Pazuru (World) (Demo) (Aftermarket).min" size="29568" crc="08c07ddf" md5="ea7a26be47020af10058ac36a8b6d626" sha1="bf31fcc3b834be3d2deeb8e15b085be5dc87849b"/>
+		<description>Pazuru (World) (Aftermarket) (Unl)</description>
+		<rom name="Pazuru (World) (Aftermarket) (Unl).min" size="29568" crc="08c07ddf" md5="ea7a26be47020af10058ac36a8b6d626" sha1="bf31fcc3b834be3d2deeb8e15b085be5dc87849b"/>
 		<url>https://retroachievements.org/game/15908/hashes</url>
 		<hash>ea7a26be47020af10058ac36a8b6d626</hash>
 	</game>
 	
-	<game name="Homebrew/Pokemon Orange (World) (v0.54) (Demo) (Aftermarket)">
+	<game name="Homebrew/Pokemon Orange (World) (Demo) (v0.54) (Aftermarket) (Unl)">
 		<category></category>
-		<description>Pokemon Orange (World) (v0.54) (Demo) (Aftermarket)</description>
-		<rom name="Pokemon Orange (World) (v0.54) (Demo) (Aftermarket).min" size="19280" crc="c81e7bd9" md5="de89be869046a1cd60ea469c6df8a2b3" sha1="1665a4f57e1b63f57046e1abeb00fd723fc3e772"/>
+		<description>Pokemon Orange (World) (Demo) (v0.54) (Aftermarket) (Unl)</description>
+		<rom name="Pokemon Orange (World) (Demo) (v0.54) (Aftermarket) (Unl).min" size="19280" crc="c81e7bd9" md5="de89be869046a1cd60ea469c6df8a2b3" sha1="1665a4f57e1b63f57046e1abeb00fd723fc3e772"/>
 		<url>https://retroachievements.org/game/17393/hashes</url>
 		<hash>de89be869046a1cd60ea469c6df8a2b3</hash>
 	</game>
 	
-	<game name="Homebrew/Silver Falls - Monsters In North Island (World) (Demo) (Aftermarket)">
+	<game name="Homebrew/Silver Falls - Monsters In North Island (World) (Aftermarket) (Unl)">
 		<category></category>
-		<description>Silver Falls - Monsters In North Island (World) (Demo) (Aftermarket)</description>
-		<rom name="Silver Falls - Monsters In North Island (World) (Demo) (Aftermarket).min" size="74419" crc="68e0da6f" md5="0ce0bead3ee9911765d3d0eb097ee7e7" sha1="f3b3a7e95738033712e5adb0acb3b26c8dc2bdb2"/>
+		<description>Silver Falls - Monsters In North Island (World) (Aftermarket) (Unl)</description>
+		<rom name="Silver Falls - Monsters In North Island (World) (Aftermarket) (Unl).min" size="74419" crc="68e0da6f" md5="0ce0bead3ee9911765d3d0eb097ee7e7" sha1="f3b3a7e95738033712e5adb0acb3b26c8dc2bdb2"/>
 		<url>https://retroachievements.org/game/28820/hashes</url>
 		<hash>0ce0bead3ee9911765d3d0eb097ee7e7</hash>
 	</game>
 	
-	<game name="Homebrew/Wooloo's Run Away (World) (Demo) (Aftermarket)">
+	<game name="Homebrew/Wooloo's Run Away (World) (Demo) (Aftermarket) (Unl)">
 		<category></category>
-		<description>Wooloo's Run Away (World) (Demo) (Aftermarket)</description>
-		<rom name="Wooloo's Run Away (World) (Demo) (Aftermarket).min" size="67584" crc="5c2fde5f" md5="890fed94636776716a2b7b0754c8d5be" sha1="2feed40306fa4a253ab206b1e74ef4c407c7fdea"/>
+		<description>Wooloo's Run Away (World) (Demo) (Aftermarket) (Unl)</description>
+		<rom name="Wooloo's Run Away (World) (Demo) (Aftermarket) (Unl).min" size="67584" crc="5c2fde5f" md5="890fed94636776716a2b7b0754c8d5be" sha1="2feed40306fa4a253ab206b1e74ef4c407c7fdea"/>
 		<url>https://retroachievements.org/game/21685/hashes</url>
 		<hash>890fed94636776716a2b7b0754c8d5be</hash>
 	</game>
 	
-	<game name="Homebrew/Zelda Mini (World) (v1.0) (Demo) (Aftermarket)">
+	<game name="Homebrew/Zelda Mini (World) (Demo) (v1.0) (Aftermarket) (Unl)">
 		<category></category>
-		<description>Zelda Mini (World) (v1.0) (Demo) (Aftermarket)</description>
-		<rom name="Zelda Mini (World) (v1.0) (Demo) (Aftermarket).min" size="17995" crc="87d86d1c" md5="d204bb4f33c0034dc6cdd8c9b6ff9846" sha1="1e4dc752bfffeb7fc5a281d20d3b583aca8e7f20"/>
+		<description>Zelda Mini (World) (Demo) (v1.0) (Aftermarket) (Unl)</description>
+		<rom name="Zelda Mini (World) (Demo) (v1.0) (Aftermarket) (Unl).min" size="17995" crc="87d86d1c" md5="d204bb4f33c0034dc6cdd8c9b6ff9846" sha1="1e4dc752bfffeb7fc5a281d20d3b583aca8e7f20"/>
 		<url>https://retroachievements.org/game/18331/hashes</url>
 		<hash>d204bb4f33c0034dc6cdd8c9b6ff9846</hash>
 	</game>
 	
-	<game name="Homebrew/PokeMaze (World) (Proto) (Aftermarket)">
+	<game name="Homebrew/PokeMaze (World) (Proto) (Aftermarket) (Unl)">
 		<category></category>
-		<description>PokeMaze (World) (Proto) (Aftermarket)</description>
-		<rom name="PokeMaze (World) (Proto) (Aftermarket).min" size="14304" crc="6d45286a" md5="db53ab1335e95df2b33d4ef3735d7af6" sha1="c436ae6659b96d2290c6909c751247207e371bfe"/>
+		<description>PokeMaze (World) (Proto) (Aftermarket) (Unl)</description>
+		<rom name="PokeMaze (World) (Proto) (Aftermarket) (Unl).min" size="14304" crc="6d45286a" md5="db53ab1335e95df2b33d4ef3735d7af6" sha1="c436ae6659b96d2290c6909c751247207e371bfe"/>
 		<url>https://retroachievements.org/game/15722/hashes</url>
 		<hash>db53ab1335e95df2b33d4ef3735d7af6</hash>
 	</game>
 	
-	<game name="Homebrew/Bat Trip (World) (Aftermarket)">
+	<game name="Homebrew/Bat Trip (World) (Aftermarket) (Unl)">
 		<category></category>
-		<description>Bat Trip (World) (Aftermarket)</description>
-		<rom name="Bat Trip (World) (Aftermarket).min" size="78592" crc="82ef1716" md5="f8cac8a6bec766f8f6905b77aab3b29f" sha1="0afdd1a7242f0caa0fdd42f81b8a394b873adf9b"/>
+		<description>Bat Trip (World) (Aftermarket) (Unl)</description>
+		<rom name="Bat Trip (World) (Aftermarket) (Unl).min" size="78592" crc="82ef1716" md5="f8cac8a6bec766f8f6905b77aab3b29f" sha1="0afdd1a7242f0caa0fdd42f81b8a394b873adf9b"/>
 		<url>https://retroachievements.org/game/22050/hashes</url>
 		<hash>f8cac8a6bec766f8f6905b77aab3b29f</hash>
 	</game>
 	
-	<game name="Homebrew/Coretex (World) (v0.70) (Aftermarket)">
+	<game name="Homebrew/Coretex (World) (v0.70) (Aftermarket) (Unl)">
 		<category></category>
-		<description>Coretex (World) (v0.70) (Aftermarket)</description>
-		<rom name="Coretex (World) (v0.70) (Aftermarket).min" size="29359" crc="892b1b54" md5="f03d77b9353c9b875a6331275bb480a5" sha1="161a2a6c0d34c59ac5353f82d5d87fc00d109834"/>
+		<description>Coretex (World) (v0.70) (Aftermarket) (Unl)</description>
+		<rom name="Coretex (World) (v0.70) (Aftermarket) (Unl).min" size="29359" crc="892b1b54" md5="f03d77b9353c9b875a6331275bb480a5" sha1="161a2a6c0d34c59ac5353f82d5d87fc00d109834"/>
 		<url>https://retroachievements.org/game/15725/hashes</url>
 		<hash>f03d77b9353c9b875a6331275bb480a5</hash>
 	</game>
 	
-	<game name="Homebrew/Deathtrap (World) (v1.1) (Aftermarket)">
+	<game name="Homebrew/Deathtrap (World) (v1.1) (Aftermarket) (Unl)">
 		<category></category>
-		<description>Deathtrap (World) (v1.1) (Aftermarket)</description>
-		<rom name="Deathtrap (World) (v1.1) (Aftermarket).min" size="19520" crc="5645b12f" md5="e82230f90504c966610a31b8186ff419" sha1="894fb6f9f3e21ef644f62e569789a4f062e82c47"/>
+		<description>Deathtrap (World) (v1.1) (Aftermarket) (Unl)</description>
+		<rom name="Deathtrap (World) (v1.1) (Aftermarket) (Unl).min" size="19520" crc="5645b12f" md5="e82230f90504c966610a31b8186ff419" sha1="894fb6f9f3e21ef644f62e569789a4f062e82c47"/>
 		<url>https://retroachievements.org/game/19498/hashes</url>
 		<hash>e82230f90504c966610a31b8186ff419</hash>
 	</game>
 	
-	<game name="Homebrew/Flappy Bird (World) (Aftermarket)">
+	<game name="Homebrew/Flappy Bird (World) (Demo) (Aftermarket) (Unl)">
 		<category></category>
-		<description>Flappy Bird (World) (Aftermarket)</description>
-		<rom name="Flappy Bird (World) (Aftermarket).min" size="32176" crc="f370b21d" md5="613cb77ff503f8fd374727526b6a1581" sha1="46938f04135127201e6f10beacd69bf6710d5a18"/>
+		<description>Flappy Bird (World) (Demo) (Aftermarket) (Unl)</description>
+		<rom name="Flappy Bird (World) (Demo) (Aftermarket) (Unl).min" size="32176" crc="f370b21d" md5="613cb77ff503f8fd374727526b6a1581" sha1="46938f04135127201e6f10beacd69bf6710d5a18"/>
 		<url>https://retroachievements.org/game/17676/hashes</url>
 		<hash>613cb77ff503f8fd374727526b6a1581</hash>
 	</game>
 	
-	<game name="Homebrew/Franky the Fruit Fly (World) (v2021-05-21) (Aftermarket)">
+	<game name="Homebrew/Franky the Fruit Fly (World) (v2021-05-21) (Aftermarket) (Unl)">
 		<category></category>
-		<description>Franky the Fruit Fly (World) (v2021-05-21) (Aftermarket)</description>
-		<rom name="Franky the Fruit Fly (World) (v2021-05-21) (Aftermarket).min" size="233456" crc="04c39c90" md5="3e3c37a97fa0c772bdb0237b3c220315" sha1="5fd05bc6e5746a311beb22ae5531210569f1e1a2"/>
+		<description>Franky the Fruit Fly (World) (v2021-05-21) (Aftermarket) (Unl)</description>
+		<rom name="Franky the Fruit Fly (World) (v2021-05-21) (Aftermarket) (Unl).min" size="233456" crc="04c39c90" md5="3e3c37a97fa0c772bdb0237b3c220315" sha1="5fd05bc6e5746a311beb22ae5531210569f1e1a2"/>
 		<url>https://retroachievements.org/game/14713/hashes</url>
 		<hash>3e3c37a97fa0c772bdb0237b3c220315</hash>
 	</game>
 	
-	<game name="Homebrew/Galactix (World) (Aftermarket)">
+	<game name="Homebrew/Galactix (World) (Aftermarket) (Unl)">
 		<category></category>
-		<description>Galactix (World) (Aftermarket)</description>
-		<rom name="Galactix (World) (Aftermarket).min" size="70046" crc="4e6305b7" md5="4e66ffdb6eed6652e4a443247a74038a" sha1="90fd0d0f8fd8a5d7540e8d324482fb02ac6bec00"/>
+		<description>Galactix (World) (Aftermarket) (Unl)</description>
+		<rom name="Galactix (World) (Aftermarket) (Unl).min" size="70046" crc="4e6305b7" md5="4e66ffdb6eed6652e4a443247a74038a" sha1="90fd0d0f8fd8a5d7540e8d324482fb02ac6bec00"/>
 		<url>https://retroachievements.org/game/15726/hashes</url>
 		<hash>4e66ffdb6eed6652e4a443247a74038a</hash>
 	</game>
 	
-	<game name="Homebrew/Hamburger in Space! (World) (Aftermarket)">
+	<game name="Homebrew/Hamburger in Space! (World) (Aftermarket) (Unl)">
 		<category></category>
-		<description>Hamburger in Space! (World) (Aftermarket)</description>
-		<rom name="Hamburger in Space! (World) (Aftermarket).min" size="14592" crc="a340af09" md5="decbb5eacc06db3b4e9f6d206b3bffb9" sha1="27c673af03acee80da08340393edcf4568f13ceb"/>
+		<description>Hamburger in Space! (World) (Aftermarket) (Unl)</description>
+		<rom name="Hamburger in Space! (World) (Aftermarket) (Unl).min" size="14592" crc="a340af09" md5="decbb5eacc06db3b4e9f6d206b3bffb9" sha1="27c673af03acee80da08340393edcf4568f13ceb"/>
 		<url>https://retroachievements.org/game/19708/hashes</url>
 		<hash>decbb5eacc06db3b4e9f6d206b3bffb9</hash>
 	</game>
 	
-	<game name="Homebrew/LightsOut (World) (v1.1) (Aftermarket)">
+	<game name="Homebrew/LightsOut (World) (v1.1) (Aftermarket) (Unl)">
 		<category></category>
-		<description>LightsOut (World) (v1.1) (Aftermarket)</description>
-		<rom name="LightsOut (World) (v1.1) (Aftermarket).min" size="69376" crc="a504bd34" md5="43dbd3bda79b2e72276ef444152b695f" sha1="cc98b80a9889044e80b408d79d42e4037130b439"/>
+		<description>LightsOut (World) (v1.1) (Aftermarket) (Unl)</description>
+		<rom name="LightsOut (World) (v1.1) (Aftermarket) (Unl).min" size="69376" crc="a504bd34" md5="43dbd3bda79b2e72276ef444152b695f" sha1="cc98b80a9889044e80b408d79d42e4037130b439"/>
 		<url>https://retroachievements.org/game/15727/hashes</url>
 		<hash>43dbd3bda79b2e72276ef444152b695f</hash>
 	</game>
 	
-	<game name="Homebrew/Mini Cookie (World) (Aftermarket)">
+	<game name="Homebrew/Mini Cookie (World) (Demo) (Aftermarket) (Unl)">
 		<category></category>
-		<description>Mini Cookie (World) (Aftermarket)</description>
-		<rom name="Mini Cookie (World) (Aftermarket).min" size="12544" crc="b2a9a1ee" md5="78197d139406095e68b0043fbf004860" sha1="9dfc34364ab09fe3211a0b7188b214780a17e85e"/>
+		<description>Mini Cookie (World) (Demo) (Aftermarket) (Unl)</description>
+		<rom name="Mini Cookie (World) (Demo) (Aftermarket) (Unl).min" size="12544" crc="b2a9a1ee" md5="78197d139406095e68b0043fbf004860" sha1="9dfc34364ab09fe3211a0b7188b214780a17e85e"/>
 		<url>https://retroachievements.org/game/18257/hashes</url>
 		<hash>78197d139406095e68b0043fbf004860</hash>
 	</game>
@@ -173,26 +173,26 @@
 		<hash>ef8984f9e252298296f373598ca63e7e</hash>
 	</game>
 	
-	<game name="Homebrew/Pac-It (World) (Aftermarket)">
+	<game name="Homebrew/Pac-It (World) (Demo) (Aftermarket) (Unl)">
 		<category></category>
-		<description>Pac-It (World) (Aftermarket)</description>
-		<rom name="Pac-It (World) (Aftermarket).min" size="82688" crc="c9e2b23b" md5="c73d85b16295266a4e3fe62ecdb761b2" sha1="4057dd97313444d05db4264f57c0917e6b427d6b"/>
+		<description>Pac-It (World) (Demo) (Aftermarket) (Unl)</description>
+		<rom name="Pac-It (World) (Demo) (Aftermarket) (Unl).min" size="82688" crc="c9e2b23b" md5="c73d85b16295266a4e3fe62ecdb761b2" sha1="4057dd97313444d05db4264f57c0917e6b427d6b"/>
 		<url>https://retroachievements.org/game/19568/hashes</url>
 		<hash>c73d85b16295266a4e3fe62ecdb761b2</hash>
 	</game>
 	
-	<game name="Homebrew/Petals Around the Rose (World) (Aftermarket)">
+	<game name="Homebrew/Petals Around the Rose (World) (Demo) (Aftermarket) (Unl)">
 		<category></category>
-		<description>Petals Around the Rose (World) (Aftermarket)</description>
-		<rom name="Petals Around the Rose (World) (Aftermarket).min" size="17388" crc="555d19f0" md5="fc837a8a99829a4879dc37adb3435e5e" sha1="8728b7e566925afeaa701fb142c66d484b6d1850"/>
+		<description>Petals Around the Rose (World) (Demo) (Aftermarket) (Unl)</description>
+		<rom name="Petals Around the Rose (World) (Demo) (Aftermarket) (Unl).min" size="17388" crc="555d19f0" md5="fc837a8a99829a4879dc37adb3435e5e" sha1="8728b7e566925afeaa701fb142c66d484b6d1850"/>
 		<url>https://retroachievements.org/game/15730/hashes</url>
 		<hash>fc837a8a99829a4879dc37adb3435e5e</hash>
 	</game>
 	
-	<game name="Homebrew/PokeMaze (World) (Aftermarket)">
+	<game name="Homebrew/PokeMaze (World) (Aftermarket) (Unl)">
 		<category></category>
-		<description>PokeMaze (World) (Aftermarket)</description>
-		<rom name="PokeMaze (World) (Aftermarket).min" size="36040" crc="3db4b128" md5="d48392de0e6a80497c1955042ad38611" sha1="f808813cc780be023848a594b9568a06a27f59f4"/>
+		<description>PokeMaze (World) (Aftermarket) (Unl)</description>
+		<rom name="PokeMaze (World) (Aftermarket) (Unl).min" size="36040" crc="3db4b128" md5="d48392de0e6a80497c1955042ad38611" sha1="f808813cc780be023848a594b9568a06a27f59f4"/>
 		<url>https://retroachievements.org/game/19706/hashes</url>
 		<hash>d48392de0e6a80497c1955042ad38611</hash>
 	</game>
@@ -205,64 +205,64 @@
 		<hash>0156b0b9c002b4f9b9fec777d4503594</hash>
 	</game>
 	
-	<game name="Homebrew/Pokemon Party mini 2 (World) (Aftermarket)">
+	<game name="Homebrew/Pokemon Party mini 2 (World) (Aftermarket) (Unl)">
 		<category></category>
-		<description>Pokemon Party mini 2 (World) (Aftermarket)</description>
-		<rom name="Pokemon Party mini 2 (World) (Aftermarket).min" size="30528" crc="61bb6d4c" md5="8a69cc5a94afb712e9b313d13ef7a8a2" sha1="dccbf7376f07d1fbecfe0b7d0b0a1389a4360e9d"/>
+		<description>Pokemon Party mini 2 (World) (Aftermarket) (Unl)</description>
+		<rom name="Pokemon Party mini 2 (World) (Aftermarket) (Unl).min" size="30528" crc="61bb6d4c" md5="8a69cc5a94afb712e9b313d13ef7a8a2" sha1="dccbf7376f07d1fbecfe0b7d0b0a1389a4360e9d"/>
 		<url>https://retroachievements.org/game/19709/hashes</url>
 		<hash>8a69cc5a94afb712e9b313d13ef7a8a2</hash>
 	</game>
 	
-	<game name="Homebrew/Pokemon Psychic Seeds/Pokemon Psychic Seeds (World) (Aftermarket)">
+	<game name="Homebrew/Pokemon Psychic Seeds/Pokemon Psychic Seeds (World) (Aftermarket) (Unl)">
 		<category></category>
-		<description>Pokemon Psychic Seeds (World) (Aftermarket)</description>
-		<rom name="Pokemon Psychic Seeds (World) (Aftermarket).min" size="272704" crc="e2b0d791" md5="092819a9abe895f6a0b70a685a854aa7" sha1="66d6852ea00840627645c324b0cc0011ac1a85f6"/>
+		<description>Pokemon Psychic Seeds (World) (Aftermarket) (Unl)</description>
+		<rom name="Pokemon Psychic Seeds (World) (Aftermarket) (Unl).min" size="272704" crc="e2b0d791" md5="092819a9abe895f6a0b70a685a854aa7" sha1="66d6852ea00840627645c324b0cc0011ac1a85f6"/>
 		<url>https://retroachievements.org/game/15724/hashes</url>
 		<hash>092819a9abe895f6a0b70a685a854aa7</hash>
 	</game>
-	<game name="Homebrew/Pokemon Psychic Seeds/Pokemon Psychic Seeds (World) (Demo) (Aftermarket)">
+	<game name="Homebrew/Pokemon Psychic Seeds/Pokemon Psychic Seeds (World) (Demo) (Aftermarket) (Unl)">
 		<category></category>
-		<description>Pokemon Psychic Seeds (World) (Demo) (Aftermarket)</description>
-		<rom name="Pokemon Psychic Seeds (World) (Demo) (Aftermarket).min" size="233664" crc="ff04b931" md5="ab2d43a547fee0ae36db0eac3657242b" sha1="0c9f11dc7451d411bf8ab0dd8ff43ef599afa7e2"/>
+		<description>Pokemon Psychic Seeds (World) (Demo) (Aftermarket) (Unl)</description>
+		<rom name="Pokemon Psychic Seeds (World) (Demo) (Aftermarket) (Unl).min" size="233664" crc="ff04b931" md5="ab2d43a547fee0ae36db0eac3657242b" sha1="0c9f11dc7451d411bf8ab0dd8ff43ef599afa7e2"/>
 		<url>https://retroachievements.org/game/15724/hashes</url>
 		<hash>ab2d43a547fee0ae36db0eac3657242b</hash>
 	</game>
 	
-	<game name="Homebrew/PokeSnake (World) (Aftermarket)">
+	<game name="Homebrew/PokeSnake (World) (Aftermarket) (Unl)">
 		<category></category>
-		<description>PokeSnake (World) (Aftermarket)</description>
-		<rom name="PokeSnake (World) (Aftermarket).min" size="13440" crc="1bcc7c21" md5="473b191bc7833fb62388e1d9f21a241c" sha1="d772d820eb914cc9a551cca4a59a3885187b134a"/>
+		<description>PokeSnake (World) (Aftermarket) (Unl)</description>
+		<rom name="PokeSnake (World) (Aftermarket) (Unl).min" size="13440" crc="1bcc7c21" md5="473b191bc7833fb62388e1d9f21a241c" sha1="d772d820eb914cc9a551cca4a59a3885187b134a"/>
 		<url>https://retroachievements.org/game/15723/hashes</url>
 		<hash>473b191bc7833fb62388e1d9f21a241c</hash>
 	</game>
 	
-	<game name="Homebrew/Pongemon (World) (Aftermarket)">
+	<game name="Homebrew/Pongemon (World) (Demo) (Aftermarket) (Unl)">
 		<category></category>
-		<description>Pongemon (World) (Aftermarket)</description>
-		<rom name="Pongemon (World) (Aftermarket).min" size="13440" crc="4afeca41" md5="3fbd1d94969da4070f37763861763486" sha1="d7c9ceb370718046870311c5fec9382e20b1738c"/>
+		<description>Pongemon (World) (Demo) (Aftermarket) (Unl)</description>
+		<rom name="Pongemon (World) (Demo) (Aftermarket) (Unl).min" size="13440" crc="4afeca41" md5="3fbd1d94969da4070f37763861763486" sha1="d7c9ceb370718046870311c5fec9382e20b1738c"/>
 		<url>https://retroachievements.org/game/17311/hashes</url>
 		<hash>3fbd1d94969da4070f37763861763486</hash>
 	</game>
 	
-	<game name="Homebrew/SOKOmini/SOKOmini (World) (v1.0) (Hardware Fixed) (Aftermarket)">
+	<game name="Homebrew/SOKOmini/SOKOmini (World) (v1.0) (Hardware Fixed) (Aftermarket) (Unl)">
 		<category></category>
-		<description>SOKOmini (World) (v1.0) (Hardware Fixed) (Aftermarket)</description>
-		<rom name="SOKOmini (World) (v1.0) (Hardware Fixed) (Aftermarket).min" size="56288" crc="350f91e9" md5="2586b3aa4989969c0b200a57c13f5aae" sha1="9a4f9152d0fe3cc0f32255bab1d2f1edcc4b00b6"/>
+		<description>SOKOmini (World) (v1.0) (Hardware Fixed) (Aftermarket) (Unl)</description>
+		<rom name="SOKOmini (World) (v1.0) (Hardware Fixed) (Aftermarket) (Unl).min" size="56288" crc="350f91e9" md5="2586b3aa4989969c0b200a57c13f5aae" sha1="9a4f9152d0fe3cc0f32255bab1d2f1edcc4b00b6"/>
 		<url>https://retroachievements.org/game/15728/hashes</url>
 		<hash>2586b3aa4989969c0b200a57c13f5aae</hash>
 	</game>
-	<game name="Homebrew/SOKOmini/SOKOmini (World) (v1.0) (Aftermarket)">
+	<game name="Homebrew/SOKOmini/SOKOmini (World) (v1.0) (Aftermarket) (Unl)">
 		<category></category>
-		<description>SOKOmini (World) (v1.0) (Aftermarket)</description>
-		<rom name="SOKOmini (World) (v1.0) (Aftermarket).min" size="524288" crc="28a67132" md5="6048dce48222e4d75e8fdce9c2f55c39" sha1="5f79e5ae22fca1e758fbd8c2f438497f12bad4ba"/>
+		<description>SOKOmini (World) (v1.0) (Aftermarket) (Unl)</description>
+		<rom name="SOKOmini (World) (v1.0) (Aftermarket) (Unl).min" size="524288" crc="28a67132" md5="6048dce48222e4d75e8fdce9c2f55c39" sha1="5f79e5ae22fca1e758fbd8c2f438497f12bad4ba"/>
 		<url>https://retroachievements.org/game/15728/hashes</url>
 		<hash>6048dce48222e4d75e8fdce9c2f55c39</hash>
 	</game>
 	
-	<game name="Homebrew/Sonic Arena (World) (v1.0) (En) (Aftermarket)">
+	<game name="Homebrew/Sonic Arena (World) (v1.0) (En) (Aftermarket) (Unl)">
 		<category></category>
-		<description>Sonic Arena (World) (v1.0) (En) (Aftermarket)</description>
-		<rom name="Sonic Arena (World) (v1.0) (En) (Aftermarket).min" size="20224" crc="28c3eedd" md5="e1fc9f3b2a32990eb0c479c40d28049d" sha1="6f20b8f552b925b2d7827cd8197c67ffd0e7c61f"/>
+		<description>Sonic Arena (World) (v1.0) (En) (Aftermarket) (Unl)</description>
+		<rom name="Sonic Arena (World) (v1.0) (En) (Aftermarket) (Unl).min" size="20224" crc="28c3eedd" md5="e1fc9f3b2a32990eb0c479c40d28049d" sha1="6f20b8f552b925b2d7827cd8197c67ffd0e7c61f"/>
 		<url>https://retroachievements.org/game/15729/hashes</url>
 		<hash>e1fc9f3b2a32990eb0c479c40d28049d</hash>
 	</game>
@@ -410,10 +410,10 @@
 		<url>https://retroachievements.org/game/14701/hashes</url>
 		<hash>a4eb2facaa5beb947f306ced2bf5cd15</hash>
 	</game>
-	<game name="Retail/Togepi's Great Adventure/Togepi's Great Adventure (Japan) (En) (v1.0) (Mr. Blinky)">
+	<game name="Retail/Togepi's Great Adventure/Togepi no Daibouken (Japan) (En) (v1.0) (Mr. Blinky)">
 		<category></category>
-		<description>Togepi's Great Adventure (Japan) (En) (v1.0) (Mr. Blinky)</description>
-		<rom name="Togepi's Great Adventure (Japan) (En) (v1.0) (Mr. Blinky).min" size="524288" crc="acab99f3" md5="cac3842f010dba9e4155e459111b6ebd" sha1="7f2de7dfabc1b52c916567a33d7bed1d655a5d44"/>
+		<description>Togepi no Daibouken (Japan) (En) (v1.0) (Mr. Blinky)</description>
+		<rom name="Togepi no Daibouken (Japan) (En) (v1.0) (Mr. Blinky).min" size="524288" crc="acab99f3" md5="cac3842f010dba9e4155e459111b6ebd" sha1="7f2de7dfabc1b52c916567a33d7bed1d655a5d44"/>
 		<url>https://retroachievements.org/game/14701/hashes</url>
 		<hash>cac3842f010dba9e4155e459111b6ebd</hash>
 	</game>

--- a/DATs/RetroAchievements (Subfolders)/RA - Nintendo Virtual Boy.dat
+++ b/DATs/RetroAchievements (Subfolders)/RA - Nintendo Virtual Boy.dat
@@ -5,129 +5,129 @@
 		<name>RA - Nintendo Virtual Boy</name>
 		<description>Nintendo Virtual Boy</description>
 		<category>Subfolders</category>
-		<version>20251225</version>
-		<date>25 December 2025</date>
+		<version>20260428</version>
+		<date>28 April 2026</date>
 		<author>AzgoRAth, NeoRetroGamer (Contributor), Jumphil (Contributor)</author>
 		<homepage>https://retroachievements.org</homepage>
 		<url>https://retroachievements.org/system/28/games</url>
-		<titlecount>38</titlecount>
-		<hashcount>48</hashcount>
+		<titlecount>41</titlecount>
+		<hashcount>51</hashcount>
 	</header>
-	<game name="Homebrew/3D Crosswords (World) (Emulator Version) (Aftermarket)">
+	<game name="Homebrew/3D Crosswords (World) (Emulator Version) (Aftermarket) (Unl)">
 		<category></category>
-		<description>3D Crosswords (World) (Emulator Version) (Aftermarket)</description>
-		<rom name="3D Crosswords (World) (Emulator Version) (Aftermarket).vb" size="2097152" crc="bb061c9d" md5="cef10df7728f4398af46d51efc89d3d0" sha1="c778106d5c378022bbb078cd303bd0155e9fcabc"/>
+		<description>3D Crosswords (World) (Emulator Version) (Aftermarket) (Unl)</description>
+		<rom name="3D Crosswords (World) (Emulator Version) (Aftermarket) (Unl).vb" size="2097152" crc="bb061c9d" md5="cef10df7728f4398af46d51efc89d3d0" sha1="c778106d5c378022bbb078cd303bd0155e9fcabc"/>
 		<url>https://retroachievements.org/game/17020/hashes</url>
 		<hash>cef10df7728f4398af46d51efc89d3d0</hash>
 	</game>
 	
-	<game name="Homebrew/Advanced Pasta Cooking Simulator (USA) (HorvatM) (Aftermarket)">
+	<game name="Homebrew/Advanced Pasta Cooking Simulator (USA) (Aftermarket) (Unl) (HorvatM)">
 		<category></category>
-		<description>Advanced Pasta Cooking Simulator (USA) (HorvatM) (Aftermarket)</description>
-		<rom name="Advanced Pasta Cooking Simulator (USA) (HorvatM) (Aftermarket).vb" size="2097152" crc="639ca272" md5="a1b32c3b70ad0875fada464d681867f7" sha1="dd535b06c7b43ae3a122553c9b6fb9ace3bf11af"/>
+		<description>Advanced Pasta Cooking Simulator (USA) (Aftermarket) (Unl) (HorvatM)</description>
+		<rom name="Advanced Pasta Cooking Simulator (USA) (Aftermarket) (Unl) (HorvatM).vb" size="2097152" crc="639ca272" md5="a1b32c3b70ad0875fada464d681867f7" sha1="dd535b06c7b43ae3a122553c9b6fb9ace3bf11af"/>
 		<url>https://retroachievements.org/game/19567/hashes</url>
 		<hash>a1b32c3b70ad0875fada464d681867f7</hash>
 	</game>
 	
-	<game name="Homebrew/BLOX (World) (v1.1) (Aftermarket)">
+	<game name="Homebrew/BLOX (World) (v1.1) (Aftermarket) (Unl)">
 		<category></category>
-		<description>BLOX (World) (v1.1) (Aftermarket)</description>
-		<rom name="BLOX (World) (v1.1) (Aftermarket).vb" size="1048576" crc="450feab5" md5="f82d4c9fdd81518537d88f70c6602bb5" sha1="f2105349dff09bdc00e4548460991dde9ac7c2af"/>
+		<description>BLOX (World) (v1.1) (Aftermarket) (Unl)</description>
+		<rom name="BLOX (World) (v1.1) (Aftermarket) (Unl).vb" size="1048576" crc="450feab5" md5="f82d4c9fdd81518537d88f70c6602bb5" sha1="f2105349dff09bdc00e4548460991dde9ac7c2af"/>
 		<url>https://retroachievements.org/game/13161/hashes</url>
 		<hash>f82d4c9fdd81518537d88f70c6602bb5</hash>
 	</game>
 	
-	<game name="Homebrew/BLOX 2 (World) (Aftermarket)">
+	<game name="Homebrew/BLOX 2 (World) (En,Fr,De,Es,It,Sv,Fi,Cs,Sl) (Aftermarket) (Unl)">
 		<category></category>
-		<description>BLOX 2 (World) (Aftermarket)</description>
-		<rom name="BLOX 2 (World) (Aftermarket).vb" size="2097152" crc="85460a25" md5="cc91d6389df2c9777919e8e8ab2c0e66" sha1="66b2a25ef8e1af74bed4bbba4785951a9d6edce0"/>
+		<description>BLOX 2 (World) (En,Fr,De,Es,It,Sv,Fi,Cs,Sl) (Aftermarket) (Unl)</description>
+		<rom name="BLOX 2 (World) (En,Fr,De,Es,It,Sv,Fi,Cs,Sl) (Aftermarket) (Unl).vb" size="2097152" crc="85460a25" md5="cc91d6389df2c9777919e8e8ab2c0e66" sha1="66b2a25ef8e1af74bed4bbba4785951a9d6edce0"/>
 		<url>https://retroachievements.org/game/17019/hashes</url>
 		<hash>cc91d6389df2c9777919e8e8ab2c0e66</hash>
 	</game>
 	
-	<game name="Homebrew/Castle of Doom (USA) (VirtualChris) (Aftermarket)">
+	<game name="Homebrew/Castle of Doom (USA) (Aftermarket) (Unl) (VirtualChris)">
 		<category></category>
-		<description>Castle of Doom (USA) (VirtualChris) (Aftermarket)</description>
-		<rom name="Castle of Doom (USA) (VirtualChris) (Aftermarket).vb" size="524288" crc="b8cea688" md5="fcfbeeca4bb33af756b025136c8b2549" sha1="eabde81ec527c671da6accd958120a57de03de15"/>
+		<description>Castle of Doom (USA) (Aftermarket) (Unl) (VirtualChris)</description>
+		<rom name="Castle of Doom (USA) (Aftermarket) (Unl) (VirtualChris).vb" size="524288" crc="b8cea688" md5="fcfbeeca4bb33af756b025136c8b2549" sha1="eabde81ec527c671da6accd958120a57de03de15"/>
 		<url>https://retroachievements.org/game/19564/hashes</url>
 		<hash>fcfbeeca4bb33af756b025136c8b2549</hash>
 	</game>
 	
-	<game name="Homebrew/Fishbone (World) (Aftermarket)">
+	<game name="Homebrew/Fishbone (World) (Aftermarket) (Unl)">
 		<category></category>
-		<description>Fishbone (World) (Aftermarket)</description>
-		<rom name="Fishbone (World) (Aftermarket).vb" size="2097152" crc="b5977e82" md5="eee8be03986ddbc3ada91b10a543f17e" sha1="c036c441bb3c16e5b2cc6ea7681f56a8605b932e"/>
+		<description>Fishbone (World) (Aftermarket) (Unl)</description>
+		<rom name="Fishbone (World) (Aftermarket) (Unl).vb" size="2097152" crc="b5977e82" md5="eee8be03986ddbc3ada91b10a543f17e" sha1="c036c441bb3c16e5b2cc6ea7681f56a8605b932e"/>
 		<url>https://retroachievements.org/game/13162/hashes</url>
 		<hash>eee8be03986ddbc3ada91b10a543f17e</hash>
 	</game>
 	
-	<game name="Homebrew/Flappy Cheep Cheep (USA) (DogP) (Aftermarket)">
+	<game name="Homebrew/Flappy Cheep Cheep (USA) (Aftermarket) (Unl) (DogP)">
 		<category></category>
-		<description>Flappy Cheep Cheep (USA) (DogP) (Aftermarket)</description>
-		<rom name="Flappy Cheep Cheep (USA) (DogP) (Aftermarket).vb" size="1048576" crc="68ec16aa" md5="2176fae66e175a5bf9fc0266b627cc6f" sha1="60e5fd56a52de4c451e09d3c5eac51a6c2af95bb"/>
+		<description>Flappy Cheep Cheep (USA) (Aftermarket) (Unl) (DogP)</description>
+		<rom name="Flappy Cheep Cheep (USA) (Aftermarket) (Unl) (DogP).vb" size="1048576" crc="68ec16aa" md5="2176fae66e175a5bf9fc0266b627cc6f" sha1="60e5fd56a52de4c451e09d3c5eac51a6c2af95bb"/>
 		<url>https://retroachievements.org/game/19509/hashes</url>
 		<hash>2176fae66e175a5bf9fc0266b627cc6f</hash>
 	</game>
 	
-	<game name="Homebrew/Game Hero (USA) (v1.1) (thunderstruck) (Aftermarket)">
+	<game name="Homebrew/Game Hero (USA) (v1.1) (Aftermarket) (Unl) (thunderstruck)">
 		<category></category>
-		<description>Game Hero (USA) (v1.1) (thunderstruck) (Aftermarket)</description>
-		<rom name="Game Hero (USA) (v1.1) (thunderstruck) (Aftermarket).vb" size="2097152" crc="ebf05942" md5="d7adb3f627d0a3bf058e56eb7bd9c58d" sha1="54dab0037f1c672c545395f641b7286814872cfd"/>
+		<description>Game Hero (USA) (v1.1) (Aftermarket) (Unl) (thunderstruck)</description>
+		<rom name="Game Hero (USA) (v1.1) (Aftermarket) (Unl) (thunderstruck).vb" size="2097152" crc="ebf05942" md5="d7adb3f627d0a3bf058e56eb7bd9c58d" sha1="54dab0037f1c672c545395f641b7286814872cfd"/>
 		<url>https://retroachievements.org/game/19858/hashes</url>
 		<hash>d7adb3f627d0a3bf058e56eb7bd9c58d</hash>
 	</game>
 	
-	<game name="Homebrew/GoSub (USA) (VirtualChris) (Aftermarket)">
+	<game name="Homebrew/GoSub (USA) (Aftermarket) (Unl) (VirtualChris)">
 		<category></category>
-		<description>GoSub (USA) (VirtualChris) (Aftermarket)</description>
-		<rom name="GoSub (USA) (VirtualChris) (Aftermarket).vb" size="524288" crc="f9360e8b" md5="907c7f10093cfcab371754efae8ed279" sha1="c357f6fb487570cd741c32babb452dd634cda0f4"/>
+		<description>GoSub (USA) (Aftermarket) (Unl) (VirtualChris)</description>
+		<rom name="GoSub (USA) (Aftermarket) (Unl) (VirtualChris).vb" size="524288" crc="f9360e8b" md5="907c7f10093cfcab371754efae8ed279" sha1="c357f6fb487570cd741c32babb452dd634cda0f4"/>
 		<url>https://retroachievements.org/game/19510/hashes</url>
 		<hash>907c7f10093cfcab371754efae8ed279</hash>
 	</game>
 	
-	<game name="Homebrew/Hamburgers En Route to Switzerland (World) (Aftermarket)">
+	<game name="Homebrew/Hamburgers En Route to Switzerland (World) (Aftermarket) (Unl)">
 		<category></category>
-		<description>Hamburgers En Route to Switzerland (World) (Aftermarket)</description>
-		<rom name="Hamburgers En Route to Switzerland (World) (Aftermarket).vb" size="524288" crc="efb7577c" md5="45aa19c4b2f10c7ef6782b0cb356e265" sha1="bf426b164378376e11dc0416ffa840a84fd1cd15"/>
+		<description>Hamburgers En Route to Switzerland (World) (Aftermarket) (Unl)</description>
+		<rom name="Hamburgers En Route to Switzerland (World) (Aftermarket) (Unl).vb" size="524288" crc="efb7577c" md5="45aa19c4b2f10c7ef6782b0cb356e265" sha1="bf426b164378376e11dc0416ffa840a84fd1cd15"/>
 		<url>https://retroachievements.org/game/22399/hashes</url>
 		<hash>45aa19c4b2f10c7ef6782b0cb356e265</hash>
 	</game>
 	
-	<game name="Homebrew/Hyper Fighting (World) (Aftermarket)">
+	<game name="Homebrew/Hyper Fighting (World) (Aftermarket) (Unl)">
 		<category></category>
-		<description>Hyper Fighting (World) (Aftermarket)</description>
-		<rom name="Hyper Fighting (World) (Aftermarket).vb" size="4194304" crc="3f2a6ba2" md5="c2047a94dcb0db30794c8533ba625622" sha1="578355de83822ce67522033dd7545631124a71ab"/>
+		<description>Hyper Fighting (World) (Aftermarket) (Unl)</description>
+		<rom name="Hyper Fighting (World) (Aftermarket) (Unl).vb" size="4194304" crc="3f2a6ba2" md5="c2047a94dcb0db30794c8533ba625622" sha1="578355de83822ce67522033dd7545631124a71ab"/>
 		<url>https://retroachievements.org/game/17734/hashes</url>
 		<hash>c2047a94dcb0db30794c8533ba625622</hash>
 	</game>
-	<game name="Homebrew/Hyper Fighting (World) (Brightness Fix) (v1.0) (Guy Perfect) (Aftermarket)">
+	<game name="Homebrew/Hyper Fighting (World) (Aftermarket) (Unl) (Brightness Fix) (v1.0) (Guy Perfect)">
 		<category></category>
-		<description>Hyper Fighting (World) (Brightness Fix) (v1.0) (Guy Perfect) (Aftermarket)</description>
-		<rom name="Hyper Fighting (World) (Brightness Fix) (v1.0) (Guy Perfect) (Aftermarket).vb" size="4194304" crc="f30c1e99" md5="8d7068bc51669a2f0db46fef5b72e6cb" sha1="5cbc0400304b6cc0c97689ac84809a7a16737ca4"/>
+		<description>Hyper Fighting (World) (Aftermarket) (Unl) (Brightness Fix) (v1.0) (Guy Perfect)</description>
+		<rom name="Hyper Fighting (World) (Aftermarket) (Unl) (Brightness Fix) (v1.0) (Guy Perfect).vb" size="4194304" crc="f30c1e99" md5="8d7068bc51669a2f0db46fef5b72e6cb" sha1="5cbc0400304b6cc0c97689ac84809a7a16737ca4"/>
 		<url>https://retroachievements.org/game/17734/hashes</url>
 		<hash>8d7068bc51669a2f0db46fef5b72e6cb</hash>
 	</game>
 	
-	<game name="Homebrew/Mario Kart - Virtual Cup (World) (Aftermarket)">
+	<game name="Homebrew/Mario Kart - Virtual Cup (World) (Aftermarket) (Unl)">
 		<category></category>
-		<description>Mario Kart - Virtual Cup (World) (Aftermarket)</description>
-		<rom name="Mario Kart - Virtual Cup (World) (Aftermarket).vb" size="1048576" crc="27988ab9" md5="4b8c8b6a7711a005dd896b3ee9b8d0f1" sha1="7743978a58a27b8e05e36d353439a8b11ead5235"/>
+		<description>Mario Kart - Virtual Cup (World) (Aftermarket) (Unl)</description>
+		<rom name="Mario Kart - Virtual Cup (World) (Aftermarket) (Unl).vb" size="1048576" crc="27988ab9" md5="4b8c8b6a7711a005dd896b3ee9b8d0f1" sha1="7743978a58a27b8e05e36d353439a8b11ead5235"/>
 		<url>https://retroachievements.org/game/13947/hashes</url>
 		<hash>4b8c8b6a7711a005dd896b3ee9b8d0f1</hash>
 	</game>
 	
-	<game name="Homebrew/Pineapple 64 (USA) (v2016-03-15) (VirtualChris) (Aftermarket)">
+	<game name="Homebrew/Pineapple 64 (USA) (v2016-03-15) (VirtualChris)">
 		<category></category>
-		<description>Pineapple 64 (USA) (v2016-03-15) (VirtualChris) (Aftermarket)</description>
-		<rom name="Pineapple 64 (USA) (v2016-03-15) (VirtualChris) (Aftermarket).vb" size="1048576" crc="e40bfa61" md5="c81e121e78b63137305b9098bb5a2ad9" sha1="a6cacaa85c1b07d3dcadea7f657065f2293fff7c"/>
+		<description>Pineapple 64 (USA) (v2016-03-15) (VirtualChris)</description>
+		<rom name="Pineapple 64 (USA) (v2016-03-15) (VirtualChris).vb" size="1048576" crc="e40bfa61" md5="c81e121e78b63137305b9098bb5a2ad9" sha1="a6cacaa85c1b07d3dcadea7f657065f2293fff7c"/>
 		<url>https://retroachievements.org/game/13163/hashes</url>
 		<hash>c81e121e78b63137305b9098bb5a2ad9</hash>
 	</game>
 	
-	<game name="Homebrew/Red Square (USA) (2019 Dream Diary Jam) (Kresna,Nyrator) (Aftermarket)">
+	<game name="Homebrew/Red Square (USA) (2019 Dream Diary Jam) (Aftermarket) (Unl) (Kresna,Nyrator)">
 		<category></category>
-		<description>Red Square (USA) (2019 Dream Diary Jam) (Kresna,Nyrator) (Aftermarket)</description>
-		<rom name="Red Square (USA) (2019 Dream Diary Jam) (Kresna,Nyrator) (Aftermarket).vb" size="524288" crc="cea4707a" md5="9c372321204b9fa65f9324f98aae53ff" sha1="a12529a0d7cf7f0711b913b8ae72fea193cebc17"/>
+		<description>Red Square (USA) (2019 Dream Diary Jam) (Aftermarket) (Unl) (Kresna,Nyrator)</description>
+		<rom name="Red Square (USA) (2019 Dream Diary Jam) (Aftermarket) (Unl) (Kresna,Nyrator).vb" size="524288" crc="cea4707a" md5="9c372321204b9fa65f9324f98aae53ff" sha1="a12529a0d7cf7f0711b913b8ae72fea193cebc17"/>
 		<url>https://retroachievements.org/game/21681/hashes</url>
 		<hash>9c372321204b9fa65f9324f98aae53ff</hash>
 	</game>
@@ -140,26 +140,34 @@
 		<hash>74d21ea01f97ac19e018d7f5a3e3bc7c</hash>
 	</game>
 	
-	<game name="Homebrew/VB Racing (USA) (FlashBoy Version) (PVBCC) (M.K.) (Aftermarket)">
+	<game name="Homebrew/Soviet Union 2011 (World) (v1.2) (Aftermarket) (Unl)">
 		<category></category>
-		<description>VB Racing (USA) (FlashBoy Version) (PVBCC) (M.K.) (Aftermarket)</description>
-		<rom name="VB Racing (USA) (FlashBoy Version) (PVBCC) (M.K.) (Aftermarket).vb" size="524288" crc="d56448ec" md5="819b9dccf1437c3bb126670b171d7c59" sha1="ac6d441370994b3000119afffbd4a200014c5a51"/>
+		<description>Soviet Union 2011 (World) (v1.2) (Aftermarket) (Unl)</description>
+		<rom name="Soviet Union 2011 (World) (v1.2) (Aftermarket) (Unl).vb" size="2097152" crc="3a2e0413" md5="7209a6bd5d788f12e97b9247d28197ce" sha1="b6f9c7c86ecaaf37f1966c3480752531f9dd5515"/>
+		<url>https://retroachievements.org/game/34102/hashes</url>
+		<hash>7209a6bd5d788f12e97b9247d28197ce</hash>
+	</game>
+	
+	<game name="Homebrew/VB Racing (USA) (FlashBoy Version) (PVBCC) (Aftermarket) (Unl) (M.K.)">
+		<category></category>
+		<description>VB Racing (USA) (FlashBoy Version) (PVBCC) (Aftermarket) (Unl) (M.K.)</description>
+		<rom name="VB Racing (USA) (FlashBoy Version) (PVBCC) (Aftermarket) (Unl) (M.K.).vb" size="524288" crc="d56448ec" md5="819b9dccf1437c3bb126670b171d7c59" sha1="ac6d441370994b3000119afffbd4a200014c5a51"/>
 		<url>https://retroachievements.org/game/13164/hashes</url>
 		<hash>819b9dccf1437c3bb126670b171d7c59</hash>
 	</game>
 	
-	<game name="Homebrew/VUE Snake (USA) (v1.1) (KR155E) (Aftermarket)">
+	<game name="Homebrew/VUE Snake (USA) (v1.1) (Aftermarket) (Unl) (KR155E)">
 		<category></category>
-		<description>VUE Snake (USA) (v1.1) (KR155E) (Aftermarket)</description>
-		<rom name="VUE Snake (USA) (v1.1) (KR155E) (Aftermarket).vb" size="262144" crc="ad054747" md5="ccfa400a0ff3d717dad36a3f736fd34d" sha1="77ebaf5dbe667d8347d098b6749b6f3be09f5814"/>
+		<description>VUE Snake (USA) (v1.1) (Aftermarket) (Unl) (KR155E)</description>
+		<rom name="VUE Snake (USA) (v1.1) (Aftermarket) (Unl) (KR155E).vb" size="262144" crc="ad054747" md5="ccfa400a0ff3d717dad36a3f736fd34d" sha1="77ebaf5dbe667d8347d098b6749b6f3be09f5814"/>
 		<url>https://retroachievements.org/game/19544/hashes</url>
 		<hash>ccfa400a0ff3d717dad36a3f736fd34d</hash>
 	</game>
 	
-	<game name="Prototype/Bound High (Japan) (En) (Proto)">
+	<game name="Prototype/Bound High (World) (Proto 1) [b]">
 		<category></category>
-		<description>Bound High (Japan) (En) (Proto)</description>
-		<rom name="Bound High (Japan) (En) (Proto).vb" size="2097152" crc="e81a3703" md5="a460e2660fa951e9d4e3b05aee9f5018" sha1="1196ef8b9a96a0ff2f3634f8eb1c4865c0fb6b01"/>
+		<description>Bound High (World) (Proto 1) [b]</description>
+		<rom name="Bound High (World) (Proto 1) [b].vb" size="2097152" crc="e81a3703" md5="a460e2660fa951e9d4e3b05aee9f5018" sha1="1196ef8b9a96a0ff2f3634f8eb1c4865c0fb6b01"/>
 		<url>https://retroachievements.org/game/16580/hashes</url>
 		<hash>a460e2660fa951e9d4e3b05aee9f5018</hash>
 	</game>
@@ -170,6 +178,14 @@
 		<rom name="Space Pinball (Japan) (En) (Proto).vb" size="2097152" crc="44c2b723" md5="31073126fad41777357391ecc36d6f7f" sha1="dc182360c7c8d26323db8921f09db76638e81ced"/>
 		<url>https://retroachievements.org/game/17749/hashes</url>
 		<hash>31073126fad41777357391ecc36d6f7f</hash>
+	</game>
+	
+	<game name="Retail/3-D Tetris (USA)">
+		<category></category>
+		<description>3-D Tetris (USA)</description>
+		<rom name="3-D Tetris (USA).vb" size="1048576" crc="bb71b522" md5="ecf1218706e9b547eab9e4be58d54e21" sha1="5177015a91442e56bd76af39447bca365e06c272"/>
+		<url>https://retroachievements.org/game/12719/hashes</url>
+		<hash>ecf1218706e9b547eab9e4be58d54e21</hash>
 	</game>
 	
 	<game name="Retail/Galactic Pinball (Japan, USA) (En)">
@@ -195,10 +211,10 @@
 		<url>https://retroachievements.org/game/13041/hashes</url>
 		<hash>1eb964d0eaa3223cfefdcc99a6265c88</hash>
 	</game>
-	<game name="Retail/Insmouth no Yakata/Innsmouth no Yakata (Japan) (En) (v1.0) (Thunderstruck)">
+	<game name="Retail/Insmouth no Yakata/Insmouth no Yakata (Japan) (En) (v1.0) (Thunderstruck)">
 		<category></category>
-		<description>Innsmouth no Yakata (Japan) (En) (v1.0) (Thunderstruck)</description>
-		<rom name="Innsmouth no Yakata (Japan) (En) (v1.0) (Thunderstruck).vb" size="1048576" crc="04ccbe94" md5="4698a0b151d95bbbb833e2a523a12be7" sha1="37f0351b1711a9580a7346127bc54b3927bc7e1e"/>
+		<description>Insmouth no Yakata (Japan) (En) (v1.0) (Thunderstruck)</description>
+		<rom name="Insmouth no Yakata (Japan) (En) (v1.0) (Thunderstruck).vb" size="1048576" crc="04ccbe94" md5="4698a0b151d95bbbb833e2a523a12be7" sha1="37f0351b1711a9580a7346127bc54b3927bc7e1e"/>
 		<url>https://retroachievements.org/game/13041/hashes</url>
 		<hash>4698a0b151d95bbbb833e2a523a12be7</hash>
 	</game>
@@ -341,10 +357,10 @@
 		<hash>c1f23aa9a6b5130a4971b4566dc19289</hash>
 	</game>
 	
-	<game name="Retail/Virtual Bowling (Japan)">
+	<game name="Retail/Virtual Bowling (Japan) (En)">
 		<category></category>
-		<description>Virtual Bowling (Japan)</description>
-		<rom name="Virtual Bowling (Japan).vb" size="1048576" crc="20688279" md5="5b11d402f7e322c71a7d4fa6503631fa" sha1="a5be7654037050f0a781e70efea0191f43d26f06"/>
+		<description>Virtual Bowling (Japan) (En)</description>
+		<rom name="Virtual Bowling (Japan) (En).vb" size="1048576" crc="20688279" md5="5b11d402f7e322c71a7d4fa6503631fa" sha1="a5be7654037050f0a781e70efea0191f43d26f06"/>
 		<url>https://retroachievements.org/game/13078/hashes</url>
 		<hash>5b11d402f7e322c71a7d4fa6503631fa</hash>
 	</game>

--- a/DATs/RetroAchievements (Subfolders)/RA - SNK Neo Geo Pocket.dat
+++ b/DATs/RetroAchievements (Subfolders)/RA - SNK Neo Geo Pocket.dat
@@ -5,90 +5,90 @@
 		<name>RA - SNK Neo Geo Pocket</name>
 		<description>SNK Neo Geo Pocket</description>
 		<category>Subfolders</category>
-		<version>20260227</version>
-		<date>27 February 2026</date>
+		<version>20260428</version>
+		<date>28 April 2026</date>
 		<author>AzgoRAth, NeoRetroGamer (Contributor), Jumphil (Contributor)</author>
 		<homepage>https://retroachievements.org</homepage>
 		<url>https://retroachievements.org/system/14/games</url>
-		<titlecount>38</titlecount>
-		<hashcount>50/51</hashcount>
+		<titlecount>42</titlecount>
+		<hashcount>55/56</hashcount>
 	</header>
-	<game name="Homebrew/Another Day in Hell (World) (v1.1) (Aftermarket)">
+	<game name="Homebrew/Another Day in Hell (World) (v1.1) (Aftermarket) (Unl)">
 		<category>Neo Geo Pocket Color</category>
-		<description>Another Day in Hell (World) (v1.1) (Aftermarket)</description>
-		<rom name="Another Day in Hell (World) (v1.1) (Aftermarket).ngc" size="1494777" crc="73d4c2a4" md5="b66c0335be91d86650e31c5942a69323" sha1="8ede8a19190fb5e74658d06f2d076a9fcf440187"/>
+		<description>Another Day in Hell (World) (v1.1) (Aftermarket) (Unl)</description>
+		<rom name="Another Day in Hell (World) (v1.1) (Aftermarket) (Unl).ngc" size="1494777" crc="73d4c2a4" md5="b66c0335be91d86650e31c5942a69323" sha1="8ede8a19190fb5e74658d06f2d076a9fcf440187"/>
 		<url>https://retroachievements.org/game/23731/hashes</url>
 		<hash>b66c0335be91d86650e31c5942a69323</hash>
 	</game>
 	
-	<game name="Homebrew/Blocks (World) (Aftermarket)">
+	<game name="Homebrew/Blocks (World) (Aftermarket) (Unl)">
 		<category>Neo Geo Pocket Color</category>
-		<description>Blocks (World) (Aftermarket)</description>
-		<rom name="Blocks (World) (Aftermarket).ngc" size="32768" crc="dfd9d777" md5="e2b6d75c63b17e18cd02411f6ce1d6e4" sha1="8bb44863e9e874d8d78234a406f84e33711fc495"/>
+		<description>Blocks (World) (Aftermarket) (Unl)</description>
+		<rom name="Blocks (World) (Aftermarket) (Unl).ngc" size="32768" crc="dfd9d777" md5="e2b6d75c63b17e18cd02411f6ce1d6e4" sha1="8bb44863e9e874d8d78234a406f84e33711fc495"/>
 		<url>https://retroachievements.org/game/23744/hashes</url>
 		<hash>e2b6d75c63b17e18cd02411f6ce1d6e4</hash>
 	</game>
 	
-	<game name="Homebrew/Bomberman (World) (v1.1) (Unl) (Aftermarket)">
+	<game name="Homebrew/Bomberman (World) (v1.1) (Aftermarket) (Unl)">
 		<category>Neo Geo Pocket Color</category>
-		<description>Bomberman (World) (v1.1) (Unl) (Aftermarket)</description>
-		<rom name="Bomberman (World) (v1.1) (Unl) (Aftermarket).ngc" size="1910804" crc="61b14431" md5="3f18507c9aa7e80b9aa75ce9e69de9ed" sha1="18f722428e3033ba631f4f049520577da867731e"/>
+		<description>Bomberman (World) (v1.1) (Aftermarket) (Unl)</description>
+		<rom name="Bomberman (World) (v1.1) (Aftermarket) (Unl).ngc" size="1910804" crc="61b14431" md5="3f18507c9aa7e80b9aa75ce9e69de9ed" sha1="18f722428e3033ba631f4f049520577da867731e"/>
 		<url>https://retroachievements.org/game/23735/hashes</url>
 		<hash>3f18507c9aa7e80b9aa75ce9e69de9ed</hash>
 	</game>
 	
-	<game name="Homebrew/Diamond Run (World) (Aftermarket)">
+	<game name="Homebrew/Diamond Run (World) (Aftermarket) (Unl)">
 		<category>Neo Geo Pocket Color</category>
-		<description>Diamond Run (World) (Aftermarket)</description>
-		<rom name="Diamond Run (World) (Aftermarket).ngc" size="32768" crc="97c58fd0" md5="0cd4aa9a72ececf14508de6ae6725ed1" sha1="76f82acc6e5df9c4980a56361966058653cd32f6"/>
+		<description>Diamond Run (World) (Aftermarket) (Unl)</description>
+		<rom name="Diamond Run (World) (Aftermarket) (Unl).ngc" size="32768" crc="97c58fd0" md5="0cd4aa9a72ececf14508de6ae6725ed1" sha1="76f82acc6e5df9c4980a56361966058653cd32f6"/>
 		<url>https://retroachievements.org/game/19896/hashes</url>
 		<hash>0cd4aa9a72ececf14508de6ae6725ed1</hash>
 	</game>
 	
-	<game name="Homebrew/Gears of Fate (World) (v20090508) (Aftermarket)">
+	<game name="Homebrew/Gears of Fate (World) (v20090508) (Aftermarket) (Unl)">
 		<category>Neo Geo Pocket Color</category>
-		<description>Gears of Fate (World) (v20090508) (Aftermarket)</description>
-		<rom name="Gears of Fate (World) (v20090508) (Aftermarket).ngc" size="1917732" crc="3c75807e" md5="782c7aec693c95de10e05a268c023ce1" sha1="b2356a4c4af8cb40a212a2e29a74084dfda6c53a"/>
+		<description>Gears of Fate (World) (v20090508) (Aftermarket) (Unl)</description>
+		<rom name="Gears of Fate (World) (v20090508) (Aftermarket) (Unl).ngc" size="1917732" crc="3c75807e" md5="782c7aec693c95de10e05a268c023ce1" sha1="b2356a4c4af8cb40a212a2e29a74084dfda6c53a"/>
 		<url>https://retroachievements.org/game/23737/hashes</url>
 		<hash>782c7aec693c95de10e05a268c023ce1</hash>
 	</game>
 	
-	<game name="Homebrew/Lights! (World) (v1.1) (Aftermarket)">
+	<game name="Homebrew/Lights! (World) (v1.1) (Aftermarket) (Unl)">
 		<category>Neo Geo Pocket Color</category>
-		<description>Lights! (World) (v1.1) (Aftermarket)</description>
-		<rom name="Lights! (World) (v1.1) (Aftermarket).ngc" size="32768" crc="281de628" md5="1715311acd6bf2717a3b1bf70321d195" sha1="eeac12009e07025e46a188b17b38fdae2c7346a6"/>
+		<description>Lights! (World) (v1.1) (Aftermarket) (Unl)</description>
+		<rom name="Lights! (World) (v1.1) (Aftermarket) (Unl).ngc" size="32768" crc="281de628" md5="1715311acd6bf2717a3b1bf70321d195" sha1="eeac12009e07025e46a188b17b38fdae2c7346a6"/>
 		<url>https://retroachievements.org/game/23745/hashes</url>
 		<hash>1715311acd6bf2717a3b1bf70321d195</hash>
 	</game>
 	
-	<game name="Homebrew/Mines (World) (Aftermarket)">
+	<game name="Homebrew/Mines (World) (Aftermarket) (Unl)">
 		<category>Neo Geo Pocket Color</category>
-		<description>Mines (World) (Aftermarket)</description>
-		<rom name="Mines (World) (Aftermarket).ngc" size="32768" crc="4b687e99" md5="6594d32d6774b616949a31641799472a" sha1="7aa07c67a6aa8d398370bceea7124f9e2e5b03f8"/>
+		<description>Mines (World) (Aftermarket) (Unl)</description>
+		<rom name="Mines (World) (Aftermarket) (Unl).ngc" size="32768" crc="4b687e99" md5="6594d32d6774b616949a31641799472a" sha1="7aa07c67a6aa8d398370bceea7124f9e2e5b03f8"/>
 		<url>https://retroachievements.org/game/23741/hashes</url>
 		<hash>6594d32d6774b616949a31641799472a</hash>
 	</game>
 	
-	<game name="Homebrew/Mr. Do! (World) (Aftermarket)">
+	<game name="Homebrew/Mr. Do! (World) (Aftermarket) (Unl)">
 		<category>Neo Geo Pocket Color</category>
-		<description>Mr. Do! (World) (Aftermarket)</description>
-		<rom name="Mr. Do! (World) (Aftermarket).ngc" size="16152" crc="0098c7b5" md5="2ee3331dd1e34020bbafdd91df0ce1bb" sha1="3e0ea487d3647936413a42570d0a1a6565cc6ec9"/>
+		<description>Mr. Do! (World) (Aftermarket) (Unl)</description>
+		<rom name="Mr. Do! (World) (Aftermarket) (Unl).ngc" size="16152" crc="0098c7b5" md5="2ee3331dd1e34020bbafdd91df0ce1bb" sha1="3e0ea487d3647936413a42570d0a1a6565cc6ec9"/>
 		<url>https://retroachievements.org/game/23747/hashes</url>
 		<hash>2ee3331dd1e34020bbafdd91df0ce1bb</hash>
 	</game>
 	
-	<game name="Homebrew/Puzzle Gems (World) (v1.1) (Aftermarket)">
+	<game name="Homebrew/Puzzle Gems (World) (v1.1) (Aftermarket) (Unl)">
 		<category>Neo Geo Pocket Color</category>
-		<description>Puzzle Gems (World) (v1.1) (Aftermarket)</description>
-		<rom name="Puzzle Gems (World) (v1.1) (Aftermarket).ngc" size="39798" crc="ef104269" md5="04a35a8f274479a061b88bdeee8ee6d4" sha1="cf0fc231f7386ffb9fbf5825d03a758fa0236081"/>
+		<description>Puzzle Gems (World) (v1.1) (Aftermarket) (Unl)</description>
+		<rom name="Puzzle Gems (World) (v1.1) (Aftermarket) (Unl).ngc" size="39798" crc="ef104269" md5="04a35a8f274479a061b88bdeee8ee6d4" sha1="cf0fc231f7386ffb9fbf5825d03a758fa0236081"/>
 		<url>https://retroachievements.org/game/23733/hashes</url>
 		<hash>04a35a8f274479a061b88bdeee8ee6d4</hash>
 	</game>
 	
-	<game name="Homebrew/Snake (World) (v1.2) (Aftermarket)">
+	<game name="Homebrew/Snake (World) (v1.2) (Aftermarket) (Unl)">
 		<category>Neo Geo Pocket Color</category>
-		<description>Snake (World) (v1.2) (Aftermarket)</description>
-		<rom name="Snake (World) (v1.2) (Aftermarket).ngc" size="524288" crc="82510aa9" md5="62029cf9c8af82f4dd13bd0243693d32" sha1="2ca5b0e26dbb6f399ff89183de17603ea78e87a7"/>
+		<description>Snake (World) (v1.2) (Aftermarket) (Unl)</description>
+		<rom name="Snake (World) (v1.2) (Aftermarket) (Unl).ngc" size="524288" crc="82510aa9" md5="62029cf9c8af82f4dd13bd0243693d32" sha1="2ca5b0e26dbb6f399ff89183de17603ea78e87a7"/>
 		<url>https://retroachievements.org/game/23738/hashes</url>
 		<hash>62029cf9c8af82f4dd13bd0243693d32</hash>
 	</game>
@@ -101,12 +101,12 @@
 		<hash>184dc284995dc20ddce599426b9cac7d</hash>
 	</game>
 	
-	<game name="Retail/Biomotor Unitron (USA, Europe)">
+	<game name="Retail/Bust-A-Move Pocket (USA)">
 		<category>Neo Geo Pocket Color</category>
-		<description>Biomotor Unitron (USA, Europe)</description>
-		<rom name="Biomotor Unitron (USA, Europe).ngc" size="1048576" crc="3807df4f" md5="f4bbe8cf42074b75c8a911bf7b0562d5" sha1="ff74d5877bf58164419710888923e46b9cfb415e"/>
-		<url>https://retroachievements.org/game/11572/hashes</url>
-		<hash>f4bbe8cf42074b75c8a911bf7b0562d5</hash>
+		<description>Bust-A-Move Pocket (USA)</description>
+		<rom name="Bust-A-Move Pocket (USA).ngc" size="1048576" crc="b073d601" md5="d91fd1c6c941bc2bde4ada3580fe408f" sha1="3b102e32fccf8ff389c508be55517368d56b144f"/>
+		<url>https://retroachievements.org/game/11573/hashes</url>
+		<hash>d91fd1c6c941bc2bde4ada3580fe408f</hash>
 	</game>
 	
 	<game name="Retail/Cool Boarders Pocket (Japan, Europe) (En,Ja)">
@@ -155,10 +155,10 @@
 		<url>https://retroachievements.org/game/14396/hashes</url>
 		<hash>64495ddd898f14e9c89e02179ab6f5e0</hash>
 	</game>
-	<game name="Retail/Delta Warp/Delta Warp (Japan) (En,Ja) (RetroHQ Fixed) ">
+	<game name="Retail/Delta Warp/Delta Warp (Japan) (En,Ja) (RetroHQ Fixed)">
 		<category>Neo Geo Pocket Color</category>
-		<description>Delta Warp (Japan) (En,Ja) (RetroHQ Fixed) </description>
-		<rom name="Delta Warp (Japan) (En,Ja) (RetroHQ Fixed) .ngc" size="1048576" crc="efecb4b8" md5="905a97b0100f8ee7080628bfef815a33" sha1="dccdcd138f9f2413387a9ef5cd879ebf9dc2473e"/>
+		<description>Delta Warp (Japan) (En,Ja) (RetroHQ Fixed)</description>
+		<rom name="Delta Warp (Japan) (En,Ja) (RetroHQ Fixed).ngc" size="1048576" crc="efecb4b8" md5="905a97b0100f8ee7080628bfef815a33" sha1="dccdcd138f9f2413387a9ef5cd879ebf9dc2473e"/>
 		<url>https://retroachievements.org/game/14396/hashes</url>
 		<hash>905a97b0100f8ee7080628bfef815a33</hash>
 	</game>
@@ -416,10 +416,10 @@
 		<url>https://retroachievements.org/game/32107/hashes</url>
 		<hash>362e9c04ec255225eeb0a9dee8fcac1b</hash>
 	</game>
-	<game name="Retail/The King of Fighters - Battle de Paradise/King of Fighters, The - Battle de Paradise (En) (v1.0) (marc_max, xenophile127)">
+	<game name="Retail/The King of Fighters - Battle de Paradise/King of Fighters, The - Battle de Paradise (Japan) (v1.0) (marc_max, xenophile127)">
 		<category>Neo Geo Pocket Color</category>
-		<description>King of Fighters, The - Battle de Paradise (En) (v1.0) (marc_max, xenophile127)</description>
-		<rom name="King of Fighters, The - Battle de Paradise (En) (v1.0) (marc_max, xenophile127).ngc" size="2097152" crc="e08dc918" md5="b16a89f1787c83212b964e7fb570a060" sha1="967b0d1a7074ecbfbd4bf476fcaed3be30e2a7b3"/>
+		<description>King of Fighters, The - Battle de Paradise (Japan) (v1.0) (marc_max, xenophile127)</description>
+		<rom name="King of Fighters, The - Battle de Paradise (Japan) (v1.0) (marc_max, xenophile127).ngc" size="2097152" crc="e08dc918" md5="b16a89f1787c83212b964e7fb570a060" sha1="967b0d1a7074ecbfbd4bf476fcaed3be30e2a7b3"/>
 		<url>https://retroachievements.org/game/32107/hashes</url>
 		<hash>b16a89f1787c83212b964e7fb570a060</hash>
 	</game>

--- a/DATs/RetroAchievements (Subfolders)/RA - Sega 32X.dat
+++ b/DATs/RetroAchievements (Subfolders)/RA - Sega 32X.dat
@@ -5,8 +5,8 @@
 		<name>RA - Sega 32X</name>
 		<description>Sega 32X</description>
 		<category>Subfolders</category>
-		<version>20260227</version>
-		<date>27 February 2026</date>
+		<version>20260427</version>
+		<date>27 April 2026</date>
 		<author>AzgoRAth, NeoRetroGamer (Contributor), Jumphil (Contributor)</author>
 		<homepage>https://retroachievements.org</homepage>
 		<url>https://retroachievements.org/system/10/games</url>
@@ -60,34 +60,34 @@
 		<hash>16a811628cd9245f2101e218581cd594</hash>
 	</game>
 	
-	<game name="Homebrew/Double Symbol (World) (v1.35) (Timur Lyazgiev) (Aftermarket)">
+	<game name="Homebrew/Double Symbol (World) (v1.35) (Aftermarket) (Timur Lyazgiev)">
 		<category></category>
-		<description>Double Symbol (World) (v1.35) (Timur Lyazgiev) (Aftermarket)</description>
-		<rom name="Double Symbol (World) (v1.35) (Timur Lyazgiev) (Aftermarket).32x" size="484748" crc="2812d4fe" md5="4b14e8c22a97b4fd164e077a4980c582" sha1="54421dcfeecb9d00d1e6deeb191d921baa323a4e"/>
+		<description>Double Symbol (World) (v1.35) (Aftermarket) (Timur Lyazgiev)</description>
+		<rom name="Double Symbol (World) (v1.35) (Aftermarket) (Timur Lyazgiev).32x" size="484748" crc="2812d4fe" md5="4b14e8c22a97b4fd164e077a4980c582" sha1="54421dcfeecb9d00d1e6deeb191d921baa323a4e"/>
 		<url>https://retroachievements.org/game/33570/hashes</url>
 		<hash>4b14e8c22a97b4fd164e077a4980c582</hash>
 	</game>
 	
-	<game name="Homebrew/xRick (USA) (v2011-04-30) (Chilly Willy) (Aftermarket)">
+	<game name="Homebrew/xRick (World) (Aftermarket) (Unl)">
 		<category></category>
-		<description>xRick (USA) (v2011-04-30) (Chilly Willy) (Aftermarket)</description>
-		<rom name="xRick (USA) (v2011-04-30) (Chilly Willy) (Aftermarket).bin" size="4194304" crc="fd07db46" md5="f642e289bfb670022e0ae001786bdf94" sha1="f951890e6cd3cfd5e4cba13be8c8aea4f70d36a5"/>
+		<description>xRick (World) (Aftermarket) (Unl)</description>
+		<rom name="xRick (World) (Aftermarket) (Unl).32x" size="4194304" crc="fd07db46" md5="f642e289bfb670022e0ae001786bdf94" sha1="f951890e6cd3cfd5e4cba13be8c8aea4f70d36a5"/>
 		<url>https://retroachievements.org/game/17682/hashes</url>
 		<hash>f642e289bfb670022e0ae001786bdf94</hash>
 	</game>
 	
-	<game name="Prototype/ClayFighter 2 (USA) (Proto) (1995-04-28)">
+	<game name="Prototype/ClayFighter 2 (USA) (Proto)">
 		<category></category>
-		<description>ClayFighter 2 (USA) (Proto) (1995-04-28)</description>
-		<rom name="ClayFighter 2 (USA) (Proto) (1995-04-28).32x" size="1048576" crc="59701755" md5="dee27ac83240ddebdcaa92e9f58fde4f" sha1="1d3c372b55fa1418556aea1949995f997227b5fa"/>
+		<description>ClayFighter 2 (USA) (Proto)</description>
+		<rom name="ClayFighter 2 (USA) (Proto).32x" size="1048576" crc="59701755" md5="dee27ac83240ddebdcaa92e9f58fde4f" sha1="1d3c372b55fa1418556aea1949995f997227b5fa"/>
 		<url>https://retroachievements.org/game/16794/hashes</url>
 		<hash>dee27ac83240ddebdcaa92e9f58fde4f</hash>
 	</game>
 	
-	<game name="Prototype/Pinocchio (Europe) (Proto) (1995-12-06)">
+	<game name="Prototype/Pinocchio (Europe) (Proto)">
 		<category></category>
-		<description>Pinocchio (Europe) (Proto) (1995-12-06)</description>
-		<rom name="Pinocchio (Europe) (Proto) (1995-12-06).32x" size="4194304" crc="390a90f9" md5="406ab3e46797d8459c3d9efbbc044282" sha1="39ccf67e516bdaec879f1e30b23d5f253e82b6c8"/>
+		<description>Pinocchio (Europe) (Proto)</description>
+		<rom name="Pinocchio (Europe) (Proto).32x" size="4194304" crc="390a90f9" md5="406ab3e46797d8459c3d9efbbc044282" sha1="39ccf67e516bdaec879f1e30b23d5f253e82b6c8"/>
 		<url>https://retroachievements.org/game/16800/hashes</url>
 		<hash>406ab3e46797d8459c3d9efbbc044282</hash>
 	</game>

--- a/DATs/RetroAchievements (Subfolders)/RA - Sega Game Gear.dat
+++ b/DATs/RetroAchievements (Subfolders)/RA - Sega Game Gear.dat
@@ -5,34 +5,42 @@
 		<name>RA - Sega Game Gear</name>
 		<description>Sega Game Gear</description>
 		<category>Subfolders</category>
-		<version>20260214</version>
-		<date>14 February 2026</date>
+		<version>20260428</version>
+		<date>28 April 2026</date>
 		<author>AzgoRAth, NeoRetroGamer (Contributor), Jumphil (Contributor)</author>
 		<homepage>https://retroachievements.org</homepage>
 		<url>https://retroachievements.org/system/15/games</url>
-		<titlecount>113</titlecount>
-		<hashcount>137/138</hashcount>
+		<titlecount>119</titlecount>
+		<hashcount>143/144</hashcount>
 	</header>
-	<game name="Homebrew/Hamburgers en Route to Switzerland (World) (v0.75) (Proto) (Aftermarket)">
+	<game name="Homebrew/Hamburgers en Route to Switzerland (World) (Proto 2) (Aftermarket) (Unl)">
 		<category></category>
-		<description>Hamburgers en Route to Switzerland (World) (v0.75) (Proto) (Aftermarket)</description>
-		<rom name="Hamburgers en Route to Switzerland (World) (v0.75) (Proto) (Aftermarket).gg" size="131072" crc="f4fad7c2" md5="c91f1bcc0b4ab1abac998ce8a02bbafb" sha1="de7f24f7bcc6b6a225b994c82d4e2ea6aac0f4e7"/>
+		<description>Hamburgers en Route to Switzerland (World) (Proto 2) (Aftermarket) (Unl)</description>
+		<rom name="Hamburgers en Route to Switzerland (World) (Proto 2) (Aftermarket) (Unl).gg" size="131072" crc="f4fad7c2" md5="c91f1bcc0b4ab1abac998ce8a02bbafb" sha1="de7f24f7bcc6b6a225b994c82d4e2ea6aac0f4e7"/>
 		<url>https://retroachievements.org/game/28834/hashes</url>
 		<hash>c91f1bcc0b4ab1abac998ce8a02bbafb</hash>
 	</game>
 	
-	<game name="Homebrew/Snepzhen Solitaire (World) (v1.0) (Wainstop) (Aftermarket)">
+	<game name="Homebrew/Hopman Mini (World) (Aftermarket) (Unl)">
 		<category></category>
-		<description>Snepzhen Solitaire (World) (v1.0) (Wainstop) (Aftermarket)</description>
-		<rom name="Snepzhen Solitaire (World) (v1.0) (Wainstop) (Aftermarket).gg" size="32768" crc="fd06798c" md5="aca63448b5d887239fc8821760d36efb" sha1="891811a7b86222b01f9a43664db8186e2f8001b8"/>
+		<description>Hopman Mini (World) (Aftermarket) (Unl)</description>
+		<rom name="Hopman Mini (World) (Aftermarket) (Unl).gg" size="16368" crc="84fd672d" md5="73cda8d9cf406c5ad1d69747333482e9" sha1="920aa9c3d64073d140280bf0baed64fe2aaa5dfa"/>
+		<url>https://retroachievements.org/game/32992/hashes</url>
+		<hash>73cda8d9cf406c5ad1d69747333482e9</hash>
+	</game>
+	
+	<game name="Homebrew/Snepzhen Solitaire (World) (Aftermarket) (Unl)">
+		<category></category>
+		<description>Snepzhen Solitaire (World) (Aftermarket) (Unl)</description>
+		<rom name="Snepzhen Solitaire (World) (Aftermarket) (Unl).gg" size="32768" crc="fd06798c" md5="aca63448b5d887239fc8821760d36efb" sha1="891811a7b86222b01f9a43664db8186e2f8001b8"/>
 		<url>https://retroachievements.org/game/30932/hashes</url>
 		<hash>aca63448b5d887239fc8821760d36efb</hash>
 	</game>
 	
-	<game name="Homebrew/Swabby (World) (v1.11) (Aftermarket)">
+	<game name="Homebrew/Swabby (World) (v1.11) (Aftermarket) (Unl)">
 		<category></category>
-		<description>Swabby (World) (v1.11) (Aftermarket)</description>
-		<rom name="Swabby (World) (v1.11) (Aftermarket).gg" size="131072" crc="b814ad3d" md5="db672d52225564b6f520e8a0a4b1a4c7" sha1="64f7350ca2c37c44b679e35f9bfd2766c7259cb9"/>
+		<description>Swabby (World) (v1.11) (Aftermarket) (Unl)</description>
+		<rom name="Swabby (World) (v1.11) (Aftermarket) (Unl).gg" size="131072" crc="b814ad3d" md5="db672d52225564b6f520e8a0a4b1a4c7" sha1="64f7350ca2c37c44b679e35f9bfd2766c7259cb9"/>
 		<url>https://retroachievements.org/game/26880/hashes</url>
 		<hash>db672d52225564b6f520e8a0a4b1a4c7</hash>
 	</game>
@@ -186,10 +194,10 @@
 		<hash>90bd4681e3e4b07445eaf35e83b223db</hash>
 	</game>
 	
-	<game name="Retail/Crayon Shin-chan - Taiketsu! Kantam Panic!! (Japan) (En)">
+	<game name="Retail/Crayon Shin-chan - Taiketsu! Kantam Panic!! (Japan)">
 		<category></category>
-		<description>Crayon Shin-chan - Taiketsu! Kantam Panic!! (Japan) (En)</description>
-		<rom name="Crayon Shin-chan - Taiketsu! Kantam Panic!! (Japan) (En).gg" size="524288" crc="48c18828" md5="3788f49e16ddb70d0af7b2cf63456246" sha1="01aac4e14ae71d3980cf968cc2bd6831e3987ab1"/>
+		<description>Crayon Shin-chan - Taiketsu! Kantam Panic!! (Japan)</description>
+		<rom name="Crayon Shin-chan - Taiketsu! Kantam Panic!! (Japan).gg" size="524288" crc="48c18828" md5="3788f49e16ddb70d0af7b2cf63456246" sha1="01aac4e14ae71d3980cf968cc2bd6831e3987ab1"/>
 		<url>https://retroachievements.org/game/29324/hashes</url>
 		<hash>3788f49e16ddb70d0af7b2cf63456246</hash>
 	</game>
@@ -265,10 +273,10 @@
 		<url>https://retroachievements.org/game/14297/hashes</url>
 		<hash>c58d6291da8a4919328b8f42be8640a7</hash>
 	</game>
-	<game name="Retail/Eternal Legend/Eternal Legend - Eien no Densetsu (Japan) (En) (No-Encounter) (v1.0) (LIPEMCO!,Searo)">
+	<game name="Retail/Eternal Legend/Eternal Legend (Japan) (En) (No-Encounter) (v1.0) (LIPEMCO!,Searo)">
 		<category></category>
-		<description>Eternal Legend - Eien no Densetsu (Japan) (En) (No-Encounter) (v1.0) (LIPEMCO!,Searo)</description>
-		<rom name="Eternal Legend - Eien no Densetsu (Japan) (En) (No-Encounter) (v1.0) (LIPEMCO!,Searo).gg" size="1048576" crc="75988ab3" md5="e8f49ea568e174b50079f725ce29f45d" sha1="5a5cf544317465db0b486e4edc6d1354b693f0a8"/>
+		<description>Eternal Legend (Japan) (En) (No-Encounter) (v1.0) (LIPEMCO!,Searo)</description>
+		<rom name="Eternal Legend (Japan) (En) (No-Encounter) (v1.0) (LIPEMCO!,Searo).gg" size="1048576" crc="75988ab3" md5="e8f49ea568e174b50079f725ce29f45d" sha1="5a5cf544317465db0b486e4edc6d1354b693f0a8"/>
 		<url>https://retroachievements.org/game/14297/hashes</url>
 		<hash>e8f49ea568e174b50079f725ce29f45d</hash>
 	</game>
@@ -297,10 +305,10 @@
 		<hash>43301e7c15fe11f66b29b00e6ec47a52</hash>
 	</game>
 	
-	<game name="Retail/GG Aleste 3 (Japan) (En) (Playability Patch)">
+	<game name="Retail/GG Aleste 3 (Japan) (En) (Aleste Collection) (Playability Patch)">
 		<category></category>
-		<description>GG Aleste 3 (Japan) (En) (Playability Patch)</description>
-		<rom name="GG Aleste 3 (Japan) (En) (Playability Patch).gg" size="1048576" crc="717fd9e3" md5="41f9b360571a8aae3b01e780e90a9f68" sha1="b2948f2498d3095aebdb5fe4a62590c12c8ea846"/>
+		<description>GG Aleste 3 (Japan) (En) (Aleste Collection) (Playability Patch)</description>
+		<rom name="GG Aleste 3 (Japan) (En) (Aleste Collection) (Playability Patch).gg" size="1048576" crc="717fd9e3" md5="41f9b360571a8aae3b01e780e90a9f68" sha1="b2948f2498d3095aebdb5fe4a62590c12c8ea846"/>
 		<url>https://retroachievements.org/game/27591/hashes</url>
 		<hash>41f9b360571a8aae3b01e780e90a9f68</hash>
 	</game>
@@ -320,7 +328,7 @@
 		<url>https://retroachievements.org/game/17036/hashes</url>
 		<hash>82d3c23cf9617174aa47bed8e76438df</hash>
 	</game>
-
+	
 	<game name="Gunstar Heroes (Japan)">
 		<category>Retail</category>
 		<description>Gunstar Heroes (Japan)</description>
@@ -329,7 +337,7 @@
 		<url>https://retroachievements.org/game/12624/hashes</url>
 		<hash>c46d46f3ab4873cb1ed7ae8b9b70f2b4</hash>
 	</game>
-
+	
 	<game name="Retail/Halley Wars (USA, Europe, Brazil) (En)">
 		<category></category>
 		<description>Halley Wars (USA, Europe, Brazil) (En)</description>
@@ -383,10 +391,10 @@
 		<url>https://retroachievements.org/game/12896/hashes</url>
 		<hash>ac6ed281ac8e9d71af186602951cfd7a</hash>
 	</game>
-	<game name="Retail/Kishin Douji Zenki/Kishin Douji Zenki (Japan) (En) (v1.0) (LIPEMCO Translations)">
+	<game name="Retail/Kishin Douji Zenki/Kishin Douji Zenki (Japan) (En) (v1.0) (LIPEMCO! Translations)">
 		<category></category>
-		<description>Kishin Douji Zenki (Japan) (En) (v1.0) (LIPEMCO Translations)</description>
-		<rom name="Kishin Douji Zenki (Japan) (En) (v1.0) (LIPEMCO Translations).gg" size="1048576" crc="dcd63e4c" md5="b0f8f7a3b573468f1d65b660c173dc82" sha1="048e3bddc01f4079d0a6a54efbeca1254d10d1f2"/>
+		<description>Kishin Douji Zenki (Japan) (En) (v1.0) (LIPEMCO! Translations)</description>
+		<rom name="Kishin Douji Zenki (Japan) (En) (v1.0) (LIPEMCO! Translations).gg" size="1048576" crc="dcd63e4c" md5="b0f8f7a3b573468f1d65b660c173dc82" sha1="048e3bddc01f4079d0a6a54efbeca1254d10d1f2"/>
 		<url>https://retroachievements.org/game/12896/hashes</url>
 		<hash>b0f8f7a3b573468f1d65b660c173dc82</hash>
 	</game>
@@ -609,10 +617,10 @@
 		<hash>4d0d6d25dfef7e1a509d828f157d515f</hash>
 	</game>
 	
-	<game name="Retail/Pengo/Pengo (Japan)">
+	<game name="Retail/Pengo/Pengo (Japan) (En)">
 		<category></category>
-		<description>Pengo (Japan)</description>
-		<rom name="Pengo (Japan).gg" size="32768" crc="ce863dba" md5="95cea3a33a3f5915942904b4817b2010" sha1="5883e2d19ab7126d52abc177a97d44bc88c319de"/>
+		<description>Pengo (Japan) (En)</description>
+		<rom name="Pengo (Japan) (En).gg" size="32768" crc="ce863dba" md5="95cea3a33a3f5915942904b4817b2010" sha1="5883e2d19ab7126d52abc177a97d44bc88c319de"/>
 		<url>https://retroachievements.org/game/12251/hashes</url>
 		<hash>95cea3a33a3f5915942904b4817b2010</hash>
 	</game>
@@ -632,19 +640,19 @@
 		<hash>c069464b6a0f9fa547c22133f143b75c</hash>
 	</game>
 	
-	<game name="Retail/Phantasy Star Gaiden/Phantasy Star Gaiden (Japan) (En) (v1.012) (Dynamic Designs)">
-		<category></category>
-		<description>Phantasy Star Gaiden (Japan) (En) (v1.012) (Dynamic Designs)</description>
-		<rom name="Phantasy Star Gaiden (Japan) (En) (v1.012) (Dynamic Designs).gg" size="262144" crc="17e64f1e" md5="39aa719b13cd1c50c30232cf5ac80059" sha1="adab47ecc3c0d574243205ddd6edbae6c12bce64"/>
-		<url>https://retroachievements.org/game/12884/hashes</url>
-		<hash>39aa719b13cd1c50c30232cf5ac80059</hash>
-	</game>
 	<game name="Retail/Phantasy Star Gaiden/Phantasy Star Gaiden (Japan)">
 		<category></category>
 		<description>Phantasy Star Gaiden (Japan)</description>
 		<rom name="Phantasy Star Gaiden (Japan).gg" size="262144" crc="a942514a" md5="54be96ca21885145108f1c02e4d88eba" sha1="914f1e693f396794a37b5d99acaf5db54fe529c2"/>
 		<url>https://retroachievements.org/game/12884/hashes</url>
 		<hash>54be96ca21885145108f1c02e4d88eba</hash>
+	</game>
+	<game name="Retail/Phantasy Star Gaiden/Phantasy Star Gaiden (Japan) (En) (v1.012) (Dynamic Designs)">
+		<category></category>
+		<description>Phantasy Star Gaiden (Japan) (En) (v1.012) (Dynamic Designs)</description>
+		<rom name="Phantasy Star Gaiden (Japan) (En) (v1.012) (Dynamic Designs).gg" size="262144" crc="17e64f1e" md5="39aa719b13cd1c50c30232cf5ac80059" sha1="adab47ecc3c0d574243205ddd6edbae6c12bce64"/>
+		<url>https://retroachievements.org/game/12884/hashes</url>
+		<hash>39aa719b13cd1c50c30232cf5ac80059</hash>
 	</game>
 	<game name="Retail/Phantasy Star Gaiden/Phantasy Star Gaiden (Japan) (En) (Wide Font) (v1.012) (Dynamic Designs)">
 		<category></category>
@@ -654,10 +662,10 @@
 		<hash>ba091114cbc5a4b3482e6887094070bb</hash>
 	</game>
 	
-	<game name="Retail/Pop Breaker (Japan)">
+	<game name="Retail/Pop Breaker (Japan) (En)">
 		<category></category>
-		<description>Pop Breaker (Japan)</description>
-		<rom name="Pop Breaker (Japan).gg" size="131072" crc="71deba5a" md5="e0e2fbd5834c04574795c923b0147f39" sha1="9c358504d3c106dd62bd8981132b47cdb95903de"/>
+		<description>Pop Breaker (Japan) (En)</description>
+		<rom name="Pop Breaker (Japan) (En).gg" size="131072" crc="71deba5a" md5="e0e2fbd5834c04574795c923b0147f39" sha1="9c358504d3c106dd62bd8981132b47cdb95903de"/>
 		<url>https://retroachievements.org/game/14301/hashes</url>
 		<hash>e0e2fbd5834c04574795c923b0147f39</hash>
 	</game>
@@ -693,10 +701,10 @@
 		<url>https://retroachievements.org/game/14059/hashes</url>
 		<hash>52cfddc12af6a3a64030f62ccf6aca83</hash>
 	</game>
-	<game name="Retail/Psychic World/Psychic World (Japan) (En)">
+	<game name="Retail/Psychic World/Psychic World (Japan)">
 		<category></category>
-		<description>Psychic World (Japan) (En)</description>
-		<rom name="Psychic World (Japan) (En).sms" size="131072" crc="afcc7828" md5="a764b44555aadb48c519e7c85bdf7895" sha1="1c0074c811ed4eb369be31c1bc7d851e40ae8797"/>
+		<description>Psychic World (Japan)</description>
+		<rom name="Psychic World (Japan).sms" size="131072" crc="afcc7828" md5="a764b44555aadb48c519e7c85bdf7895" sha1="1c0074c811ed4eb369be31c1bc7d851e40ae8797"/>
 		<url>https://retroachievements.org/game/14059/hashes</url>
 		<hash>a764b44555aadb48c519e7c85bdf7895</hash>
 	</game>
@@ -708,11 +716,11 @@
 		<url>https://retroachievements.org/game/26242/hashes</url>
 		<hash>dcec1000aea3882b218b0cc0aed5a5d8</hash>
 	</game>
-
-	<game name="Retail/Rastan Saga (Japan)">
+	
+	<game name="Retail/Rastan Saga (Japan) (En)">
 		<category></category>
-		<description>Rastan Saga (Japan)</description>
-		<rom name="Rastan Saga (Japan).sms" size="262144" crc="9c76fb3a" md5="fd82af26ebbed24f57c4eea8eddf3136" sha1="96bf8a67919218aac91fb74cde80a16f90df77d5"/>
+		<description>Rastan Saga (Japan) (En)</description>
+		<rom name="Rastan Saga (Japan) (En).sms" size="262144" crc="9c76fb3a" md5="fd82af26ebbed24f57c4eea8eddf3136" sha1="96bf8a67919218aac91fb74cde80a16f90df77d5"/>
 		<url>https://retroachievements.org/game/17698/hashes</url>
 		<hash>fd82af26ebbed24f57c4eea8eddf3136</hash>
 	</game>
@@ -764,10 +772,10 @@
 		<hash>f96d7da86e4f63d66175b1903f976b2c</hash>
 	</game>
 	
-	<game name="Retail/Shining Force Gaiden/Shining Force Gaiden - Final Conflict (Japan) (En) (Debug Patch) (Bartis1989)">
+	<game name="Retail/Shining Force Gaiden/Shining Force Gaiden - Final Conflict (Japan) (En) (Debug Patch) (Shining Force Central,Bartis1989)">
 		<category></category>
-		<description>Shining Force Gaiden - Final Conflict (Japan) (En) (Debug Patch) (Bartis1989)</description>
-		<rom name="Shining Force Gaiden - Final Conflict (Japan) (En) (Debug Patch) (Bartis1989).gg" size="524288" crc="88d26fcd" md5="219b1a3f5e055fce7245d869e1fc9249" sha1="a7f5ee9d8287a32e7d9c18ff8f491555785f5ed1"/>
+		<description>Shining Force Gaiden - Final Conflict (Japan) (En) (Debug Patch) (Shining Force Central,Bartis1989)</description>
+		<rom name="Shining Force Gaiden - Final Conflict (Japan) (En) (Debug Patch) (Shining Force Central,Bartis1989).gg" size="524288" crc="88d26fcd" md5="219b1a3f5e055fce7245d869e1fc9249" sha1="a7f5ee9d8287a32e7d9c18ff8f491555785f5ed1"/>
 		<url>https://retroachievements.org/game/12640/hashes</url>
 		<hash>219b1a3f5e055fce7245d869e1fc9249</hash>
 	</game>
@@ -779,10 +787,10 @@
 		<hash>b7b023b6c716c8c984c3268a962cf99b</hash>
 	</game>
 	
-	<game name="Retail/Shining Force - The Sword of Hajya/Shining Force - The Sword of Hajya (USA) (Debug Patch) (Bartis 1989)">
+	<game name="Retail/Shining Force - The Sword of Hajya/Shining Force - The Sword of Hajya (USA) (Debug Patch) (Bartis1989)">
 		<category></category>
-		<description>Shining Force - The Sword of Hajya (USA) (Debug Patch) (Bartis 1989)</description>
-		<rom name="Shining Force - The Sword of Hajya (USA) (Debug Patch) (Bartis 1989).gg" size="524288" crc="90ac7c6a" md5="4c749140795a0fb69a06574d5187cd25" sha1="c010b70d2ab6dd010bee676da11bf69a90c39a01"/>
+		<description>Shining Force - The Sword of Hajya (USA) (Debug Patch) (Bartis1989)</description>
+		<rom name="Shining Force - The Sword of Hajya (USA) (Debug Patch) (Bartis1989).gg" size="524288" crc="90ac7c6a" md5="4c749140795a0fb69a06574d5187cd25" sha1="c010b70d2ab6dd010bee676da11bf69a90c39a01"/>
 		<url>https://retroachievements.org/game/12639/hashes</url>
 		<hash>4c749140795a0fb69a06574d5187cd25</hash>
 	</game>
@@ -1093,6 +1101,22 @@
 		<rom name="X-Men (USA).gg" size="524288" crc="567a5ee6" md5="21d75ed09b6f73037544894580933a0b" sha1="215e5f761475ca17a091371e39f636718f213403"/>
 		<url>https://retroachievements.org/game/13394/hashes</url>
 		<hash>21d75ed09b6f73037544894580933a0b</hash>
+	</game>
+	
+	<game name="Retail/X-Men - Gamemaster's Legacy (USA, Europe)">
+		<category></category>
+		<description>X-Men - Gamemaster's Legacy (USA, Europe)</description>
+		<rom name="X-Men - Gamemaster's Legacy (USA, Europe).gg" size="524288" crc="c169c344" md5="571ac03b80e3075c699cd583bf8651fd" sha1="872596d40aae1755c9dda99180cb165166267904"/>
+		<url>https://retroachievements.org/game/13396/hashes</url>
+		<hash>571ac03b80e3075c699cd583bf8651fd</hash>
+	</game>
+	
+	<game name="Retail/X-Men - Mojo World (USA)">
+		<category></category>
+		<description>X-Men - Mojo World (USA)</description>
+		<rom name="X-Men - Mojo World (USA).gg" size="524288" crc="c2cba9d7" md5="ca15f2ba2507ebd836c42d9d10231eb1" sha1="cff15c4a3e555c2868af93c55386b5ab3d3db4e3"/>
+		<url>https://retroachievements.org/game/26255/hashes</url>
+		<hash>ca15f2ba2507ebd836c42d9d10231eb1</hash>
 	</game>
 	
 	<game name="Retail/Yu Yu Hakusho II/Yu Yu Hakusho II - Gekitou! Nanakyou no Tatakai (Japan)">

--- a/DATs/RetroAchievements (Subfolders)/RA - Sega SG-1000.dat
+++ b/DATs/RetroAchievements (Subfolders)/RA - Sega SG-1000.dat
@@ -5,144 +5,144 @@
 		<name>RA - Sega SG-1000</name>
 		<description>Sega SG-1000</description>
 		<category>Subfolders</category>
-		<version>20251225</version>
-		<date>25 December 2025</date>
+		<version>20260427</version>
+		<date>27 April 2026</date>
 		<author>AzgoRAth, NeoRetroGamer (Contributor), Jumphil (Contributor)</author>
 		<homepage>https://retroachievements.org</homepage>
 		<url>https://retroachievements.org/system/33/games</url>
-		<titlecount>92</titlecount>
-		<hashcount>108/109</hashcount>
+		<titlecount>93</titlecount>
+		<hashcount>109/110</hashcount>
 	</header>
-	<game name="Homebrew/Cheril Perils Classic (World) (NTSC) (Aftermarket)">
+	<game name="Homebrew/Cheril Perils Classic (World) (NTSC) (Aftermarket) (Unl)">
 		<category></category>
-		<description>Cheril Perils Classic (World) (NTSC) (Aftermarket)</description>
-		<rom name="Cheril Perils Classic (World) (NTSC) (Aftermarket).sg" size="49152" crc="60d5c65d" md5="dea9e4e5891fbdcd3e0df16fc840afbe" sha1="877c7f71daf10c451745d68c2c88e5c06abc5c42"/>
+		<description>Cheril Perils Classic (World) (NTSC) (Aftermarket) (Unl)</description>
+		<rom name="Cheril Perils Classic (World) (NTSC) (Aftermarket) (Unl).sg" size="49152" crc="60d5c65d" md5="dea9e4e5891fbdcd3e0df16fc840afbe" sha1="877c7f71daf10c451745d68c2c88e5c06abc5c42"/>
 		<url>https://retroachievements.org/game/22685/hashes</url>
 		<hash>dea9e4e5891fbdcd3e0df16fc840afbe</hash>
 	</game>
 	
-	<game name="Homebrew/Earth Attack (USA) (v2021116) (Aftermarket)">
+	<game name="Homebrew/Earth Attack (USA) (v2021116) (Aftermarket) (Unl)">
 		<category></category>
-		<description>Earth Attack (USA) (v2021116) (Aftermarket)</description>
-		<rom name="Earth Attack (USA) (v2021116) (Aftermarket).sg" size="16384" crc="575c7f2a" md5="be7798f9073f9a587ff0a36b646c65b7" sha1="92636a511152051a593976a4651c85c8affea614"/>
+		<description>Earth Attack (USA) (v2021116) (Aftermarket) (Unl)</description>
+		<rom name="Earth Attack (USA) (v2021116) (Aftermarket) (Unl).sg" size="16384" crc="575c7f2a" md5="be7798f9073f9a587ff0a36b646c65b7" sha1="92636a511152051a593976a4651c85c8affea614"/>
 		<url>https://retroachievements.org/game/25804/hashes</url>
 		<hash>be7798f9073f9a587ff0a36b646c65b7</hash>
 	</game>
 	
-	<game name="Homebrew/Foryster/Foryster (USA) (v00.9) (Aftermarket)">
+	<game name="Homebrew/Foryster/Foryster (USA) (v00.9) (Aftermarket) (Unl)">
 		<category></category>
-		<description>Foryster (USA) (v00.9) (Aftermarket)</description>
-		<rom name="Foryster (USA) (v00.9) (Aftermarket).sg" size="32768" crc="f8d7fa2c" md5="7aeb05029bdb9a571b1b72482daad5eb" sha1="6d9ed7208032ad3ec9011bbc999cea426aca46d3"/>
+		<description>Foryster (USA) (v00.9) (Aftermarket) (Unl)</description>
+		<rom name="Foryster (USA) (v00.9) (Aftermarket) (Unl).sg" size="32768" crc="f8d7fa2c" md5="7aeb05029bdb9a571b1b72482daad5eb" sha1="6d9ed7208032ad3ec9011bbc999cea426aca46d3"/>
 		<url>https://retroachievements.org/game/25010/hashes</url>
 		<hash>7aeb05029bdb9a571b1b72482daad5eb</hash>
 	</game>
-	<game name="Homebrew/Foryster/Foryster (USA) (v00.9 - Level 10 Fix) (Aftermarket)">
+	<game name="Homebrew/Foryster/Foryster (USA) (v00.9 - Level 10 Fix) (Aftermarket) (Unl)">
 		<category></category>
-		<description>Foryster (USA) (v00.9 - Level 10 Fix) (Aftermarket)</description>
-		<rom name="Foryster (USA) (v00.9 - Level 10 Fix) (Aftermarket).sg" size="32768" crc="c3bdd92c" md5="1065ae51e06b8a07ce99998a37c7db79" sha1="f59be1768fbab79d1bffb886f4074d1e06498f9f"/>
+		<description>Foryster (USA) (v00.9 - Level 10 Fix) (Aftermarket) (Unl)</description>
+		<rom name="Foryster (USA) (v00.9 - Level 10 Fix) (Aftermarket) (Unl).sg" size="32768" crc="c3bdd92c" md5="1065ae51e06b8a07ce99998a37c7db79" sha1="f59be1768fbab79d1bffb886f4074d1e06498f9f"/>
 		<url>https://retroachievements.org/game/25010/hashes</url>
 		<hash>1065ae51e06b8a07ce99998a37c7db79</hash>
 	</game>
 	
-	<game name="Homebrew/H7N9 (USA) (v20161024) (Aftermarket)">
+	<game name="Homebrew/H7N9 (USA) (v20161024) (Aftermarket) (Unl)">
 		<category></category>
-		<description>H7N9 (USA) (v20161024) (Aftermarket)</description>
-		<rom name="H7N9 (USA) (v20161024) (Aftermarket).sg" size="8192" crc="8643027f" md5="784f9220a864953323b42aef566d667e" sha1="5848cc4a8116ce428caa8b775829ed4ffee8fb52"/>
+		<description>H7N9 (USA) (v20161024) (Aftermarket) (Unl)</description>
+		<rom name="H7N9 (USA) (v20161024) (Aftermarket) (Unl).sg" size="8192" crc="8643027f" md5="784f9220a864953323b42aef566d667e" sha1="5848cc4a8116ce428caa8b775829ed4ffee8fb52"/>
 		<url>https://retroachievements.org/game/25825/hashes</url>
 		<hash>784f9220a864953323b42aef566d667e</hash>
 	</game>
 	
-	<game name="Homebrew/Hopman (USA) (v1.0) (Aftermarket)">
+	<game name="Homebrew/Hopman (USA) (v1.0) (Aftermarket) (Unl)">
 		<category></category>
-		<description>Hopman (USA) (v1.0) (Aftermarket)</description>
-		<rom name="Hopman (USA) (v1.0) (Aftermarket).sg" size="9958" crc="8bc01dd6" md5="ed86987c468fbdcf6255a22536c3bac1" sha1="b9ca846d0dbdbd32ed00fa106fb162a0aceda259"/>
+		<description>Hopman (USA) (v1.0) (Aftermarket) (Unl)</description>
+		<rom name="Hopman (USA) (v1.0) (Aftermarket) (Unl).sg" size="9958" crc="8bc01dd6" md5="ed86987c468fbdcf6255a22536c3bac1" sha1="b9ca846d0dbdbd32ed00fa106fb162a0aceda259"/>
 		<url>https://retroachievements.org/game/25826/hashes</url>
 		<hash>ed86987c468fbdcf6255a22536c3bac1</hash>
 	</game>
 	
-	<game name="Homebrew/Jet Paco and Jet Puri/Jet Paco and Jet Puri (USA) (v1.0) (Aftermarket)">
+	<game name="Homebrew/Jet Paco and Jet Puri/Jet Paco and Jet Puri (USA) (v1.0) (Aftermarket) (Unl)">
 		<category></category>
-		<description>Jet Paco and Jet Puri (USA) (v1.0) (Aftermarket)</description>
-		<rom name="Jet Paco and Jet Puri (USA) (v1.0) (Aftermarket).sg" size="49152" crc="d31c6b3b" md5="c07672a810c23e269a65a02e3893172a" sha1="e2dbe48a9a4490857ae7d51e306f6afba5aac3fa"/>
+		<description>Jet Paco and Jet Puri (USA) (v1.0) (Aftermarket) (Unl)</description>
+		<rom name="Jet Paco and Jet Puri (USA) (v1.0) (Aftermarket) (Unl).sg" size="49152" crc="d31c6b3b" md5="c07672a810c23e269a65a02e3893172a" sha1="e2dbe48a9a4490857ae7d51e306f6afba5aac3fa"/>
 		<url>https://retroachievements.org/game/25011/hashes</url>
 		<hash>c07672a810c23e269a65a02e3893172a</hash>
 	</game>
-	<game name="Homebrew/Jet Paco and Jet Puri/Jet Paco and Jet Puri (Europe) (v1.0) (Aftermarket)">
+	<game name="Homebrew/Jet Paco and Jet Puri/Jet Paco and Jet Puri (Europe) (v1.0) (Aftermarket) (Unl)">
 		<category></category>
-		<description>Jet Paco and Jet Puri (Europe) (v1.0) (Aftermarket)</description>
-		<rom name="Jet Paco and Jet Puri (Europe) (v1.0) (Aftermarket).sg" size="49152" crc="3246adab" md5="e13c66c69904b94459fa46da26aca87e" sha1="4b36acfb4faacdbcce56baf3ddba5cd8d72ce047"/>
+		<description>Jet Paco and Jet Puri (Europe) (v1.0) (Aftermarket) (Unl)</description>
+		<rom name="Jet Paco and Jet Puri (Europe) (v1.0) (Aftermarket) (Unl).sg" size="49152" crc="3246adab" md5="e13c66c69904b94459fa46da26aca87e" sha1="4b36acfb4faacdbcce56baf3ddba5cd8d72ce047"/>
 		<url>https://retroachievements.org/game/25011/hashes</url>
 		<hash>e13c66c69904b94459fa46da26aca87e</hash>
 	</game>
 	
-	<game name="Homebrew/Klondike Solitaire (USA) (v1.04b) (Aftermarket)">
+	<game name="Homebrew/Klondike Solitaire (USA) (v1.04b) (Aftermarket) (Unl)">
 		<category></category>
-		<description>Klondike Solitaire (USA) (v1.04b) (Aftermarket)</description>
-		<rom name="Klondike Solitaire (USA) (v1.04b) (Aftermarket).sg" size="32768" crc="5f9f8b15" md5="9ced5749ab0db9d67b5446381a0182f7" sha1="c52e3ff244bc55802b2856054fb01aba7f747620"/>
+		<description>Klondike Solitaire (USA) (v1.04b) (Aftermarket) (Unl)</description>
+		<rom name="Klondike Solitaire (USA) (v1.04b) (Aftermarket) (Unl).sg" size="32768" crc="5f9f8b15" md5="9ced5749ab0db9d67b5446381a0182f7" sha1="c52e3ff244bc55802b2856054fb01aba7f747620"/>
 		<url>https://retroachievements.org/game/25013/hashes</url>
 		<hash>9ced5749ab0db9d67b5446381a0182f7</hash>
 	</game>
 	
-	<game name="Homebrew/Mahjong Solitaire (World) (v1.16) (under4mhz) (Aftermarket)">
+	<game name="Homebrew/Mahjong Solitaire (World) (v1.16) (Aftermarket) (Unl) (under4mhz)">
 		<category></category>
-		<description>Mahjong Solitaire (World) (v1.16) (under4mhz) (Aftermarket)</description>
-		<rom name="Mahjong Solitaire (World) (v1.16) (under4mhz) (Aftermarket).sg" size="32768" crc="d07afa95" md5="894cb6837dc67fd4ada3be7126c1cbd4" sha1="7524486ce0fa3c7a21c5231cce35133ef2f20a57"/>
+		<description>Mahjong Solitaire (World) (v1.16) (Aftermarket) (Unl) (under4mhz)</description>
+		<rom name="Mahjong Solitaire (World) (v1.16) (Aftermarket) (Unl) (under4mhz).sg" size="32768" crc="d07afa95" md5="894cb6837dc67fd4ada3be7126c1cbd4" sha1="7524486ce0fa3c7a21c5231cce35133ef2f20a57"/>
 		<url>https://retroachievements.org/game/25012/hashes</url>
 		<hash>894cb6837dc67fd4ada3be7126c1cbd4</hash>
 	</game>
 	
-	<game name="Homebrew/Palikat (USA) (v1.0) (Aftermarket)">
+	<game name="Homebrew/Palikat (USA) (v1.0) (Aftermarket) (Unl)">
 		<category></category>
-		<description>Palikat (USA) (v1.0) (Aftermarket)</description>
-		<rom name="Palikat (USA) (v1.0) (Aftermarket).sg" size="32768" crc="ec169914" md5="a90090e446b4e86ce3cadc451530c0ad" sha1="77493202ba6e5eec599c054e96fe8f86b84b0c96"/>
+		<description>Palikat (USA) (v1.0) (Aftermarket) (Unl)</description>
+		<rom name="Palikat (USA) (v1.0) (Aftermarket) (Unl).sg" size="32768" crc="ec169914" md5="a90090e446b4e86ce3cadc451530c0ad" sha1="77493202ba6e5eec599c054e96fe8f86b84b0c96"/>
 		<url>https://retroachievements.org/game/25009/hashes</url>
 		<hash>a90090e446b4e86ce3cadc451530c0ad</hash>
 	</game>
 	
-	<game name="Homebrew/Pegged (World) (v1.02) (under4mhz) (Aftermarket)">
+	<game name="Homebrew/Pegged (World) (v1.02) (Aftermarket) (Unl) (under4mhz)">
 		<category></category>
-		<description>Pegged (World) (v1.02) (under4mhz) (Aftermarket)</description>
-		<rom name="Pegged (World) (v1.02) (under4mhz) (Aftermarket).sg" size="32768" crc="f6c2547d" md5="54be39abfa98f34f9cfeeeaa75aee054" sha1="c524f5f682e3b39608f4a04f4a29f80b923dce1b"/>
+		<description>Pegged (World) (v1.02) (Aftermarket) (Unl) (under4mhz)</description>
+		<rom name="Pegged (World) (v1.02) (Aftermarket) (Unl) (under4mhz).sg" size="32768" crc="f6c2547d" md5="54be39abfa98f34f9cfeeeaa75aee054" sha1="c524f5f682e3b39608f4a04f4a29f80b923dce1b"/>
 		<url>https://retroachievements.org/game/25602/hashes</url>
 		<hash>54be39abfa98f34f9cfeeeaa75aee054</hash>
 	</game>
 	
-	<game name="Homebrew/Pitman (World) (v1.03) (under4mhz) (Aftermarket)">
+	<game name="Homebrew/Pitman (World) (v1.03) (Aftermarket) (Unl) (under4mhz)">
 		<category></category>
-		<description>Pitman (World) (v1.03) (under4mhz) (Aftermarket)</description>
-		<rom name="Pitman (World) (v1.03) (under4mhz) (Aftermarket).sg" size="32768" crc="e325f022" md5="f8d0df42b3143c16d3730a37ff1190b9" sha1="22b6c05f186bc87bfbeb734e8ef107d314f6825d"/>
+		<description>Pitman (World) (v1.03) (Aftermarket) (Unl) (under4mhz)</description>
+		<rom name="Pitman (World) (v1.03) (Aftermarket) (Unl) (under4mhz).sg" size="32768" crc="e325f022" md5="f8d0df42b3143c16d3730a37ff1190b9" sha1="22b6c05f186bc87bfbeb734e8ef107d314f6825d"/>
 		<url>https://retroachievements.org/game/22087/hashes</url>
 		<hash>f8d0df42b3143c16d3730a37ff1190b9</hash>
 	</game>
 	
-	<game name="Homebrew/Snake (Rick Skrbina) (USA) (v1.0) (Aftermarket)">
+	<game name="Homebrew/Snake (Rick Skrbina) (USA) (v1.0) (Aftermarket) (Unl)">
 		<category></category>
-		<description>Snake (Rick Skrbina) (USA) (v1.0) (Aftermarket)</description>
-		<rom name="Snake (Rick Skrbina) (USA) (v1.0) (Aftermarket).sg" size="32768" crc="af29bba8" md5="3bec2aa3d11a1d1e9b1de9dbef6b513c" sha1="4984dbeab2f7f04bd05b1e357583e005677709d4"/>
+		<description>Snake (Rick Skrbina) (USA) (v1.0) (Aftermarket) (Unl)</description>
+		<rom name="Snake (Rick Skrbina) (USA) (v1.0) (Aftermarket) (Unl).sg" size="32768" crc="af29bba8" md5="3bec2aa3d11a1d1e9b1de9dbef6b513c" sha1="4984dbeab2f7f04bd05b1e357583e005677709d4"/>
 		<url>https://retroachievements.org/game/14474/hashes</url>
 		<hash>3bec2aa3d11a1d1e9b1de9dbef6b513c</hash>
 	</game>
 	
-	<game name="Homebrew/Snake (under4mhz) (USA) (v1.0) (Aftermarket)">
+	<game name="Homebrew/Snake (under4mhz) (USA) (v1.0) (Aftermarket) (Unl)">
 		<category></category>
-		<description>Snake (under4mhz) (USA) (v1.0) (Aftermarket)</description>
-		<rom name="Snake (under4mhz) (USA) (v1.0) (Aftermarket).sg" size="32768" crc="c885db61" md5="bb91e8818fdd78c9e6cd2b94bbe552ff" sha1="47829d776889e2f4cf48d41ce07a374d14c521a2"/>
+		<description>Snake (under4mhz) (USA) (v1.0) (Aftermarket) (Unl)</description>
+		<rom name="Snake (under4mhz) (USA) (v1.0) (Aftermarket) (Unl).sg" size="32768" crc="c885db61" md5="bb91e8818fdd78c9e6cd2b94bbe552ff" sha1="47829d776889e2f4cf48d41ce07a374d14c521a2"/>
 		<url>https://retroachievements.org/game/22345/hashes</url>
 		<hash>bb91e8818fdd78c9e6cd2b94bbe552ff</hash>
 	</game>
 	
-	<game name="Homebrew/Super Uwol (World) (v2016-11-19) (Mojon Twins) (Aftermarket)">
+	<game name="Homebrew/Super Uwol (World) (v2016-11-19) (Aftermarket) (Unl) (Mojon Twins)">
 		<category></category>
-		<description>Super Uwol (World) (v2016-11-19) (Mojon Twins) (Aftermarket)</description>
-		<rom name="Super Uwol (World) (v2016-11-19) (Mojon Twins) (Aftermarket).sg" size="49152" crc="aa8ea6eb" md5="44a7e8eaf9187835f3fb6c6ddda45327" sha1="ffd3c645662d8926965d4e334f68764648db851f"/>
+		<description>Super Uwol (World) (v2016-11-19) (Aftermarket) (Unl) (Mojon Twins)</description>
+		<rom name="Super Uwol (World) (v2016-11-19) (Aftermarket) (Unl) (Mojon Twins).sg" size="49152" crc="aa8ea6eb" md5="44a7e8eaf9187835f3fb6c6ddda45327" sha1="ffd3c645662d8926965d4e334f68764648db851f"/>
 		<url>https://retroachievements.org/game/19716/hashes</url>
 		<hash>44a7e8eaf9187835f3fb6c6ddda45327</hash>
 	</game>
 	
-	<game name="Homebrew/Vexed (World) (v1.03) (Aftermarket)">
+	<game name="Homebrew/Vexed (World) (v1.03) (Aftermarket) (Unl)">
 		<category></category>
-		<description>Vexed (World) (v1.03) (Aftermarket)</description>
-		<rom name="Vexed (World) (v1.03) (Aftermarket).sg" size="32768" crc="6159a842" md5="7cd478e059987105eaf4f2780be137c9" sha1="aff1f34dab6f92685348d850db28048c43760a6a"/>
+		<description>Vexed (World) (v1.03) (Aftermarket) (Unl)</description>
+		<rom name="Vexed (World) (v1.03) (Aftermarket) (Unl).sg" size="32768" crc="6159a842" md5="7cd478e059987105eaf4f2780be137c9" sha1="aff1f34dab6f92685348d850db28048c43760a6a"/>
 		<url>https://retroachievements.org/game/22072/hashes</url>
 		<hash>7cd478e059987105eaf4f2780be137c9</hash>
 	</game>
@@ -161,6 +161,14 @@
 		<rom name="Cabbage Patch Kids (Taiwan) (Unl).sg" size="32768" crc="9d91ab78" md5="1c2c5851deb0e9142b5ff19e8dcd8442" sha1="5c011f37f4fcbaa72167293a9917bb6af0e30b55"/>
 		<url>https://retroachievements.org/game/24311/hashes</url>
 		<hash>1c2c5851deb0e9142b5ff19e8dcd8442</hash>
+	</game>
+	
+	<game name="Unlicensed/King's Valley (Taiwan) (Unl)">
+		<category></category>
+		<description>King's Valley (Taiwan) (Unl)</description>
+		<rom name="King's Valley (Taiwan) (Unl).sg" size="32768" crc="223397A1" md5="ff28e684eb3952ae3f7cf3e3d1c507ef" sha1="922d23895c12707b2fc382ea5cb769c5cb9b5755"/>
+		<url>https://retroachievements.org/game/24546/hashes</url>
+		<hash>ff28e684eb3952ae3f7cf3e3d1c507ef</hash>
 	</game>
 	
 	<game name="Unlicensed/Knightmare (Taiwan) (Unl)">
@@ -267,10 +275,10 @@
 		<hash>25c742e43bc9f1329f3f26502fefb10a</hash>
 	</game>
 	
-	<game name="Retail/C So! (Japan)">
+	<game name="Retail/C_So! (Japan)">
 		<category></category>
-		<description>C So! (Japan)</description>
-		<rom name="C So! (Japan).sg" size="32768" crc="be7ed0eb" md5="d87daad7de33105d703b613052ccc2dd" sha1="d45a230b3cbf2d2dcfe7b94691fc7f1a5d747625"/>
+		<description>C_So! (Japan)</description>
+		<rom name="C_So! (Japan).sg" size="32768" crc="be7ed0eb" md5="d87daad7de33105d703b613052ccc2dd" sha1="d45a230b3cbf2d2dcfe7b94691fc7f1a5d747625"/>
 		<url>https://retroachievements.org/game/24528/hashes</url>
 		<hash>d87daad7de33105d703b613052ccc2dd</hash>
 	</game>

--- a/DATs/RetroAchievements (Subfolders)/RA - Uzebox.dat
+++ b/DATs/RetroAchievements (Subfolders)/RA - Uzebox.dat
@@ -5,42 +5,42 @@
 		<name>RA - Uzebox</name>
 		<description>Uzebox</description>
 		<category>Subfolders</category>
-		<version>20260208</version>
-		<date>08 February 2026</date>
+		<version>20260428</version>
+		<date>28 April 2026</date>
 		<author>AzgoRAth, NeoRetroGamer (Contributor), Jumphil (Contributor)</author>
 		<homepage>https://retroachievements.org</homepage>
 		<url>https://retroachievements.org/system/80/games</url>
-		<titlecount>41</titlecount>
-		<hashcount>41</hashcount>
+		<titlecount>45</titlecount>
+		<hashcount>45</hashcount>
 	</header>
-	<game name="Hack/Megatris (Arcade Edition) (World) (v1.03) (clymax) (Hack)">
+	<game name="Hack/Megatris - Arcade Edition (World) (v1.03) (clymax)">
 		<category></category>
-		<description>Megatris (Arcade Edition) (World) (v1.03) (clymax) (Hack)</description>
-		<rom name="Megatris (Arcade Edition) (World) (v1.03) (clymax) (Hack).uze" size="59296" crc="a61161dc" md5="4cf318df04117de0067e876db7faaf5b" sha1="67684e18092c86d75c6d9f0a80a1e1e19743b4e8"/>
+		<description>Megatris - Arcade Edition (World) (v1.03) (clymax)</description>
+		<rom name="Megatris - Arcade Edition (World) (v1.03) (clymax).uze" size="59296" crc="a61161dc" md5="4cf318df04117de0067e876db7faaf5b" sha1="67684e18092c86d75c6d9f0a80a1e1e19743b4e8"/>
 		<url>https://retroachievements.org/game/24755/hashes</url>
 		<hash>4cf318df04117de0067e876db7faaf5b</hash>
 	</game>
 	
-	<game name="Subset/Megatris (Arcade Edition) (World) (v1.03) (clymax) (Hack) (Subset - Bonus)">
+	<game name="Subset/Megatris - Arcade Edition (World) (v1.03-Bonus) (clymax)">
 		<category></category>
-		<description>Megatris (Arcade Edition) (World) (v1.03) (clymax) (Hack) (Subset - Bonus)</description>
-		<rom name="Megatris (Arcade Edition) (World) (v1.03) (clymax) (Hack) (Subset - Bonus).uze" size="59296" crc="57b9284c" md5="8e765bd046b2dee4e6876eb043d6a532" sha1="74971496fafd62139df3969c9c26c2331c18f993"/>
+		<description>Megatris - Arcade Edition (World) (v1.03-Bonus) (clymax)</description>
+		<rom name="Megatris - Arcade Edition (World) (v1.03-Bonus) (clymax).uze" size="59296" crc="57b9284c" md5="8e765bd046b2dee4e6876eb043d6a532" sha1="74971496fafd62139df3969c9c26c2331c18f993"/>
 		<url>https://retroachievements.org/game/28806/hashes</url>
 		<hash>8e765bd046b2dee4e6876eb043d6a532</hash>
 	</game>
 	
-	<game name="Hack/Space Age (World) (Pitfall Jones) - Director's Cut (v1.01) (clymax) (Hack)">
+	<game name="Hack/Space Age (World) (Pitfall Jones) - Director's Cut (v1.01) (clymax)">
 		<category></category>
-		<description>Space Age (World) (Pitfall Jones) - Director's Cut (v1.01) (clymax) (Hack)</description>
-		<rom name="Space Age (World) (Pitfall Jones) - Director's Cut (v1.01) (clymax) (Hack).uze" size="56668" crc="ecf33e30" md5="b899ca234f713f920cde11a01fd857d0" sha1="a12a30e239ca210a3a74936772de512afc6003d4"/>
+		<description>Space Age (World) (Pitfall Jones) - Director's Cut (v1.01) (clymax)</description>
+		<rom name="Space Age (World) (Pitfall Jones) - Director's Cut (v1.01) (clymax).uze" size="56668" crc="ecf33e30" md5="b899ca234f713f920cde11a01fd857d0" sha1="a12a30e239ca210a3a74936772de512afc6003d4"/>
 		<url>https://retroachievements.org/game/28940/hashes</url>
 		<hash>b899ca234f713f920cde11a01fd857d0</hash>
 	</game>
 	
-	<game name="Hack/UzeMaze - UzeMaze RA (World) (pinguupinguu) (Hack)">
+	<game name="Hack/UzeMaze - UzeMaze RA (pinguupinguu)">
 		<category></category>
-		<description>UzeMaze - UzeMaze RA (World) (pinguupinguu) (Hack)</description>
-		<rom name="UzeMaze - UzeMaze RA (World) (pinguupinguu) (Hack).uze" size="19604" crc="d7094b70" md5="ae053a9a71680a22a59518544ab7c70b" sha1="80d57ad82286e193cf0ea89ff9242ae9054a3545"/>
+		<description>UzeMaze - UzeMaze RA (pinguupinguu)</description>
+		<rom name="UzeMaze - UzeMaze RA (pinguupinguu).uze" size="19604" crc="d7094b70" md5="ae053a9a71680a22a59518544ab7c70b" sha1="80d57ad82286e193cf0ea89ff9242ae9054a3545"/>
 		<url>https://retroachievements.org/game/25084/hashes</url>
 		<hash>ae053a9a71680a22a59518544ab7c70b</hash>
 	</game>
@@ -93,10 +93,10 @@
 		<hash>b62117e7c6448e266ce9f7f8d46def5a</hash>
 	</game>
 	
-	<game name="Retail/Chickens In Choppers (World) (CunningFellow)">
+	<game name="Retail/Chicken in Choppers (World) (CunningFellow)">
 		<category></category>
-		<description>Chickens In Choppers (World) (CunningFellow)</description>
-		<rom name="Chickens In Choppers (World) (CunningFellow).uze" size="61952" crc="dbbaa9ea" md5="d781bdc469c322270bb7b6f177435e8a" sha1="e9ae022e3a1daa3f51b80f5373ca03435995f233"/>
+		<description>Chicken in Choppers (World) (CunningFellow)</description>
+		<rom name="Chicken in Choppers (World) (CunningFellow).uze" size="61952" crc="dbbaa9ea" md5="d781bdc469c322270bb7b6f177435e8a" sha1="e9ae022e3a1daa3f51b80f5373ca03435995f233"/>
 		<url>https://retroachievements.org/game/24725/hashes</url>
 		<hash>d781bdc469c322270bb7b6f177435e8a</hash>
 	</game>
@@ -195,6 +195,14 @@
 		<rom name="Joyrider (World) (jhhoward).uze" size="59310" crc="18820af6" md5="7f353ceb0bb15f87917355cf62a3c909" sha1="602c649b52dc784e1db0df2f023c4820f9dcf63d"/>
 		<url>https://retroachievements.org/game/24744/hashes</url>
 		<hash>7f353ceb0bb15f87917355cf62a3c909</hash>
+	</game>
+	
+	<game name="Retail/Lander (World) (Harty123)">
+		<category></category>
+		<description>Lander (World) (Harty123)</description>
+		<rom name="Lander (World) (Harty123).uze" size="48246" crc="53d00c16" md5="187bc5fd6d073047cf0f06df8d5465bc" sha1="607ee737870fb13820771532d1b5b0a4c31c6cb3"/>
+		<url>https://retroachievements.org/game/24745/hashes</url>
+		<hash>187bc5fd6d073047cf0f06df8d5465bc</hash>
 	</game>
 	
 	<game name="Retail/Laser Puzzle (World) (Artcfox)">

--- a/DATs/RetroAchievements (Subfolders)/RA - WASM-4.dat
+++ b/DATs/RetroAchievements (Subfolders)/RA - WASM-4.dat
@@ -5,13 +5,13 @@
 		<name>RA - WASM-4</name>
 		<description>WASM-4</description>
 		<category>Subfolders</category>
-		<version>20251225</version>
-		<date>25 December 2025</date>
+		<version>20260428</version>
+		<date>28 April 2026</date>
 		<author>AzgoRAth, NeoRetroGamer (Contributor), Jumphil (Contributor)</author>
 		<homepage>https://retroachievements.org</homepage>
 		<url>https://retroachievements.org/system/72/games</url>
-		<titlecount>60</titlecount>
-		<hashcount>64</hashcount>
+		<titlecount>64</titlecount>
+		<hashcount>69</hashcount>
 	</header>
 	<game name="Retail/2048 (World) (Peter Hellberg)">
 		<category></category>
@@ -109,6 +109,14 @@
 		<hash>892b0811bb4c21ad276f97ab8895de4f</hash>
 	</game>
 	
+	<game name="Retail/Floppy Fish (World) (Chris Breece) (RA Compatibility) (PS2Hagrid)">
+		<category></category>
+		<description>Floppy Fish (World) (Chris Breece) (RA Compatibility) (PS2Hagrid)</description>
+		<rom name="Floppy Fish (World) (Chris Breece) (RA Compatibility) (PS2Hagrid).wasm" size="15219" crc="" md5="a9493e58653da70d06e229355db94ce5" sha1="8de0315a6ad332a6835dc657c1854f679fa29268"/>
+		<url>https://retroachievements.org/game/27641/hashes</url>
+		<hash>a9493e58653da70d06e229355db94ce5</hash>
+	</game>
+	
 	<game name="Retail/Formula 1 (World) (Davy Willems)">
 		<category></category>
 		<description>Formula 1 (World) (Davy Willems)</description>
@@ -139,6 +147,14 @@
 		<rom name="GALDR (World) (jonathand).wasm" size="46169" crc="f6a9a241" md5="00e3c7577b124f20dbf667e5c2bc3d11" sha1="95b6fe1a3e2c1ca01be294f5ecc2b9011f4cfe08"/>
 		<url>https://retroachievements.org/game/27651/hashes</url>
 		<hash>00e3c7577b124f20dbf667e5c2bc3d11</hash>
+	</game>
+	
+	<game name="Retail/Glitch Dungeon (World) (Wormi)">
+		<category></category>
+		<description>Glitch Dungeon (World) (Wormi)</description>
+		<rom name="Glitch Dungeon (World) (Wormi).wasm" size="62135" crc="551dd101" md5="3340d9ca43ad3c11f4e6732f084e299b" sha1="7729764f196dd25de49e5b855280d116e16af8b3"/>
+		<url>https://retroachievements.org/game/37988/hashes</url>
+		<hash>3340d9ca43ad3c11f4e6732f084e299b</hash>
 	</game>
 	
 	<game name="Retail/Hammer Joe (World) (Proto) (MFauzan26)">
@@ -251,10 +267,10 @@
 		<hash>d7b509d435d9699f12744e615254a2c4</hash>
 	</game>
 	
-	<game name="Retail/Ninja vs Knights (World) (v1.0.1) (Mr.Rafael)">
+	<game name="Retail/Ninja vs Knights (World) (v1.0.1) (World) (Mr.Rafael)">
 		<category></category>
-		<description>Ninja vs Knights (World) (v1.0.1) (Mr.Rafael)</description>
-		<rom name="Ninja vs Knights (World) (v1.0.1) (Mr.Rafael).wasm" size="59424" crc="9de9b738" md5="5921f8b9bb63024bd3145172806d2498" sha1="8a6e1b3375415f09874e149b20891603b31f4701"/>
+		<description>Ninja vs Knights (World) (v1.0.1) (World) (Mr.Rafael)</description>
+		<rom name="Ninja vs Knights (World) (v1.0.1) (World) (Mr.Rafael).wasm" size="59424" crc="9de9b738" md5="5921f8b9bb63024bd3145172806d2498" sha1="8a6e1b3375415f09874e149b20891603b31f4701"/>
 		<url>https://retroachievements.org/game/21393/hashes</url>
 		<hash>5921f8b9bb63024bd3145172806d2498</hash>
 	</game>
@@ -291,10 +307,10 @@
 		<hash>973c5e969ba18229376ebe6e8420fe56</hash>
 	</game>
 	
-	<game name="Retail/Plctfarmer (World) (Proto) (pfg)">
+	<game name="Retail/Plctformer (World) (Proto) (pfg)">
 		<category></category>
-		<description>Plctfarmer (World) (Proto) (pfg)</description>
-		<rom name="Plctfarmer (World) (Proto) (pfg).wasm" size="55938" crc="9b7d48bb" md5="9280d1d157f0eb4eeda9e1dacedcf4b6" sha1="a81b96e2048040d3926fef00c8d5b1b42c609df6"/>
+		<description>Plctformer (World) (Proto) (pfg)</description>
+		<rom name="Plctformer (World) (Proto) (pfg).wasm" size="55938" crc="9b7d48bb" md5="9280d1d157f0eb4eeda9e1dacedcf4b6" sha1="a81b96e2048040d3926fef00c8d5b1b42c609df6"/>
 		<url>https://retroachievements.org/game/19309/hashes</url>
 		<hash>9280d1d157f0eb4eeda9e1dacedcf4b6</hash>
 	</game>
@@ -315,10 +331,10 @@
 		<hash>b5653249e28bd05cbb28d7483de29ab3</hash>
 	</game>
 	
-	<game name="Retail/Punch-Em-Up (World) (Louis Pearson)">
+	<game name="Retail/Punch'Em Up (World) (Louis Pearson)">
 		<category></category>
-		<description>Punch-Em-Up (World) (Louis Pearson)</description>
-		<rom name="Punch-Em-Up (World) (Louis Pearson).wasm" size="34671" crc="3b73f50d" md5="053d4b372253533561f51573564472af" sha1="1c51036909740344221b877350d5740eb467fe51"/>
+		<description>Punch'Em Up (World) (Louis Pearson)</description>
+		<rom name="Punch'Em Up (World) (Louis Pearson).wasm" size="34671" crc="3b73f50d" md5="053d4b372253533561f51573564472af" sha1="1c51036909740344221b877350d5740eb467fe51"/>
 		<url>https://retroachievements.org/game/25680/hashes</url>
 		<hash>053d4b372253533561f51573564472af</hash>
 	</game>
@@ -530,10 +546,10 @@
 		<hash>8df88405a112173638e7d6f0d95fb67a</hash>
 	</game>
 	
-	<game name="Retail/ZxZ/ZxZ (World) (Rev 1)">
+	<game name="Retail/ZxZ/ZxZ (World) (Rev 1) (Scislaw Dercz)">
 		<category></category>
-		<description>ZxZ (World) (Rev 1)</description>
-		<rom name="ZxZ (World) (Rev 1).wasm" size="18711" crc="e3cbe9f4" md5="88f0a50bf711bdc9fae8f1ee91395cb1" sha1="5cc971fa63389d51131eb2c094f4481e39082169"/>
+		<description>ZxZ (World) (Rev 1) (Scislaw Dercz)</description>
+		<rom name="ZxZ (World) (Rev 1) (Scislaw Dercz).wasm" size="18711" crc="e3cbe9f4" md5="88f0a50bf711bdc9fae8f1ee91395cb1" sha1="5cc971fa63389d51131eb2c094f4481e39082169"/>
 		<url>https://retroachievements.org/game/19298/hashes</url>
 		<hash>88f0a50bf711bdc9fae8f1ee91395cb1</hash>
 	</game>

--- a/DATs/RetroAchievements (Subfolders)/RA - Watara Supervision.dat
+++ b/DATs/RetroAchievements (Subfolders)/RA - Watara Supervision.dat
@@ -5,98 +5,98 @@
 		<name>RA - Watara Supervision</name>
 		<description>Watara Supervision</description>
 		<category>Subfolders</category>
-		<version>20251225</version>
-		<date>25 December 2025</date>
+		<version>20260428</version>
+		<date>28 April 2026</date>
 		<author>AzgoRAth, NeoRetroGamer (Contributor), Jumphil (Contributor)</author>
 		<homepage>https://retroachievements.org</homepage>
 		<url>https://retroachievements.org/system/63/games</url>
 		<titlecount>75</titlecount>
-		<hashcount>81</hashcount>
+		<hashcount>82</hashcount>
 	</header>
-	<game name="Homebrew/AntiAir Mini (World) (v20240422) (Inufuto) (Aftermarket)">
+	<game name="Homebrew/AntiAir Mini (World) (v20240422) (Aftermarket) (Inufuto)">
 		<category></category>
-		<description>AntiAir Mini (World) (v20240422) (Inufuto) (Aftermarket)</description>
-		<rom name="AntiAir Mini (World) (v20240422) (Inufuto) (Aftermarket).sv" size="16384" crc="b10634c0" md5="8b5071a6648aecbf86fe6e44a5a2e3c7" sha1="e9c3e4763ca6a80ddfff9c26c7c2012667d889bd"/>
+		<description>AntiAir Mini (World) (v20240422) (Aftermarket) (Inufuto)</description>
+		<rom name="AntiAir Mini (World) (v20240422) (Aftermarket) (Inufuto).sv" size="16384" crc="b10634c0" md5="8b5071a6648aecbf86fe6e44a5a2e3c7" sha1="e9c3e4763ca6a80ddfff9c26c7c2012667d889bd"/>
 		<url>https://retroachievements.org/game/33069/hashes</url>
 		<hash>8b5071a6648aecbf86fe6e44a5a2e3c7</hash>
 	</game>
 	
-	<game name="Homebrew/Assembloids (World) (Aftermarket)">
+	<game name="Homebrew/Assembloids (World) (Digital) (Aftermarket) (Unl)">
 		<category></category>
-		<description>Assembloids (World) (Aftermarket)</description>
-		<rom name="Assembloids (World) (Aftermarket).sv" size="65536" crc="c71131e4" md5="6dd574473abfe47583c81a2fe33d3d02" sha1="79831275a6a30064d400b21c7eff709403ebcecc"/>
+		<description>Assembloids (World) (Digital) (Aftermarket) (Unl)</description>
+		<rom name="Assembloids (World) (Digital) (Aftermarket) (Unl).sv" size="65536" crc="c71131e4" md5="6dd574473abfe47583c81a2fe33d3d02" sha1="79831275a6a30064d400b21c7eff709403ebcecc"/>
 		<url>https://retroachievements.org/game/17660/hashes</url>
 		<hash>6dd574473abfe47583c81a2fe33d3d02</hash>
 	</game>
 	
-	<game name="Homebrew/Cross Bomber (World) (Aftermarket)">
+	<game name="Homebrew/Cross Bomber (World) (Aftermarket) (Unl)">
 		<category></category>
-		<description>Cross Bomber (World) (Aftermarket)</description>
-		<rom name="Cross Bomber (World) (Aftermarket).sv" size="32768" crc="5fac2aa3" md5="7a905b02571bfd0a7fdbb03b0637af4f" sha1="d579049862297d05ad8fbf318cf21f5423ed9b64"/>
+		<description>Cross Bomber (World) (Aftermarket) (Unl)</description>
+		<rom name="Cross Bomber (World) (Aftermarket) (Unl).sv" size="32768" crc="5fac2aa3" md5="7a905b02571bfd0a7fdbb03b0637af4f" sha1="d579049862297d05ad8fbf318cf21f5423ed9b64"/>
 		<url>https://retroachievements.org/game/23775/hashes</url>
 		<hash>7a905b02571bfd0a7fdbb03b0637af4f</hash>
 	</game>
 	
-	<game name="Homebrew/Cross Chase (World) (Aftermarket)">
+	<game name="Homebrew/Cross Chase (World) (Aftermarket) (Unl)">
 		<category></category>
-		<description>Cross Chase (World) (Aftermarket)</description>
-		<rom name="Cross Chase (World) (Aftermarket).sv" size="32768" crc="346a7bba" md5="c077ce97c8d134230a68006ccc788b60" sha1="6564e4644e66005d8fb9fe23018b514503e0c869"/>
+		<description>Cross Chase (World) (Aftermarket) (Unl)</description>
+		<rom name="Cross Chase (World) (Aftermarket) (Unl).sv" size="32768" crc="346a7bba" md5="c077ce97c8d134230a68006ccc788b60" sha1="6564e4644e66005d8fb9fe23018b514503e0c869"/>
 		<url>https://retroachievements.org/game/23771/hashes</url>
 		<hash>c077ce97c8d134230a68006ccc788b60</hash>
 	</game>
 	
-	<game name="Homebrew/Cross Horde (World) (Aftermarket)">
+	<game name="Homebrew/Cross Horde (World) (Aftermarket) (Unl)">
 		<category></category>
-		<description>Cross Horde (World) (Aftermarket)</description>
-		<rom name="Cross Horde (World) (Aftermarket).sv" size="32768" crc="7885ce58" md5="4048c11b1be067483fa948724fbb9869" sha1="a09c3c83ea7e8f610611be852a4f51262d94e280"/>
+		<description>Cross Horde (World) (Aftermarket) (Unl)</description>
+		<rom name="Cross Horde (World) (Aftermarket) (Unl).sv" size="32768" crc="7885ce58" md5="4048c11b1be067483fa948724fbb9869" sha1="a09c3c83ea7e8f610611be852a4f51262d94e280"/>
 		<url>https://retroachievements.org/game/23770/hashes</url>
 		<hash>4048c11b1be067483fa948724fbb9869</hash>
 	</game>
 	
-	<game name="Homebrew/Cross Shoot (World) (Aftermarket)">
+	<game name="Homebrew/Cross Shoot (World) (Aftermarket) (Unl)">
 		<category></category>
-		<description>Cross Shoot (World) (Aftermarket)</description>
-		<rom name="Cross Shoot (World) (Aftermarket).sv" size="32768" crc="017f75af" md5="19b3812f3a3ffbf3eff501521078c5a2" sha1="8b734d620eb8d28f4ab932fe686fc884b9299910"/>
+		<description>Cross Shoot (World) (Aftermarket) (Unl)</description>
+		<rom name="Cross Shoot (World) (Aftermarket) (Unl).sv" size="32768" crc="017f75af" md5="19b3812f3a3ffbf3eff501521078c5a2" sha1="8b734d620eb8d28f4ab932fe686fc884b9299910"/>
 		<url>https://retroachievements.org/game/23772/hashes</url>
 		<hash>19b3812f3a3ffbf3eff501521078c5a2</hash>
 	</game>
 	
-	<game name="Homebrew/Cross Shuriken (World) (Aftermarket)">
+	<game name="Homebrew/Cross Shuriken (World) (Aftermarket) (Unl)">
 		<category></category>
-		<description>Cross Shuriken (World) (Aftermarket)</description>
-		<rom name="Cross Shuriken (World) (Aftermarket).sv" size="32768" crc="36a6a62b" md5="6f4938e6ea4b8e62479a0081c4ab3ab5" sha1="c244b0075a81e1175e359f5e7bf56d8f26269a1b"/>
+		<description>Cross Shuriken (World) (Aftermarket) (Unl)</description>
+		<rom name="Cross Shuriken (World) (Aftermarket) (Unl).sv" size="32768" crc="36a6a62b" md5="6f4938e6ea4b8e62479a0081c4ab3ab5" sha1="c244b0075a81e1175e359f5e7bf56d8f26269a1b"/>
 		<url>https://retroachievements.org/game/29755/hashes</url>
 		<hash>6f4938e6ea4b8e62479a0081c4ab3ab5</hash>
 	</game>
 	
-	<game name="Homebrew/Cross Snake (World) (Aftermarket)">
+	<game name="Homebrew/Cross Snake (World) (Aftermarket) (Unl)">
 		<category></category>
-		<description>Cross Snake (World) (Aftermarket)</description>
-		<rom name="Cross Snake (World) (Aftermarket).sv" size="32768" crc="24b141f7" md5="a7055f5cd9a3101e26ce62dd022c3635" sha1="50d811b555e4471765121a36173f4356d971363a"/>
+		<description>Cross Snake (World) (Aftermarket) (Unl)</description>
+		<rom name="Cross Snake (World) (Aftermarket) (Unl).sv" size="32768" crc="24b141f7" md5="a7055f5cd9a3101e26ce62dd022c3635" sha1="50d811b555e4471765121a36173f4356d971363a"/>
 		<url>https://retroachievements.org/game/23773/hashes</url>
 		<hash>a7055f5cd9a3101e26ce62dd022c3635</hash>
 	</game>
 	
-	<game name="Homebrew/Cross Stinger (World) (Aftermarket)">
+	<game name="Homebrew/Cross Stinger (World) (Aftermarket) (Unl)">
 		<category></category>
-		<description>Cross Stinger (World) (Aftermarket)</description>
-		<rom name="Cross Stinger (World) (Aftermarket).sv" size="32768" crc="b79492ae" md5="6cfe4c52ddc5afca426889a210eb1e99" sha1="93dffde8ccd6c13e7cbb8a1c5ea830b07980ab52"/>
+		<description>Cross Stinger (World) (Aftermarket) (Unl)</description>
+		<rom name="Cross Stinger (World) (Aftermarket) (Unl).sv" size="32768" crc="b79492ae" md5="6cfe4c52ddc5afca426889a210eb1e99" sha1="93dffde8ccd6c13e7cbb8a1c5ea830b07980ab52"/>
 		<url>https://retroachievements.org/game/29756/hashes</url>
 		<hash>6cfe4c52ddc5afca426889a210eb1e99</hash>
 	</game>
 	
-	<game name="Homebrew/Cross Verbix (World) (Aftermarket)">
+	<game name="Homebrew/Cross Verbix (World) (Aftermarket) (Unl)">
 		<category></category>
-		<description>Cross Verbix (World) (Aftermarket)</description>
-		<rom name="Cross Verbix (World) (Aftermarket).sv" size="32768" crc="2606a717" md5="a989076fdf62db8e63b5604d579a1e72" sha1="0aa4e96ea1c6c76a7f6639adbc4d1ef7e5e1303f"/>
+		<description>Cross Verbix (World) (Aftermarket) (Unl)</description>
+		<rom name="Cross Verbix (World) (Aftermarket) (Unl).sv" size="32768" crc="2606a717" md5="a989076fdf62db8e63b5604d579a1e72" sha1="0aa4e96ea1c6c76a7f6639adbc4d1ef7e5e1303f"/>
 		<url>https://retroachievements.org/game/23774/hashes</url>
 		<hash>a989076fdf62db8e63b5604d579a1e72</hash>
 	</game>
 	
-	<game name="Homebrew/Mazy Mini (World) (v20240311) (Inufuto) (Aftermarket)">
+	<game name="Homebrew/Mazy Mini (World) (v20240311) (Aftermarket) (Inufuto)">
 		<category></category>
-		<description>Mazy Mini (World) (v20240311) (Inufuto) (Aftermarket)</description>
-		<rom name="Mazy Mini (World) (v20240311) (Inufuto) (Aftermarket).sv" size="16384" crc="0d236cba" md5="646dfa79b64831f3b32b8b7b4b209ac4" sha1="3806f6b6ac4307e9362632f74c7d7280d40028bf"/>
+		<description>Mazy Mini (World) (v20240311) (Aftermarket) (Inufuto)</description>
+		<rom name="Mazy Mini (World) (v20240311) (Aftermarket) (Inufuto).sv" size="16384" crc="0d236cba" md5="646dfa79b64831f3b32b8b7b4b209ac4" sha1="3806f6b6ac4307e9362632f74c7d7280d40028bf"/>
 		<url>https://retroachievements.org/game/31767/hashes</url>
 		<hash>646dfa79b64831f3b32b8b7b4b209ac4</hash>
 	</game>
@@ -498,19 +498,19 @@
 		<hash>504d378933cb037f9d047279306ed520</hash>
 	</game>
 	
-	<game name="Retail/Police Bust/Police Bust (USA, Europe) (Level 11 Fix) (PixieGlow)">
-		<category></category>
-		<description>Police Bust (USA, Europe) (Level 11 Fix) (PixieGlow)</description>
-		<rom name="Police Bust (USA, Europe) (Level 11 Fix) (PixieGlow).sv" size="65536" crc="a37ae594" md5="3abc347ec03fe567dacfb851bec308f8" sha1="da89b0143886d5c78429eec47138336a2750b7fe"/>
-		<url>https://retroachievements.org/game/17621/hashes</url>
-		<hash>3abc347ec03fe567dacfb851bec308f8</hash>
-	</game>
 	<game name="Retail/Police Bust/Police Bust (USA, Europe)">
 		<category></category>
 		<description>Police Bust (USA, Europe)</description>
 		<rom name="Police Bust (USA, Europe).sv" size="65536" crc="531f0b51" md5="427488cb0f3251a46e923f9e8608ff80" sha1="9fa06b4d171d9ade2f9e4a639e80feba15c963f9"/>
 		<url>https://retroachievements.org/game/17621/hashes</url>
 		<hash>427488cb0f3251a46e923f9e8608ff80</hash>
+	</game>
+	<game name="Retail/Police Bust/Police Bust (USA, Europe) (Level 11 Fix) (PixieGlow)">
+		<category></category>
+		<description>Police Bust (USA, Europe) (Level 11 Fix) (PixieGlow)</description>
+		<rom name="Police Bust (USA, Europe) (Level 11 Fix) (PixieGlow).sv" size="65536" crc="a37ae594" md5="3abc347ec03fe567dacfb851bec308f8" sha1="da89b0143886d5c78429eec47138336a2750b7fe"/>
+		<url>https://retroachievements.org/game/17621/hashes</url>
+		<hash>3abc347ec03fe567dacfb851bec308f8</hash>
 	</game>
 	
 	<game name="Retail/Popo Team (USA, Europe)">
@@ -537,19 +537,19 @@
 		<hash>0a07c444324d0b41546e2363679360da</hash>
 	</game>
 	
-	<game name="Retail/Scaffolder/Scaffolder (USA, Europe) (Level Fix by Hotscrock)">
-		<category></category>
-		<description>Scaffolder (USA, Europe) (Level Fix by Hotscrock)</description>
-		<rom name="Scaffolder (USA, Europe) (Level Fix by Hotscrock).sv" size="65536" crc="4d5f6666" md5="7816deddb48c44df99c6bb3535c1dc88" sha1="88bddc446c3e761750b1ec9736cf47d7e1830f8c"/>
-		<url>https://retroachievements.org/game/17599/hashes</url>
-		<hash>7816deddb48c44df99c6bb3535c1dc88</hash>
-	</game>
 	<game name="Retail/Scaffolder/Scaffolder (USA, Europe)">
 		<category></category>
 		<description>Scaffolder (USA, Europe)</description>
 		<rom name="Scaffolder (USA, Europe).sv" size="65536" crc="46fb22c5" md5="c07638809b49f2c922c4d4d7519e6f9c" sha1="4fd487ce62c8b7a6f3d4000fcd72f2a269d32fc2"/>
 		<url>https://retroachievements.org/game/17599/hashes</url>
 		<hash>c07638809b49f2c922c4d4d7519e6f9c</hash>
+	</game>
+	<game name="Retail/Scaffolder/Scaffolder (USA, Europe) (Level Fix) (Hotscrock)">
+		<category></category>
+		<description>Scaffolder (USA, Europe) (Level Fix) (Hotscrock)</description>
+		<rom name="Scaffolder (USA, Europe) (Level Fix) (Hotscrock).sv" size="65536" crc="4d5f6666" md5="7816deddb48c44df99c6bb3535c1dc88" sha1="88bddc446c3e761750b1ec9736cf47d7e1830f8c"/>
+		<url>https://retroachievements.org/game/17599/hashes</url>
+		<hash>7816deddb48c44df99c6bb3535c1dc88</hash>
 	</game>
 	
 	<game name="Retail/Soccer Champion (USA, Europe)">

--- a/DATs/RetroAchievements (Subfolders)/RA - WonderSwan.dat
+++ b/DATs/RetroAchievements (Subfolders)/RA - WonderSwan.dat
@@ -5,42 +5,42 @@
 		<name>RA - WonderSwan</name>
 		<description>WonderSwan</description>
 		<category>Subfolders</category>
-		<version>20260208</version>
-		<date>08 February 2026</date>
+		<version>20260427</version>
+		<date>27 April 2026</date>
 		<author>AzgoRAth, NeoRetroGamer (Contributor), Jumphil (Contributor)</author>
 		<homepage>https://retroachievements.org</homepage>
 		<url>https://retroachievements.org/system/53/games</url>
-		<titlecount>48</titlecount>
-		<hashcount>65</hashcount>
+		<titlecount>49</titlecount>
+		<hashcount>66</hashcount>
 	</header>
-	<game name="Homebrew/Atop the Witch's Tower (World) (v1.1) (Aftermarket)">
+	<game name="Homebrew/Atop the Witch's Tower (World) (v1.1) (Aftermarket) (Unl)">
 		<category>WonderSwan Color</category>
-		<description>Atop the Witch's Tower (World) (v1.1) (Aftermarket)</description>
-		<rom name="Atop the Witch's Tower (World) (v1.1) (Aftermarket).wsc" size="131072" crc="23e814cc" md5="db3569afdb8d8f553da626970f1804e7" sha1="1487a981e576bf8248818b1f1a12c947760be511"/>
+		<description>Atop the Witch's Tower (World) (v1.1) (Aftermarket) (Unl)</description>
+		<rom name="Atop the Witch's Tower (World) (v1.1) (Aftermarket) (Unl).wsc" size="131072" crc="23e814cc" md5="db3569afdb8d8f553da626970f1804e7" sha1="1487a981e576bf8248818b1f1a12c947760be511"/>
 		<url>https://retroachievements.org/game/26483/hashes</url>
 		<hash>db3569afdb8d8f553da626970f1804e7</hash>
 	</game>
 	
-	<game name="Homebrew/Cracky Mini (World) (v20240612) (Aftermarket)">
+	<game name="Homebrew/Cracky Mini (World) (v20240612) (Aftermarket) (Unl)">
 		<category>WonderSwan</category>
-		<description>Cracky Mini (World) (v20240612) (Aftermarket)</description>
-		<rom name="Cracky Mini (World) (v20240612) (Aftermarket).wsc" size="65536" crc="3071302b" md5="2ad72633b07f623b6eb0a641ec44dfd3" sha1="0323adb8a740466f7d2b6f29dc55acaee357be48"/>
+		<description>Cracky Mini (World) (v20240612) (Aftermarket) (Unl)</description>
+		<rom name="Cracky Mini (World) (v20240612) (Aftermarket) (Unl).wsc" size="65536" crc="3071302b" md5="2ad72633b07f623b6eb0a641ec44dfd3" sha1="0323adb8a740466f7d2b6f29dc55acaee357be48"/>
 		<url>https://retroachievements.org/game/32532/hashes</url>
 		<hash>2ad72633b07f623b6eb0a641ec44dfd3</hash>
 	</game>
 	
-	<game name="Homebrew/Mazy Mini (World) (v20230618) (Aftermarket)">
+	<game name="Homebrew/Mazy (World) (v20230618) (Aftermarket) (Unl)">
 		<category>WonderSwan Color</category>
-		<description>Mazy Mini (World) (v20230618) (Aftermarket)</description>
-		<rom name="Mazy Mini (World) (v20230618) (Aftermarket).wsc" size="65536" crc="2620c258" md5="4ea83a19867a3e32749b1c9d898583ca" sha1="d7dd04a77d8c0edee79df61a3cd7f308fdde611d"/>
+		<description>Mazy (World) (v20230618) (Aftermarket) (Unl)</description>
+		<rom name="Mazy (World) (v20230618) (Aftermarket) (Unl).wsc" size="65536" crc="2620c258" md5="4ea83a19867a3e32749b1c9d898583ca" sha1="d7dd04a77d8c0edee79df61a3cd7f308fdde611d"/>
 		<url>https://retroachievements.org/game/32952/hashes</url>
 		<hash>4ea83a19867a3e32749b1c9d898583ca</hash>
 	</game>
 	
-	<game name="Homebrew/Wondersnake (World) (Aftermarket)">
+	<game name="Homebrew/Wondersnake (World) (Aftermarket) (Unl)">
 		<category>WonderSwan Color</category>
-		<description>Wondersnake (World) (Aftermarket)</description>
-		<rom name="Wondersnake (World) (Aftermarket).wsc" size="524288" crc="a0591f00" md5="f8706cc921099ce84b2dd154b3cbbac6" sha1="fec915b4993f2d84ea30bd0fa4d8575e9074d292"/>
+		<description>Wondersnake (World) (Aftermarket) (Unl)</description>
+		<rom name="Wondersnake (World) (Aftermarket) (Unl).wsc" size="524288" crc="a0591f00" md5="f8706cc921099ce84b2dd154b3cbbac6" sha1="fec915b4993f2d84ea30bd0fa4d8575e9074d292"/>
 		<url>https://retroachievements.org/game/19897/hashes</url>
 		<hash>f8706cc921099ce84b2dd154b3cbbac6</hash>
 	</game>
@@ -61,10 +61,10 @@
 		<hash>b814e71eb1d079466a9535566d605280</hash>
 	</game>
 	
-	<game name="Retail/Cardinal Sins - Recycle Edition (World) (Ja) (v1.02) (WonderWitch) (Aftermarket)">
+	<game name="Retail/Cardinal Sins - Recycle Edition (World) (Ja) (v1.02) (WonderWitch) (Aftermarket) (Unl)">
 		<category>WonderSwan Color</category>
-		<description>Cardinal Sins - Recycle Edition (World) (Ja) (v1.02) (WonderWitch) (Aftermarket)</description>
-		<rom name="Cardinal Sins - Recycle Edition (World) (Ja) (v1.02) (WonderWitch) (Aftermarket).wsc" size="524288" crc="deaec59b" md5="50425331b91ee4273df1d56d7dcd519f" sha1="0a250a6e7d09787ea2062347a69f0452412c6b8d"/>
+		<description>Cardinal Sins - Recycle Edition (World) (Ja) (v1.02) (WonderWitch) (Aftermarket) (Unl)</description>
+		<rom name="Cardinal Sins - Recycle Edition (World) (Ja) (v1.02) (WonderWitch) (Aftermarket) (Unl).wsc" size="524288" crc="deaec59b" md5="50425331b91ee4273df1d56d7dcd519f" sha1="0a250a6e7d09787ea2062347a69f0452412c6b8d"/>
 		<url>https://retroachievements.org/game/22100/hashes</url>
 		<hash>50425331b91ee4273df1d56d7dcd519f</hash>
 	</game>
@@ -91,10 +91,10 @@
 		<url>https://retroachievements.org/game/14874/hashes</url>
 		<hash>8f0ba3401662a40e8da5ebcfe7b85e81</hash>
 	</game>
-	<game name="Retail/Clock Tower for WonderSwan/Clock Tower for WonderSwan (Japan) (En) (v1.1) (Team C.U.T.S.)">
+	<game name="Retail/Clock Tower for WonderSwan/Clock Tower for WonderSwan (Japan) (Rev 1) (En) (v1.1) (Team C.U.T.S.)">
 		<category>WonderSwan</category>
-		<description>Clock Tower for WonderSwan (Japan) (En) (v1.1) (Team C.U.T.S.)</description>
-		<rom name="Clock Tower for WonderSwan (Japan) (En) (v1.1) (Team C.U.T.S.).ws" size="2097152" crc="d536a070" md5="bdaacc5193951ca7fff2845b1664d451" sha1="245b722f978bbe0ea301a14d41afbf6a2040b903"/>
+		<description>Clock Tower for WonderSwan (Japan) (Rev 1) (En) (v1.1) (Team C.U.T.S.)</description>
+		<rom name="Clock Tower for WonderSwan (Japan) (Rev 1) (En) (v1.1) (Team C.U.T.S.).ws" size="2097152" crc="d536a070" md5="bdaacc5193951ca7fff2845b1664d451" sha1="245b722f978bbe0ea301a14d41afbf6a2040b903"/>
 		<url>https://retroachievements.org/game/14874/hashes</url>
 		<hash>bdaacc5193951ca7fff2845b1664d451</hash>
 	</game>
@@ -122,6 +122,14 @@
 		<hash>d5f7fbf06c57aa50f08c14e64d2e02a2</hash>
 	</game>
 	
+	<game name="Retail/Digimon Adventure 02 - D1 Tamers (Japan) (En) (v0.97) (USC)">
+		<category>WonderSwan Color</category>
+		<description>Digimon Adventure 02 - D1 Tamers (Japan) (En) (v0.97) (USC)</description>
+		<rom name="Digimon Adventure 02 - D1 Tamers (Japan) (En) (v0.97) (USC).wsc" size="4194304" crc="74A1AE86" md5="0b4973f8406e90f325198b6747b4e632" sha1="4ad4642abc8b97fd9291b90f98f610bc1462d2d6"/>
+		<url>https://retroachievements.org/game/16142/hashes</url>
+		<hash>0b4973f8406e90f325198b6747b4e632</hash>
+	</game>
+	
 	<game name="Retail/Digimon Adventure 02/Digimon Adventure 02 - Tag Tamers (Japan) (Rev 1)">
 		<category>WonderSwan</category>
 		<description>Digimon Adventure 02 - Tag Tamers (Japan) (Rev 1)</description>
@@ -129,10 +137,10 @@
 		<url>https://retroachievements.org/game/16143/hashes</url>
 		<hash>2cb264ba76b88452d7576992f2b90dbf</hash>
 	</game>
-	<game name="Retail/Digimon Adventure 02/Digimon Adventure 02 - Tag Tamers (Japan) (En) (v1.4.5) (USC)">
+	<game name="Retail/Digimon Adventure 02/Digimon Adventure 02 - Tag Tamers (Japan) (Rev 1) (En) (v1.4.5) (USC)">
 		<category>WonderSwan</category>
-		<description>Digimon Adventure 02 - Tag Tamers (Japan) (En) (v1.4.5) (USC)</description>
-		<rom name="Digimon Adventure 02 - Tag Tamers (Japan) (En) (v1.4.5) (USC).ws" size="2097152" crc="885058a9" md5="521dee8107ef14ffc0e0b3795207d9fd" sha1="5dd7f045071c15451ee5828154566a0c6be24cc2"/>
+		<description>Digimon Adventure 02 - Tag Tamers (Japan) (Rev 1) (En) (v1.4.5) (USC)</description>
+		<rom name="Digimon Adventure 02 - Tag Tamers (Japan) (Rev 1) (En) (v1.4.5) (USC).ws" size="2097152" crc="885058a9" md5="521dee8107ef14ffc0e0b3795207d9fd" sha1="5dd7f045071c15451ee5828154566a0c6be24cc2"/>
 		<url>https://retroachievements.org/game/16143/hashes</url>
 		<hash>521dee8107ef14ffc0e0b3795207d9fd</hash>
 	</game>
@@ -168,19 +176,19 @@
 		<hash>bfafb9bc64fc88bb71f5936172c2abcd</hash>
 	</game>
 	
-	<game name="Retail/Final Fantasy/Final Fantasy (Japan) (En) (v0.91) (Kalas)">
-		<category>WonderSwan Color</category>
-		<description>Final Fantasy (Japan) (En) (v0.91) (Kalas)</description>
-		<rom name="Final Fantasy (Japan) (En) (v0.91) (Kalas).wsc" size="4194304" crc="df94a149" md5="0d5c239eb1b99b4ab756acda11992ce3" sha1="08e70b98918df5e5cf2fe057908ce5e8a69e05fe"/>
-		<url>https://retroachievements.org/game/15580/hashes</url>
-		<hash>0d5c239eb1b99b4ab756acda11992ce3</hash>
-	</game>
 	<game name="Retail/Final Fantasy/Final Fantasy (Japan)">
 		<category>WonderSwan Color</category>
 		<description>Final Fantasy (Japan)</description>
 		<rom name="Final Fantasy (Japan).wsc" size="4194304" crc="b7243e88" md5="e36650ac50df69d1832a0d496c165db2" sha1="26628eb76c16880b6faf2e706778d91a60144078"/>
 		<url>https://retroachievements.org/game/15580/hashes</url>
 		<hash>e36650ac50df69d1832a0d496c165db2</hash>
+	</game>
+	<game name="Retail/Final Fantasy/Final Fantasy (Japan) (En) (v0.91) (Kalas)">
+		<category>WonderSwan Color</category>
+		<description>Final Fantasy (Japan) (En) (v0.91) (Kalas)</description>
+		<rom name="Final Fantasy (Japan) (En) (v0.91) (Kalas).wsc" size="4194304" crc="df94a149" md5="0d5c239eb1b99b4ab756acda11992ce3" sha1="08e70b98918df5e5cf2fe057908ce5e8a69e05fe"/>
+		<url>https://retroachievements.org/game/15580/hashes</url>
+		<hash>0d5c239eb1b99b4ab756acda11992ce3</hash>
 	</game>
 	
 	<game name="Retail/Final Fantasy II/Final Fantasy II (Japan)">
@@ -261,19 +269,19 @@
 		<hash>816c81b156146be62a45edd7d7d49fc6</hash>
 	</game>
 	
-	<game name="Retail/Hataraku Chocobo/Hataraku Chocobo (Japan) (En) (v1.01) (Specialagentape)">
-		<category>WonderSwan Color</category>
-		<description>Hataraku Chocobo (Japan) (En) (v1.01) (Specialagentape)</description>
-		<rom name="Hataraku Chocobo (Japan) (En) (v1.01) (Specialagentape).wsc" size="1048576" crc="b6528093" md5="907ed96e5e12c55212bb15265d59801b" sha1="580be88475d0fe5acc0629b42278df9e97d9a98f"/>
-		<url>https://retroachievements.org/game/17766/hashes</url>
-		<hash>907ed96e5e12c55212bb15265d59801b</hash>
-	</game>
 	<game name="Retail/Hataraku Chocobo/Hataraku Chocobo (Japan)">
 		<category>WonderSwan Color</category>
 		<description>Hataraku Chocobo (Japan)</description>
 		<rom name="Hataraku Chocobo (Japan).wsc" size="1048576" crc="7a29e9a6" md5="ebab0f1f4148d54437834971d9756431" sha1="9bd63ed48926b27be70333fbe07da2ceed56328a"/>
 		<url>https://retroachievements.org/game/17766/hashes</url>
 		<hash>ebab0f1f4148d54437834971d9756431</hash>
+	</game>
+	<game name="Retail/Hataraku Chocobo/Hataraku Chocobo (Japan) (En) (v1.01) (Specialagentape)">
+		<category>WonderSwan Color</category>
+		<description>Hataraku Chocobo (Japan) (En) (v1.01) (Specialagentape)</description>
+		<rom name="Hataraku Chocobo (Japan) (En) (v1.01) (Specialagentape).wsc" size="1048576" crc="b6528093" md5="907ed96e5e12c55212bb15265d59801b" sha1="580be88475d0fe5acc0629b42278df9e97d9a98f"/>
+		<url>https://retroachievements.org/game/17766/hashes</url>
+		<hash>907ed96e5e12c55212bb15265d59801b</hash>
 	</game>
 	
 	<game name="Retail/Judgement Silversword - Rebirth Edition (Japan) (Rev 5C21)">
@@ -430,19 +438,19 @@
 		<hash>cadd7d9a54d7debffc52a02ff127a5b7</hash>
 	</game>
 	
-	<game name="Retail/Rockman EXE WS/Rockman EXE WS (Japan) (En) (v1.0) (Greiga Master)">
-		<category>WonderSwan Color</category>
-		<description>Rockman EXE WS (Japan) (En) (v1.0) (Greiga Master)</description>
-		<rom name="Rockman EXE WS (Japan) (En) (v1.0) (Greiga Master).wsc" size="4194304" crc="a8c02e74" md5="20379c41873b0d99a2baaf2ef959e1e6" sha1="79f7821791d99a4e6a912ff60bb10eb8ccb0bcd0"/>
-		<url>https://retroachievements.org/game/14596/hashes</url>
-		<hash>20379c41873b0d99a2baaf2ef959e1e6</hash>
-	</game>
 	<game name="Retail/Rockman EXE WS/Rockman EXE WS (Japan)">
 		<category>WonderSwan Color</category>
 		<description>Rockman EXE WS (Japan)</description>
 		<rom name="Rockman EXE WS (Japan).wsc" size="4194304" crc="658c4b98" md5="a66390da2c2defcf092eb107edaf4fa0" sha1="b4a3ff3b72639f27d1a6f449b0335074aeb9e603"/>
 		<url>https://retroachievements.org/game/14596/hashes</url>
 		<hash>a66390da2c2defcf092eb107edaf4fa0</hash>
+	</game>
+	<game name="Retail/Rockman EXE WS/Rockman EXE WS (Japan) (En) (v1.0) (Greiga Master)">
+		<category>WonderSwan Color</category>
+		<description>Rockman EXE WS (Japan) (En) (v1.0) (Greiga Master)</description>
+		<rom name="Rockman EXE WS (Japan) (En) (v1.0) (Greiga Master).wsc" size="4194304" crc="a8c02e74" md5="20379c41873b0d99a2baaf2ef959e1e6" sha1="79f7821791d99a4e6a912ff60bb10eb8ccb0bcd0"/>
+		<url>https://retroachievements.org/game/14596/hashes</url>
+		<hash>20379c41873b0d99a2baaf2ef959e1e6</hash>
 	</game>
 	
 	<game name="Retail/Rockman EXE - N1 Battle (Japan) (Rev 1)">
@@ -533,19 +541,19 @@
 		<hash>144b29a9997c016fb4b2bb05e3965cfe</hash>
 	</game>
 	
-	<game name="Retail/Wizardry Scenario 1/Wizardry Scenario 1 - Proving Grounds of the Mad Overlord (Japan) (En) (v1.1) (Hengki Kusuma Adi)">
-		<category>WonderSwan Color</category>
-		<description>Wizardry Scenario 1 - Proving Grounds of the Mad Overlord (Japan) (En) (v1.1) (Hengki Kusuma Adi)</description>
-		<rom name="Wizardry Scenario 1 - Proving Grounds of the Mad Overlord (Japan) (En) (v1.1) (Hengki Kusuma Adi).wsc" size="2097152" crc="2c055c98" md5="a9eca898b6014e7ce23b9493b2d12efe" sha1="22fca73a28893a213f3760f54d3d61a81c95753c"/>
-		<url>https://retroachievements.org/game/14595/hashes</url>
-		<hash>a9eca898b6014e7ce23b9493b2d12efe</hash>
-	</game>
 	<game name="Retail/Wizardry Scenario 1/Wizardry Scenario 1 - Proving Grounds of the Mad Overlord (Japan)">
 		<category>WonderSwan Color</category>
 		<description>Wizardry Scenario 1 - Proving Grounds of the Mad Overlord (Japan)</description>
 		<rom name="Wizardry Scenario 1 - Proving Grounds of the Mad Overlord (Japan).wsc" size="2097152" crc="15e55706" md5="f0ba64cd7b88eab7add0f7af02080072" sha1="c1ad383d337dba8a63295cfb8c7ca8470c893c67"/>
 		<url>https://retroachievements.org/game/14595/hashes</url>
 		<hash>f0ba64cd7b88eab7add0f7af02080072</hash>
+	</game>
+	<game name="Retail/Wizardry Scenario 1/Wizardry Scenario 1 - Proving Grounds of the Mad Overlord (Japan) (En) (v1.1) (Hengki Kusuma Adi)">
+		<category>WonderSwan Color</category>
+		<description>Wizardry Scenario 1 - Proving Grounds of the Mad Overlord (Japan) (En) (v1.1) (Hengki Kusuma Adi)</description>
+		<rom name="Wizardry Scenario 1 - Proving Grounds of the Mad Overlord (Japan) (En) (v1.1) (Hengki Kusuma Adi).wsc" size="2097152" crc="2c055c98" md5="a9eca898b6014e7ce23b9493b2d12efe" sha1="22fca73a28893a213f3760f54d3d61a81c95753c"/>
+		<url>https://retroachievements.org/game/14595/hashes</url>
+		<hash>a9eca898b6014e7ce23b9493b2d12efe</hash>
 	</game>
 	<game name="Retail/Wizardry Scenario 1/Wizardry Scenario 1 - Proving Grounds of the Mad Overlord (Japan) (En) (v1.1) (WonderGate Unlock) (v1.0) (Justin Gibbins)">
 		<category>WonderSwan Color</category>


### PR DESCRIPTION
Some of the names in this DAT do not match current No-Intro and Lost Level Archive DATs (Most of them being aftermarket homebrews). This PR updates this DAT to match them. Helps users build a playlist in RetroArch rather than use clrmamepro or RomVault to build a romset.

45 names needed to be updated. Here's a list of their new names.

Lost Level Archive
* Pepsi Invaders - Coke Wins (NTSC) (Prototype)
* Mega Man (NTSC) (Demo) (Aftermarket) (David Galloway)
* Touhou (NTSC) (Demo) (Aftermarket) (Unl)
* Alien Force (NTSC) (Aftermarket) (Nova32)
* Birds and Beans (NTSC) (v2.2) (Aftermarket) (Bluswimmer)
* Dark Mage (NTSC) (Aftermarket) (Greg Troutman)
* Fix-It Felix Sr. (Europe) (PAL 60) (Aftermarket) (Unl)
* Fix-It Felix Sr. (NTSC) (Aftermarket) (Unl)
* Flappy (NTSC) (RC2) (Aftermarket) (Unl)
* Katamari (NTSC) (v1.3) (Aftermarket) (Rabbit2600)
* Kelly Kangaroo (NTSC) (v0.6) (Aftermarket) (Unl)
* Pac-Man 4K (NTSC) (v2008-05-24) (Aftermarket) (Dennis Debro)
* Princess Rescue (NTSC) (v2013-07-31) (Chris Spry)
* Punch Out (Demake) (NTSC) (Aftermarket) (MathanGames)
* Rock Shot (NTSC) (Aftermarket) (Vivian Video)
* Skeleton+ (NTSC) (Aftermarket) (Eric Ball)
* Slide Boy in Maze Land (NTSC) (Final) (Aftermarket) (Unl)
* Snake (Rick Skrbina) (NTSC) (Aftermarket) (Unl)
* Spies in the Night (NTSC) (Aftermarket) (Jared Gray West)
* Tetris26 (NTSC) (Aftermarket) (Colin Hughes)
* Video Simon (NTSC) (Aftermarket) (Mark De Smet)
* Wall-E (NTSC) (v20130624) (Aftermarket) (Unl)
* Wipeout 2600 (NTSC) (Aftermarket) (Unl)
* Wipeout 2600 (NTSC) (Faster Missiles) (Aftermarket) (Unl)
* Xanthiom (NTSC) (v6.0) (Aftermarket) (MathanGames)
* Yahtzee (NTSC) (Aftermarket) (Russell Babylon)
* Zippy the Porcupine (NTSC) (v2) (Aftermarket) (Chris Spry)

No-Intro
* Venetian Blinds Demo (USA) (Demo)
* RealSports Volleyball (USA, Europe) (En,Fr,De,Es,It)

No-Intro (Aftermarket/Private)
* Amoeba Jump (World) (v1.3) (PAL) (Aftermarket) (Unl)
* Amoeba Jump (World) (v1.3) (NTSC) (Aftermarket) (Unl)
* Go Fish! (World) (PAL) (Aftermarket) (Unl)
* Go Fish! (World) (NTSC) (Aftermarket) (Unl)
* Halo 2600 (World) (Aftermarket) (Unl)
* INV+ (World) (Aftermarket) (Unl)
* Oystron (World) (Aftermarket) (Unl)
* Sheep It Up! - PAL (World) (Aftermarket) (Unl)
* Sheep It Up! - NTSC (World) (Aftermarket) (Unl)
* Sheep It Up! - SECAM (World) (Aftermarket) (Unl)
* Angry Video Game Nerd K.O. Boxing (World) (NTSC) (Aftermarket) (Unl)
* Wall Jump Ninja (World) (2015-01-15) (PAL 60Hz) (Aftermarket) (Unl)
* Wall Jump Ninja (World) (2015-01-15) (NTSC) (Aftermarket) (Unl)
* Mr. Run and Jump (World) (Aftermarket) (Unl)

RAPatches
* Alpha Beam with Ernie (Japan, USA) (En) (Joystick Patch) (v2011.01.10)
* Big Bird's Egg Catch (Japan, USA) (En) (Joystick Patch)